### PR TITLE
fix undefined var if POSIX module not active

### DIFF
--- a/darshan-util/darshan-job-summary/bin/darshan-job-summary.pl.in
+++ b/darshan-util/darshan-job-summary/bin/darshan-job-summary.pl.in
@@ -432,7 +432,7 @@ open(PSX_OP_COUNTS, ">$tmp_dir/posix-op-counts.dat") || die("error opening outpu
 print PSX_OP_COUNTS "# <operation>, <POSIX count>\n";
 # filter out negative mmap values (these indicate that mmap was not
 # instrumented by Darshan; the value is not meaningful to plot)
-if($summary{POSIX_MMAPS} < 0)
+if(defined $summary{POSIX_MMAPS} && $summary{POSIX_MMAPS} < 0)
 {
     $summary{POSIX_MMAPS} = 0;
 }


### PR DESCRIPTION
Reported by Jeff Layton (see https://lists.mcs.anl.gov/pipermail/darshan-users/2021-June/000693.html).  There was a bug in logic added to darshan-job-summary.pl to filter out negative mmap counter values; it did not account for situations in which the counter was not present at all (i.e., the POSIX module was not activated).