### PR TITLE
Add "extra info" field to the records

### DIFF
--- a/darshan-runtime/configure
+++ b/darshan-runtime/configure
@@ -4674,10 +4674,10 @@ int
 main ()
 {
 
-    MPI_Comm comm;
-    char* filename;
-    int amode;
-    MPI_Info info;
+    MPI_Comm comm=0;
+    char* filename=0;
+    int amode=0;
+    MPI_Info info=0;
     MPI_File fh;
             MPI_File_open(comm, filename, amode, info, &fh);
   ;

--- a/darshan-runtime/configure.in
+++ b/darshan-runtime/configure.in
@@ -392,10 +392,10 @@ AS_IF([test "x$ENABLE_MPI" = "x1"], [
 # determine if the MPI library includes MPI-IO functions or not
 AC_MSG_CHECKING(for MPI-IO support in MPI)
 AC_TRY_LINK([#include <mpi.h>], [
-    MPI_Comm comm;
-    char* filename;
-    int amode;
-    MPI_Info info;
+    MPI_Comm comm=0;
+    char* filename=0;
+    int amode=0;
+    MPI_Info info=0;
     MPI_File fh;
             MPI_File_open(comm, filename, amode, info, &fh);],
     AC_MSG_RESULT(yes),

--- a/darshan-runtime/darshan-common.h
+++ b/darshan-runtime/darshan-common.h
@@ -82,7 +82,7 @@
  * added to the common access counter, rather than just incrementing it.
  */
 #define DARSHAN_COMMON_VAL_COUNTER_INC(__val_p, __cnt_p, __value, __count, __add_flag) do {\
-    int i; \
+    int i_; \
     int inc_count, total_count; \
     int64_t tmp_val[4] = {0}; \
     int64_t tmp_cnt[4] = {0}; \
@@ -92,21 +92,21 @@
         inc_count = 1; \
     else \
         inc_count = __count; \
-    for(i=0; i<4; i++) { \
-        if(*(__val_p + i) == __value) { \
-            total_count = *(__cnt_p + i) + inc_count; \
+    for(i_=0; i_<4; i_++) { \
+        if(*(__val_p + i_) == __value) { \
+            total_count = *(__cnt_p + i_) + inc_count; \
             break; \
         } \
     } \
-    if(i == 4) total_count = __count; \
+    if(i_ == 4) total_count = __count; \
     /* first, copy over any counters that should be sorted above this one \
      * (counters with higher counts or equal counts and larger values) \
      */ \
-    for(i=0;i < 4; i++) { \
-        if((*(__cnt_p + i) > total_count) || \
-           ((*(__cnt_p + i) == total_count) && (*(__val_p + i) > __value))) { \
-            tmp_val[tmp_ndx] = *(__val_p + i); \
-            tmp_cnt[tmp_ndx] = *(__cnt_p + i); \
+    for(i_=0;i_ < 4; i_++) { \
+        if((*(__cnt_p + i_) > total_count) || \
+           ((*(__cnt_p + i_) == total_count) && (*(__val_p + i_) > __value))) { \
+            tmp_val[tmp_ndx] = *(__val_p + i_); \
+            tmp_cnt[tmp_ndx] = *(__cnt_p + i_); \
             tmp_ndx++; \
         } \
         else break; \
@@ -118,12 +118,12 @@
     tmp_ndx++; \
     /* last, copy over any remaining counters to make sure we have 4 sets total */ \
     while(tmp_ndx != 4) { \
-        if(*(__val_p + i) != __value) { \
-            tmp_val[tmp_ndx] = *(__val_p + i); \
-            tmp_cnt[tmp_ndx] = *(__cnt_p + i); \
+        if(*(__val_p + i_) != __value) { \
+            tmp_val[tmp_ndx] = *(__val_p + i_); \
+            tmp_cnt[tmp_ndx] = *(__cnt_p + i_); \
             tmp_ndx++; \
         } \
-        i++; \
+        i_++; \
     } \
     memcpy(__val_p, tmp_val, 4*sizeof(int64_t)); \
     memcpy(__cnt_p, tmp_cnt, 4*sizeof(int64_t)); \

--- a/darshan-runtime/darshan-dxt.h
+++ b/darshan-runtime/darshan-dxt.h
@@ -45,10 +45,10 @@ void dxt_posix_read(darshan_record_id rec_id, int64_t offset,
  * with 'length' size. 'start_time' and 'end_time' are starting and ending
  * timestamps for the operation, respectively.
  */
-void dxt_mpiio_write(darshan_record_id rec_id, int64_t length,
-        double start_time, double end_time);
-void dxt_mpiio_read(darshan_record_id rec_id, int64_t length,
-        double start_time, double end_time);
+void dxt_mpiio_write(darshan_record_id rec_id, int64_t offset,
+        int64_t length, double start_time, double end_time);
+void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
+        int64_t length, double start_time, double end_time);
 
 void dxt_posix_filter_dynamic_traces(
     struct darshan_posix_file *(*rec_id_to_psx_file)(darshan_record_id));

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -517,8 +517,8 @@ void dxt_posix_read(darshan_record_id rec_id, int64_t offset,
     DXT_UNLOCK();
 }
 
-void dxt_mpiio_write(darshan_record_id rec_id, int64_t length,
-        double start_time, double end_time)
+void dxt_mpiio_write(darshan_record_id rec_id, int64_t offset,
+        int64_t length, double start_time, double end_time)
 {
     struct dxt_file_record_ref* rec_ref = NULL;
     struct dxt_file_record *file_rec;
@@ -566,6 +566,7 @@ void dxt_mpiio_write(darshan_record_id rec_id, int64_t length,
     }
 
     rec_ref->write_traces[file_rec->write_count].length = length;
+    rec_ref->write_traces[file_rec->write_count].offset = offset;
     rec_ref->write_traces[file_rec->write_count].start_time = start_time;
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
     file_rec->write_count += 1;
@@ -573,8 +574,8 @@ void dxt_mpiio_write(darshan_record_id rec_id, int64_t length,
     DXT_UNLOCK();
 }
 
-void dxt_mpiio_read(darshan_record_id rec_id, int64_t length,
-        double start_time, double end_time)
+void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
+        int64_t length, double start_time, double end_time)
 {
     struct dxt_file_record_ref* rec_ref = NULL;
     struct dxt_file_record *file_rec;
@@ -622,6 +623,7 @@ void dxt_mpiio_read(darshan_record_id rec_id, int64_t length,
     }
 
     rec_ref->read_traces[file_rec->read_count].length = length;
+    rec_ref->read_traces[file_rec->read_count].offset = offset;
     rec_ref->read_traces[file_rec->read_count].start_time = start_time;
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     file_rec->read_count += 1;

--- a/darshan-util/darshan-dxt-logutils.c
+++ b/darshan-util/darshan-dxt-logutils.c
@@ -383,6 +383,7 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
                 (struct dxt_file_record *)mpiio_file_rec;
 
     int64_t length;
+    int64_t offset;
     double start_time;
     double end_time;
     int i;
@@ -405,23 +406,25 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
     printf("# DXT, mnt_pt: %s, fs_type: %s\n", mnt_pt, fs_type);
 
     /* Print header */
-    printf("# Module    Rank  Wt/Rd  Segment       Length    Start(s)      End(s)\n");
+    printf("# Module    Rank  Wt/Rd  Segment          Offset       Length    Start(s)      End(s)\n");
 
     /* Print IO Traces information */
     for (i = 0; i < write_count; i++) {
+        offset = io_trace[i].offset;
         length = io_trace[i].length;
         start_time = io_trace[i].start_time;
         end_time = io_trace[i].end_time;
 
-        printf("%8s%8" PRId64 "%7s%9d%16" PRId64 "%12.4f%12.4f\n", "X_MPIIO", rank, "write", i, length, start_time, end_time);
+        printf("%8s%8" PRId64 "%7s%9d%16" PRId64 "%16" PRId64 "%12.4f%12.4f\n", "X_MPIIO", rank, "write", i, offset, length, start_time, end_time);
     }
 
     for (i = write_count; i < write_count + read_count; i++) {
+        offset = io_trace[i].offset;
         length = io_trace[i].length;
         start_time = io_trace[i].start_time;
         end_time = io_trace[i].end_time;
 
-        printf("%8s%8" PRId64 "%7s%9d%16" PRId64 "%12.4f%12.4f\n", "X_MPIIO", rank, "read", (int)(i - write_count), length, start_time, end_time);
+        printf("%8s%8" PRId64 "%7s%9d%16" PRId64 "%16" PRId64 "%12.4f%12.4f\n", "X_MPIIO", rank, "read", (int)(i - write_count), offset, length, start_time, end_time);
     }
 
     return;


### PR DESCRIPTION
In GitLab by @roblatham00 on Feb 21, 2018, 14:45

I did this a while back on intel-hpdd's repo, where it seems to have been forgotten.

I have sometimes needed to annotate log fields with extra information.  for example, in ROMIO, it was helpful to know which round of two-phase collective I/O an operation happened in.

I suspect EXTRA_INFO would be used rarely, so adding 64 bytes to a log entry all the time seems wasteful.  Can switch to a more dynamic approach where EXTRA_INFO allocated only if environment variable set if that seems better