### PR TITLE
WIP: PyDarshan: Adds heatmap plotting code for DXT tracing logs

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Tuple, Sequence, TypedDict
 
 import pandas as pd
 import numpy as np
+import numpy.typing as npt
 
 
 class SegDict(TypedDict):
@@ -29,7 +30,7 @@ def get_rd_wr_dfs(dict_list: Sequence[SegDict]) -> Tuple[pd.DataFrame, pd.DataFr
     Parameters
     ----------
 
-    dict_list: a list of DXT records, where each record is a
+    dict_list: a sequence of DXT records, where each record is a
     Python dictionary with the following keys: 'id', 'rank',
     'hostname', 'write_count', 'read_count', 'write_segments',
     and 'read_segments'. The read/write data is stored in
@@ -159,10 +160,10 @@ def get_single_df_dict(
 
     report: a ``darshan.DarshanReport``.
 
-    mods: a list of keys designating which Darshan modules to use for
+    mods: a sequence of keys designating which Darshan modules to use for
     data aggregation. Default is ``["DXT_POSIX"]``.
 
-    ops: a list of keys designating which Darshan operations to use for
+    ops: a sequence of keys designating which Darshan operations to use for
     data aggregation. Default is ``["read", "write"]``.
 
     Returns
@@ -228,10 +229,10 @@ def get_aggregate_data(
 
     report: a ``darshan.DarshanReport``.
 
-    mods: a list of keys designating which Darshan modules to use for
+    mods: a sequence of keys designating which Darshan modules to use for
     data aggregation. Default is ``["DXT_POSIX"]``.
 
-    ops: a list of keys designating which Darshan operations to use for
+    ops: a sequence of keys designating which Darshan operations to use for
     data aggregation. Default is ``["read", "write"]``.
 
     Returns
@@ -275,7 +276,7 @@ def get_aggregate_data(
         # if there are dataframes in the list, concatenate them into 1 dataframe
         agg_df = pd.concat(df_list, ignore_index=True)
     else:
-        raise ValueError(f"No data available for selected module(s) and operation(s).")
+        raise ValueError("No data available for selected module(s) and operation(s).")
 
     return agg_df
 
@@ -283,8 +284,8 @@ def get_aggregate_data(
 def calc_prop_data_sum(
     tmin: float,
     tmax: float,
-    total_elapsed: np.ndarray,
-    total_data: np.ndarray,
+    total_elapsed: npt.NDArray[np.float64],
+    total_data: npt.NDArray[np.float64],
 ) -> float:
     """
     Calculates the proportion of data read/written in the
@@ -323,7 +324,7 @@ def calc_prop_data_sum(
     return prop_data_sum
 
 
-def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> np.ndarray:
+def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> npt.NDArray[np.float64]:
     """
     Builds an array similar to a 2D-histogram, where the y data is the unique
     ranks and the x data is time. Each bin is populated with the data sum

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -283,50 +283,7 @@ def get_aggregate_data(
     return agg_df
 
 
-def calc_prop_data_sum(
-    tmin: float,
-    tmax: float,
-    total_elapsed: npt.NDArray[np.float64],
-    total_data: npt.NDArray[np.float64],
-) -> float:
-    """
-    Calculates the proportion of data read/written in the
-    time interval of a single bin in ``get_heatmap_data``.
-
-    Parameters
-    ----------
-
-    tmin: the lower bound of the time interval for a given bin.
-
-    tmax: the upper bound of the time interval for a given bin.
-
-    total_elapsed: an array of the elapsed times for every event
-    that occurred within the time interval of a given bin.
-
-    total_data: an array of the data totals for every event that
-    occurred within the time interval of a given bin.
-
-    Returns
-    -------
-
-    prop_data_sum: the amount of data read/written in the time
-    interval of a given bin.
-
-    """
-    # calculate the elapsed time
-    partial_elapsed = tmax - tmin
-    # calculate the ratio of the elapsed time
-    # to the total read/write event time
-    proportionate_time = partial_elapsed / total_elapsed
-    # calculate the amount of data read/written in the elapsed
-    # time (assuming a constant read/write rate)
-    proportionate_data = proportionate_time * total_data
-    # sum the data
-    prop_data_sum = proportionate_data.sum()
-    return prop_data_sum
-
-
-def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> np.ndarray:
+def get_heatmap_df(agg_df: pd.DataFrame, xbins: int) -> pd.DataFrame:
     """
     Builds an array similar to a 2D-histogram, where the y data is the unique
     ranks and the x data is time. Each bin is populated with the data sum
@@ -344,10 +301,21 @@ def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> np.ndarray:
     Returns
     -------
 
-    hmap_data: ``NxM`` array, where ``N`` is the number of unique ranks
-    and ``M`` is the number of x-axis bins. Each element contains the
-    data read/written by the corresponding rank in the x-axis bin time
-    interval.
+    hmap_df: dataframe with time intervals for columns and rank
+    index (0, 1, etc.) for rows, where each element contains the data
+    read/written by the corresponding rank in the given time interval.
+
+    Examples
+    --------
+    The first column/bin for the `hmap_df` generated from
+    "examples/example-logs/ior_hdf5_example.darshan":
+
+               (0.0, 0.09552296002705891]
+        rank
+        0                   8.951484e+05
+        1                   3.746313e+05
+        2                   6.350999e+05
+        3                   1.048576e+06
 
     """
     # generate the bin edges by generating an array of length n_bins+1, then
@@ -420,5 +388,5 @@ def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> np.ndarray:
     # the bytes data
     cats = cats.mul(agg_df["length"], axis=0)
     cats["rank"] = agg_df["rank"]
-    grouped_res = cats.groupby("rank").sum()
-    return grouped_res.to_numpy()
+    hmap_df = cats.groupby("rank").sum()
+    return hmap_df

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -1,0 +1,442 @@
+"""
+Module of data pre-processing functions for constructing the heatmap figure.
+"""
+from typing import Dict, Any, Tuple, Sequence, TypedDict
+
+import pandas as pd
+import numpy as np
+
+
+class SegDict(TypedDict):
+    """
+    Custom type hint class for `dict_list` argument in `get_rd_wr_dfs()`.
+    """
+
+    id: int
+    rank: int
+    hostname: str
+    write_count: int
+    read_count: int
+    write_segments: pd.DataFrame
+    read_segments: pd.DataFrame
+
+
+def get_rd_wr_dfs(dict_list: Sequence[SegDict]) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Uses the DXT records to construct individual
+    dataframes for both read and write segments.
+
+    Parameters
+    ----------
+
+    dict_list: a list of DXT records, where each record is a
+    Python dictionary with the following keys: 'id', 'rank',
+    'hostname', 'write_count', 'read_count', 'write_segments',
+    and 'read_segments'. The read/write data is stored in
+    ``read_segments`` and ``write_segments``, where each is a
+    ```pd.DataFrame`` containing the following data (columns):
+    'offset', 'length', 'start_time', 'end_time'.
+
+    Returns
+    -------
+
+    Tuple of form ``(read_df, write_df)``,
+    where each tuple element is a ``pd.DataFrame`` object
+    containing all of the read and write events.
+
+    Notes
+    -----
+
+    Used in ``get_single_df_dict()``.
+
+    Examples
+    --------
+
+    ``dict_list`` and ``(read_df, write_df)``
+    generated from ``tests/input/sample-dxt-simple.darshan``:
+
+        dict_list = [
+            {
+                'id': 14388265063268455899,
+                'rank': 0,
+                'hostname': 'sn176.localdomain',
+                'write_count': 1,
+                'read_count': 0,
+                'write_segments':
+                    offset  length  start_time  end_time
+                    0       0      40    0.103379  0.103388,
+                'read_segments':
+                    Empty DataFrame
+                    Columns: []
+                    Index: []
+            },
+            {
+                'id': 9457796068806373448,
+                'rank': 0,
+                'hostname': 'sn176.localdomain',
+                'write_count': 1,
+                'read_count': 0,
+                'write_segments':
+                    offset  length  start_time  end_time
+                    0       0    4000    0.104217  0.104231,
+                'read_segments':
+                    Empty DataFrame
+                    Columns: []
+                    Index: []
+            },
+        ]
+
+        (read_df, write_df) = (
+            Empty DataFrame
+            Columns: []
+            Index: [],
+            length  start_time  end_time  rank
+            0      40    0.103379  0.103388     0
+            1    4000    0.104217  0.104231     0
+        )
+
+    """
+    # columns to drop when accumulating the dataframes.
+    # Currently "offset" data is not utilized
+    drop_columns = ["offset"]
+    # create empty arrays to store
+    # read/write segment dataframes
+    read_df_list = []
+    write_df_list = []
+    # iterate over all records/dictionaries
+    # to pull out the dataframes
+    for _dict in dict_list:
+        # collect the read and write segment dataframes
+        rd_seg_df = _dict["read_segments"]
+        wr_seg_df = _dict["write_segments"]
+
+        if rd_seg_df.size:
+            # drop unused columns from the dataframe
+            rd_seg_df = rd_seg_df.drop(columns=drop_columns)
+            # create new column for the ranks
+            rd_seg_df["rank"] = _dict["rank"]
+            # add the dataframe to the list
+            read_df_list.append(rd_seg_df)
+
+        if wr_seg_df.size:
+            # drop unused columns from the dataframe
+            wr_seg_df = wr_seg_df.drop(columns=drop_columns)
+            # create new column for the ranks
+            wr_seg_df["rank"] = _dict["rank"]
+            # add the dataframe to the list
+            write_df_list.append(wr_seg_df)
+
+    if read_df_list:
+        # concatenate the list of pandas dataframes into
+        # a single one with new row indices
+        read_df = pd.concat(read_df_list, ignore_index=True)
+    else:
+        # if the list is empty assign an empty dataframe
+        read_df = pd.DataFrame()
+
+    if write_df_list:
+        # concatenate the list of pandas dataframes into
+        # a single one with new row indices
+        write_df = pd.concat(write_df_list, ignore_index=True)
+    else:
+        # if the list is empty assign an empty dataframe
+        write_df = pd.DataFrame()
+
+    return read_df, write_df
+
+
+def get_single_df_dict(
+    report: Any,
+    mods: Sequence[str] = ["DXT_POSIX"],
+    ops: Sequence[str] = ["read", "write"],
+) -> Dict[str, Dict[str, pd.DataFrame]]:
+    """
+    Reorganizes segmented read/write data into a single ``pd.DataFrame``
+    and stores them in a dictionary with an entry for each DXT module.
+
+    Parameters
+    ----------
+
+    report: a ``darshan.DarshanReport``.
+
+    mods: a list of keys designating which Darshan modules to use for
+    data aggregation. Default is ``["DXT_POSIX"]``.
+
+    ops: a list of keys designating which Darshan operations to use for
+    data aggregation. Default is ``["read", "write"]``.
+
+    Returns
+    -------
+
+    flat_data_dict: a nested dictionary where the input module
+    keys (i.e. "DXT_POSIX") are the top level keys, which contain
+    an entry for each input operation (i.e. "read"/"write") that
+    map to dataframes containing all events for the specified operation.
+
+    Examples
+    --------
+    `flat_data_dict` generated from `tests/input/sample-dxt-simple.darshan`:
+        {
+            'DXT_POSIX':
+                {
+                    'read':
+                        Empty DataFrame
+                        Columns: []
+                        Index: [],
+                    'write':
+                        length  start_time  end_time  rank
+                        0      40    0.103379  0.103388     0
+                        1    4000    0.104217  0.104231     0
+                }
+        }
+
+    """
+    # initialize an empty dictionary for storing
+    # module and read/write data
+    flat_data_dict = {}  # type: Dict[str, Dict[str, pd.DataFrame]]
+    # iterate over the modules (i.e. DXT_POSIX)
+    for module_key in mods:
+        # read in the module data, update the name records
+        report.mod_read_all_dxt_records(module_key, dtype="pandas")
+        # retrieve the list of records in pd.DataFrame() form
+        dict_list = report.records[module_key].to_df()
+        # retrieve the list of read/write dataframes from the list of records
+        read_df, write_df = get_rd_wr_dfs(dict_list=dict_list)
+        # create empty dictionary for each module
+        flat_data_dict[module_key] = {}
+        if "read" in ops:
+            # add the concatenated dataframe to the flat dictionary
+            flat_data_dict[module_key]["read"] = read_df
+        if "write" in ops:
+            # add the concatenated dataframe to the flat dictionary
+            flat_data_dict[module_key]["write"] = write_df
+
+    return flat_data_dict
+
+
+def get_aggregate_data(
+    report: Any,
+    mods: Sequence[str] = ["DXT_POSIX"],
+    ops: Sequence[str] = ["read", "write"],
+) -> pd.DataFrame:
+    """
+    Aggregates the data based on which
+    modules and operations are selected.
+
+    Parameters
+    ----------
+
+    report: a ``darshan.DarshanReport``.
+
+    mods: a list of keys designating which Darshan modules to use for
+    data aggregation. Default is ``["DXT_POSIX"]``.
+
+    ops: a list of keys designating which Darshan operations to use for
+    data aggregation. Default is ``["read", "write"]``.
+
+    Returns
+    -------
+
+    agg_df: a ``pd.DataFrame`` containing the aggregated data determined
+    by the input modules and operations.
+
+    Raises
+    ------
+
+    ValueError: raised if the selected modules/operations
+    don't contain any data.
+
+    Notes
+    -----
+    Since read and write events are considered unique events, if both are
+    selected their dataframes are simply concatenated.
+
+    Examples
+    --------
+    `agg_df` generated from `tests/input/sample-dxt-simple.darshan`:
+
+            length  start_time  end_time  rank
+        0      40    0.103379  0.103388     0
+        1    4000    0.104217  0.104231     0
+
+    """
+    # collect the concatenated dataframe data from the darshan report
+    df_dict = get_single_df_dict(report=report, mods=mods, ops=ops)
+    # TODO: generalize for all DXT modules, for now manually set `DXT_POSIX`
+    module_key = "DXT_POSIX"
+    # iterate over each dataframe based on which operations are selected
+    df_list = []
+    for op_key, op_df in df_dict[module_key].items():
+        # if the dataframe has data, append it to the list
+        if op_df.size:
+            df_list.append(op_df)
+
+    if df_list:
+        # if there are dataframes in the list, concatenate them into 1 dataframe
+        agg_df = pd.concat(df_list, ignore_index=True)
+    else:
+        raise ValueError(f"No data available for selected module(s) and operation(s).")
+
+    return agg_df
+
+
+def calc_prop_data_sum(
+    tmin: float,
+    tmax: float,
+    total_elapsed: np.ndarray,
+    total_data: np.ndarray,
+) -> float:
+    """
+    Calculates the proportion of data read/written in the
+    time interval of a single bin in ``get_heatmap_data``.
+
+    Parameters
+    ----------
+
+    tmin: the lower bound of the time interval for a given bin.
+
+    tmax: the upper bound of the time interval for a given bin.
+
+    total_elapsed: an array of the elapsed times for every event
+    that occurred within the time interval of a given bin.
+
+    total_data: an array of the data totals for every event that
+    occurred within the time interval of a given bin.
+
+    Returns
+    -------
+
+    prop_data_sum: the amount of data read/written in the time
+    interval of a given bin.
+
+    """
+    # calculate the elapsed time
+    partial_elapsed = tmax - tmin
+    # calculate the ratio of the elapsed time
+    # to the total read/write event time
+    proportionate_time = partial_elapsed / total_elapsed
+    # calculate the amount of data read/written in the elapsed
+    # time (assuming a constant read/write rate)
+    proportionate_data = proportionate_time * total_data
+    # sum the data
+    prop_data_sum = proportionate_data.sum()
+    return prop_data_sum
+
+
+def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> np.ndarray:
+    """
+    Builds an array similar to a 2D-histogram, where the y data is the unique
+    ranks and the x data is time. Each bin is populated with the data sum
+    and/or proportionate data sum for all IO events read/written during the
+    time spanned by the bin.
+
+    Parameters
+    ----------
+
+    agg_df: a ``pd.DataFrame`` containing the aggregated data determined
+    by the input modules and operations.
+
+    xbins: the number of x-axis bins to create.
+
+    Returns
+    -------
+
+    hmap_data: ``NxM`` array, where ``N`` is the number of unique ranks
+    and ``M`` is the number of x-axis bins. Each element contains the
+    data read/written by the corresponding rank in the x-axis bin time
+    interval.
+
+    """
+    # get the unique ranks
+    unique_ranks = np.unique(agg_df["rank"].values)
+
+    # generate the bin edges by generating an array of length n_bins+1, then
+    # taking pairs of data points as the min/max bin value
+    min_time = 0.0
+    max_time = agg_df["end_time"].values.max()
+    bin_edge_data = np.linspace(min_time, max_time, xbins + 1)
+
+    # calculate the elapsed time for each data point
+    elapsed_time_data = agg_df["end_time"].values - agg_df["start_time"].values
+
+    # generate an array for the heatmap data
+    hmap_data = np.zeros((unique_ranks.size, xbins), dtype=float)
+
+    # iterate over the unique ranks
+    for i, rank in enumerate(unique_ranks):
+        # for each rank, generate a mask to select only
+        # the data points that correspond to that rank
+        rank_mask = agg_df["rank"].values == rank
+        bytes_data = agg_df["length"].values[rank_mask]
+        start_data = agg_df["start_time"].values[rank_mask]
+        end_data = agg_df["end_time"].values[rank_mask]
+        elapsed_data = elapsed_time_data[rank_mask]
+
+        # iterate over the bins
+        for j, (bmin, bmax) in enumerate(zip(bin_edge_data[:-1], bin_edge_data[1:])):
+            # create a mask for all data with a start time greater than the
+            # bin minimum time
+            start_mask_min = start_data >= bmin
+            # create a mask for all data with an end time less than the
+            # bin maximum time
+            end_mask_max = end_data <= bmax
+            # use the above masks to find the indices of all data with
+            # start/end times that fall within the bin min/max times
+            start_inside_idx = np.nonzero(start_mask_min & (start_data <= bmax))[0]
+            end_inside_idx = np.nonzero((end_data > bmin) & end_mask_max)[0]
+            # using the start/end indices, find all indices that both start
+            # and end within the bin min/max limits
+            inside_idx = np.intersect1d(start_inside_idx, end_inside_idx)
+            # use the original masks to find the indices of data that start
+            # before the bin minimum time and end after the bin maximum time
+            outside_idx = np.nonzero(~start_mask_min & ~end_mask_max)[0]
+
+            if inside_idx.size:
+                # for data that start/end inside the bin limits,
+                # add the sum of the correspondign data to the hmap data
+                hmap_data[i, j] += bytes_data[inside_idx].sum()
+                # now remove any indices from the start/end index arrays
+                # to prevent double counting
+                start_inside_idx = np.setdiff1d(start_inside_idx, inside_idx)
+                end_inside_idx = np.setdiff1d(end_inside_idx, inside_idx)
+
+            if outside_idx.size:
+                # for data that start before the bin min time and end
+                # after the bin max time (run longer than 1 bin time),
+                # calculate the proportionate data used in 1 bin time
+                # and add it to the hmap data
+                prop_data_sum = calc_prop_data_sum(
+                    tmin=bmin,
+                    tmax=bmax,
+                    total_elapsed=elapsed_data[outside_idx],
+                    total_data=bytes_data[outside_idx],
+                )
+                hmap_data[i, j] += prop_data_sum
+
+            if start_inside_idx.size:
+                # for data with only a start time within the bin limits,
+                # calculate the elapsed time (from start to bin max), use the
+                # elapsed time to calculate the proportionate data read/written,
+                # and add the data sum to the hmap data
+                prop_data_sum = calc_prop_data_sum(
+                    tmin=start_data[start_inside_idx],
+                    tmax=bmax,
+                    total_elapsed=elapsed_data[start_inside_idx],
+                    total_data=bytes_data[start_inside_idx],
+                )
+                hmap_data[i, j] += prop_data_sum
+
+            if end_inside_idx.size:
+                # for data with only an end time within the bin limits,
+                # calculate the elapsed time (from bin min to end time), use the
+                # elapsed time to calculate the proportionate data read/written,
+                # and add the data sum to the hmap data
+                prop_data_sum = calc_prop_data_sum(
+                    tmin=bmin,
+                    tmax=end_data[end_inside_idx],
+                    total_elapsed=elapsed_data[end_inside_idx],
+                    total_data=bytes_data[end_inside_idx],
+                )
+                hmap_data[i, j] += prop_data_sum
+
+    return hmap_data

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -3,7 +3,13 @@ Module of data pre-processing functions for constructing the heatmap figure.
 """
 from __future__ import annotations
 
-from typing import Dict, Any, Tuple, Sequence, TypedDict, TYPE_CHECKING
+from typing import Dict, Any, Tuple, Sequence, TYPE_CHECKING
+
+import sys
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 import pandas as pd
 import numpy as np

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Dict, Any, Tuple, Sequence, TYPE_CHECKING
 
 import sys
+
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
@@ -325,7 +326,7 @@ def calc_prop_data_sum(
     return prop_data_sum
 
 
-def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> npt.NDArray[np.float64]:
+def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> np.ndarray:
     """
     Builds an array similar to a 2D-histogram, where the y data is the unique
     ranks and the x data is time. Each bin is populated with the data sum
@@ -349,96 +350,75 @@ def get_heatmap_data(agg_df: pd.DataFrame, xbins: int) -> npt.NDArray[np.float64
     interval.
 
     """
-    # get the unique ranks
-    unique_ranks = np.unique(agg_df["rank"].values)
-
     # generate the bin edges by generating an array of length n_bins+1, then
     # taking pairs of data points as the min/max bin value
-    min_time = 0.0
-    max_time = agg_df["end_time"].values.max()
-    bin_edge_data = np.linspace(min_time, max_time, xbins + 1)
-
-    # calculate the elapsed time for each data point
-    elapsed_time_data = agg_df["end_time"].values - agg_df["start_time"].values
-
-    # generate an array for the heatmap data
-    hmap_data = np.zeros((unique_ranks.size, xbins), dtype=float)
-
-    # iterate over the unique ranks
-    for i, rank in enumerate(unique_ranks):
-        # for each rank, generate a mask to select only
-        # the data points that correspond to that rank
-        rank_mask = agg_df["rank"].values == rank
-        bytes_data = agg_df["length"].values[rank_mask]
-        start_data = agg_df["start_time"].values[rank_mask]
-        end_data = agg_df["end_time"].values[rank_mask]
-        elapsed_data = elapsed_time_data[rank_mask]
-
-        # iterate over the bins
-        for j, (bmin, bmax) in enumerate(zip(bin_edge_data[:-1], bin_edge_data[1:])):
-            # create a mask for all data with a start time greater than the
-            # bin minimum time
-            start_mask_min = start_data >= bmin
-            # create a mask for all data with an end time less than the
-            # bin maximum time
-            end_mask_max = end_data <= bmax
-            # use the above masks to find the indices of all data with
-            # start/end times that fall within the bin min/max times
-            start_inside_idx = np.nonzero(start_mask_min & (start_data <= bmax))[0]
-            end_inside_idx = np.nonzero((end_data > bmin) & end_mask_max)[0]
-            # using the start/end indices, find all indices that both start
-            # and end within the bin min/max limits
-            inside_idx = np.intersect1d(start_inside_idx, end_inside_idx)
-            # use the original masks to find the indices of data that start
-            # before the bin minimum time and end after the bin maximum time
-            outside_idx = np.nonzero(~start_mask_min & ~end_mask_max)[0]
-
-            if inside_idx.size:
-                # for data that start/end inside the bin limits,
-                # add the sum of the correspondign data to the hmap data
-                hmap_data[i, j] += bytes_data[inside_idx].sum()
-                # now remove any indices from the start/end index arrays
-                # to prevent double counting
-                start_inside_idx = np.setdiff1d(start_inside_idx, inside_idx)
-                end_inside_idx = np.setdiff1d(end_inside_idx, inside_idx)
-
-            if outside_idx.size:
-                # for data that start before the bin min time and end
-                # after the bin max time (run longer than 1 bin time),
-                # calculate the proportionate data used in 1 bin time
-                # and add it to the hmap data
-                prop_data_sum = calc_prop_data_sum(
-                    tmin=bmin,
-                    tmax=bmax,
-                    total_elapsed=elapsed_data[outside_idx],
-                    total_data=bytes_data[outside_idx],
-                )
-                hmap_data[i, j] += prop_data_sum
-
-            if start_inside_idx.size:
-                # for data with only a start time within the bin limits,
-                # calculate the elapsed time (from start to bin max), use the
-                # elapsed time to calculate the proportionate data read/written,
-                # and add the data sum to the hmap data
-                prop_data_sum = calc_prop_data_sum(
-                    tmin=start_data[start_inside_idx],
-                    tmax=bmax,
-                    total_elapsed=elapsed_data[start_inside_idx],
-                    total_data=bytes_data[start_inside_idx],
-                )
-                hmap_data[i, j] += prop_data_sum
-
-            if end_inside_idx.size:
-                # for data with only an end time within the bin limits,
-                # calculate the elapsed time (from bin min to end time), use the
-                # elapsed time to calculate the proportionate data read/written,
-                # and add the data sum to the hmap data
-                prop_data_sum = calc_prop_data_sum(
-                    tmin=bmin,
-                    tmax=end_data[end_inside_idx],
-                    total_elapsed=elapsed_data[end_inside_idx],
-                    total_data=bytes_data[end_inside_idx],
-                )
-                hmap_data[i, j] += prop_data_sum
-
-    return hmap_data
+    max_time = agg_df["end_time"].max()
+    bin_edge_data = np.linspace(0.0, max_time, xbins + 1)
+    # create dummy variables for start/end time data, where dataframe columns
+    # are the x-axis bin ranges
+    cats_start = pd.get_dummies(
+        pd.cut(agg_df["start_time"], bin_edge_data, precision=16)
+    )
+    cats_end = pd.get_dummies(pd.cut(agg_df["end_time"], bin_edge_data, precision=16))
+    # get series for the elapsed times for each dxt segment
+    elapsed_times_dxt_segments = agg_df["end_time"] - agg_df["start_time"]
+    # calculate the time interval spanned by each bin
+    bin_size = bin_edge_data[1] - bin_edge_data[0]
+    # get the ratio of the bin time interval over the dxt segment elapsed times
+    true_fraction_of_dxt_segment_in_a_bin = bin_size / elapsed_times_dxt_segments
+    # create a version of the above series where any ratio above 1 is set to 1
+    fraction_of_dxt_segment_in_a_bin = true_fraction_of_dxt_segment_in_a_bin.copy()
+    fraction_of_dxt_segment_in_a_bin.mask(
+        fraction_of_dxt_segment_in_a_bin > 1, 1, inplace=True
+    )
+    # create a dataframe of binned dxt start events where occupied bins contain
+    # the start time and unoccupied bins are populated with NaNs
+    start_times_in_bins = cats_start.mul(agg_df["start_time"], axis=0).replace(
+        0, np.nan
+    )
+    # create a dataframe of binned dxt start events where occupied bins contain
+    # the proportional time spent in the bin
+    start_fraction_bin_occupancy = (bin_edge_data[1:] - start_times_in_bins) / bin_size
+    # create a dataframe of binned dxt end events where occupied bins contain
+    # the end time and unoccupied bins are populated with NaNs
+    end_times_in_bins = cats_end.mul(agg_df["end_time"], axis=0).replace(0, np.nan)
+    # create a dataframe of binned dxt end events where occupied bins contain
+    # the proportional time spent in the bin
+    end_fraction_bin_occupancy = (end_times_in_bins - bin_edge_data[:-1]) / bin_size
+    # combine the start/end fractional bin occupancy dataframes by multiplying
+    # them together. Fill any missing values with (1)
+    combo = start_fraction_bin_occupancy.mul(
+        end_fraction_bin_occupancy, fill_value=1, axis=0
+    )
+    combo.mask(combo > 1, 1, inplace=True)
+    # add the start/end dummy variable dataframes
+    # and replace any zeros with NaN's
+    cats = cats_start.add(cats_end, fill_value=0)
+    cats.replace(0, np.nan, inplace=True)
+    # for each row (IO event) fill in any empty (NaN) bins
+    # between filled bins because those are time spans b/w start
+    # and stop events
+    cats.interpolate(method="linear", limit_area="inside", axis=1, inplace=True)
+    # each time bin containing an event has a 1 in it, otherwise NaN
+    # store mask for restoring fully occupied bins
+    mask_occ = cats == 2
+    # set the fraction of segment per occupied bin
+    cats = cats.mul(fraction_of_dxt_segment_in_a_bin, axis=0)
+    # start/end in adjacent bins require special treatment
+    adjacent_mask = (cats.count(axis=1) == 2) & (cats.sum(axis=1) == 2)
+    # multiply them by the true fractions of DXT segments, which
+    # may actually be > 1 (i.e., the non-1-capped fractions)
+    cats[adjacent_mask] = cats[adjacent_mask].mul(
+        true_fraction_of_dxt_segment_in_a_bin[adjacent_mask], axis=0
+    )
+    # adjust the fractions of the starts/ends for partial occupancy
+    # of bins
+    cats = cats.mul(combo, fill_value=1, axis=0)
+    # start and end are in bin, so restore it
+    cats = cats.mask(mask_occ, 1)
+    # each full or fractional bin event is now multiplied by
+    # the bytes data
+    cats = cats.mul(agg_df["length"], axis=0)
+    cats["rank"] = agg_df["rank"]
+    grouped_res = cats.groupby("rank").sum()
+    return grouped_res.to_numpy()

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -272,7 +272,6 @@ def plot_dxt_heatmap(
             y=unique_ranks,
             width=Hmap_data.sum(axis=1),
             align="edge",
-            height=-0.99,
             facecolor="black",
             lw=0.5,
         )
@@ -313,12 +312,19 @@ def plot_dxt_heatmap(
         # do some checks on how many ranks there are earlier on since any
         # file with 1000's of ranks is too messy to plot this way.
         n_ylabels = 6
+        # get the y tick marks and labels
         sns_yticks = jgrid.ax_joint.get_yticks()
+        sns_yticklabels = np.zeros_like(sns_yticks, dtype=int)
+        for i, tlabel in enumerate(jgrid.ax_joint.get_yticklabels()):
+            sns_yticklabels[i] = int(tlabel.get_text())
+
+        # use the original tick marks to make new arrays that
+        # contain a subset (6) of the original ticks/labels
         yticks = np.linspace(sns_yticks.min(), sns_yticks.max(), n_ylabels)
-        jgrid.ax_joint.set_yticks(yticks)
         yticklabels = np.linspace(
-            unique_ranks.min(), unique_ranks.max(), n_ylabels, dtype=int
+            sns_yticklabels.min(), sns_yticklabels.max(), n_ylabels, dtype=int
         )
+        jgrid.ax_joint.set_yticks(yticks)
     else:
         # if there are less than 12 unique ranks, just label each
         # row with its rank index
@@ -344,7 +350,7 @@ def plot_dxt_heatmap(
     jgrid.fig.set_size_inches(6.5, 4.5)
 
     # set the spacing between subplots
-    hspace, wspace = 0.01, 0.02
+    hspace, wspace = 0.03, 0.04
     # adjust the subplot so the x/y tick labels are legible
     jgrid.fig.subplots_adjust(
         left=0.1, bottom=0.15, top=0.9, hspace=hspace, wspace=wspace

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -2,11 +2,14 @@
 Module for creating the ranks vs. time IO intensity
 heatmap figure for the Darshan job summary.
 """
+from __future__ import annotations
 
-from typing import Any, List, Sequence, Union
+from typing import Any, List, Sequence, Union, TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
@@ -229,22 +232,16 @@ def remove_marginal_graph_ticks_and_labels(marg_x: Any, marg_y: Any):
 
     marg_y : a y-axis marginal bar graph object.
     """
-    # turn the frame off for both bar graphs
-    marg_x.axis("off")
-    marg_y.axis("off")
-    # remove all tick mark labels for both bar graphs
-    marg_x.tick_params(
-        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
-    )
-    marg_y.tick_params(
-        axis="y", left=False, labelleft=False, right=False, labelright=False
-    )
-    marg_x.tick_params(
-        axis="y", left=False, labelleft=False, right=False, labelright=False
-    )
-    marg_y.tick_params(
-        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
-    )
+    for marg in [marg_x, marg_y]:
+        # turn the frame off for both bar graphs
+        marg.axis("off")
+        # remove all tick mark labels for both bar graphs
+        marg.tick_params(
+            axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
+        )
+        marg.tick_params(
+            axis="y", left=False, labelleft=False, right=False, labelright=False
+        )
 
 
 def adjust_for_colorbar(jointgrid: Any, fig_right: float, cbar_x0: float):

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -3,18 +3,20 @@ Module for creating the ranks vs. time IO intensity
 heatmap figure for the Darshan job summary.
 """
 
-from typing import Any, List, Sequence
+from typing import Any, List, Sequence, Union
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import seaborn as sns
+import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 
 import darshan
 from darshan.experimental.plots import heatmap_handling
 
 
-def get_x_axis_ticks(ax: Any, n_xlabels: int = 4) -> np.ndarray:
+def get_x_axis_ticks(ax: Any, n_xlabels: int = 4) -> npt.NDArray[np.float64]:
     """
     Creates the x-axis tick mark locations.
 
@@ -48,7 +50,9 @@ def get_x_axis_ticks(ax: Any, n_xlabels: int = 4) -> np.ndarray:
     return xticks
 
 
-def get_x_axis_tick_labels(agg_df: pd.DataFrame, n_xlabels: int = 4) -> np.ndarray:
+def get_x_axis_tick_labels(
+    agg_df: pd.DataFrame, n_xlabels: int = 4
+) -> Union[npt.NDArray[np.float64], npt.NDArray[np.intc]]:
     """
     Creates the x-axis tick mark labels.
 
@@ -82,7 +86,7 @@ def get_x_axis_tick_labels(agg_df: pd.DataFrame, n_xlabels: int = 4) -> np.ndarr
     return x_ticklabels
 
 
-def get_y_axis_ticks(ax: Any, n_ylabels: int = 6) -> np.ndarray:
+def get_y_axis_ticks(ax: Any, n_ylabels: int = 6) -> npt.NDArray[np.float64]:
     """
     Creates the y-axis tick mark locations.
 
@@ -128,7 +132,7 @@ def get_yticklabels(ax: Any) -> List[str]:
     Returns
     -------
 
-    y_ticklabels: array of y-axis tick mark labels of length ``n_ylabels``.
+    y_ticklabels: list of y-axis tick mark labels of length ``n_ylabels``.
 
     """
     # retrieve the original y-axis tick label strings from the axis object
@@ -136,7 +140,7 @@ def get_yticklabels(ax: Any) -> List[str]:
     return y_ticklabels
 
 
-def get_y_axis_tick_labels(ax: Any, n_ylabels: int = 6) -> np.ndarray:
+def get_y_axis_tick_labels(ax: Any, n_ylabels: int = 6) -> npt.NDArray[np.intc]:
     """
     Sets the y-axis tick mark labels.
 
@@ -293,10 +297,10 @@ def plot_heatmap(
 
     log_path: path to a darshan log file.
 
-    mods: a list of keys designating which Darshan modules to use for
+    mods: a sequence of keys designating which Darshan modules to use for
     data aggregation. Default is ``["DXT_POSIX"]``.
 
-    ops: a list of keys designating which Darshan operations to use for
+    ops: a sequence of keys designating which Darshan operations to use for
     data aggregation. Default is ``["read", "write"]``.
 
     xbins: the number of x-axis bins to create.
@@ -349,6 +353,18 @@ def plot_heatmap(
         cmap="YlOrRd",
         norm=LogNorm(),
         cbar_kws=colorbar_kws,
+    )
+
+    # add text for x-axis bin count
+    xbin_label = f"Time bins: {xbins}"
+    plt.text(
+        x=1.03,
+        y=-0.04,
+        s=xbin_label,
+        fontsize=9,
+        verticalalignment="top",
+        horizontalalignment="left",
+        transform=jgrid.ax_joint.transAxes,
     )
 
     # make the heatmap border visible

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -326,7 +326,7 @@ def plot_heatmap(
     agg_df = heatmap_handling.get_aggregate_data(report=report, mods=mods, ops=ops)
 
     # get the heatmap data array
-    Hmap_data = heatmap_handling.get_heatmap_data(agg_df=agg_df, xbins=xbins)
+    hmap_df = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)
 
     # get the unique ranks
     unique_ranks = np.unique(agg_df["rank"].values)
@@ -344,7 +344,7 @@ def plot_heatmap(
     # create the heatmap object using the heatmap data,
     # and assign it to the jointplot main figure
     hmap = sns.heatmap(
-        Hmap_data,
+        hmap_df,
         ax=jgrid.ax_joint,
         # choose a color map that is not white at any value
         cmap="YlOrRd",
@@ -373,7 +373,7 @@ def plot_heatmap(
     if unique_ranks.size > 1:
         jgrid.ax_marg_y.barh(
             y=unique_ranks,
-            width=Hmap_data.sum(axis=1),
+            width=hmap_df.sum(axis=1),
             align="edge",
             facecolor="black",
             lw=0.5,
@@ -385,7 +385,7 @@ def plot_heatmap(
     # create the vertical bar graph
     jgrid.ax_marg_x.bar(
         x=np.arange(xbins),
-        height=Hmap_data.sum(axis=0),
+        height=hmap_df.sum(axis=0),
         facecolor="black",
         align="edge",
     )

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -1,0 +1,319 @@
+import os
+import sys
+import glob
+import argparse
+
+import darshan
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+
+
+def retrieve_flat_data(report, mods, ops):
+    flat_data = {}
+
+    for module_key in mods:
+
+        report.mod_read_all_dxt_records(module_key, dtype="pandas")
+        report.update_name_records()
+        df = report.records[module_key].to_df()
+
+        flat_data[module_key] = {}
+        for op_key in ops:
+            flat_data[module_key][op_key] = {
+                "rank": [],
+                "bytes": [],
+                "start_time": [],
+                "end_time": [],
+            }
+
+        for record in df:
+            # keys: 'id', 'rank', 'hostname', 'write_count',
+            #       'read_count', 'write_segments', 'read_segments'
+            rank_idx = record["rank"]
+            for op_key in ops:
+                # 'write_segments' or 'read_segments'
+                segment_key = op_key + "_segments"
+
+                segment_df = record[segment_key]
+                if segment_df.size:
+                    # columns: 'offset', 'length', 'start_time', 'end_time'
+                    flat_data[module_key][op_key]["bytes"].extend(
+                        segment_df["length"].values
+                    )
+                    flat_data[module_key][op_key]["start_time"].extend(
+                        segment_df["start_time"].values
+                    )
+                    flat_data[module_key][op_key]["end_time"].extend(
+                        segment_df["end_time"].values
+                    )
+                    rank_arr = rank_idx * np.ones(
+                        segment_df["start_time"].values.size, dtype=int
+                    )
+                    flat_data[module_key][op_key]["rank"].extend(rank_arr)
+
+    return flat_data
+
+
+def aggregate_data(data, mods, ops):
+    # TODO: implement data from any/all modules in .darshan log
+    # for now just retrieve `DXT_POSIX` and read data from that
+    module_key = mods[0]
+
+    start_data = []
+    end_data = []
+    ranks_data = []
+    bytes_data = []
+    for op_key in ops:
+        start_data.extend(data[module_key][op_key]["start_time"])
+        end_data.extend(data[module_key][op_key]["end_time"])
+        ranks_data.extend(data[module_key][op_key]["rank"])
+        bytes_data.extend(data[module_key][op_key]["bytes"])
+
+    start_data = np.asarray(start_data, dtype=float)
+    end_data = np.asarray(end_data, dtype=float)
+    ranks_data = np.asarray(ranks_data, dtype=int)
+    bytes_data = np.asarray(bytes_data, dtype=int)
+
+    time_data = (end_data + start_data) / 2
+
+    # sort the data arrays in chronological order
+    sorted_idx = np.argsort(time_data)
+    time_data = time_data[sorted_idx]
+    ranks_data = ranks_data[sorted_idx]
+    bytes_data = bytes_data[sorted_idx]
+
+    return time_data, ranks_data, bytes_data
+
+
+def plot_dxt_heatmap(
+    report,
+    mods=None,
+    ops=None,
+    xbins=100,
+):
+    if mods is None:
+        mods = ["DXT_POSIX"]
+    elif mods[0] != "DXT_POSIX":
+        # TODO: for the moment reject any cases that don't input "DXT_POSIX"
+        # until we can properly aggregate the data
+        raise NotImplementedError(f"DXT heatmap not implemented for module {mods[0]}")
+    if ops is None:
+        ops = ["read", "write"]
+
+    # retrieve the data
+    flat_data = retrieve_flat_data(report=report, mods=mods, ops=ops)
+    time_data, ranks_data, bytes_data = aggregate_data(
+        data=flat_data, mods=mods, ops=ops
+    )
+
+    # get the unique ranks
+    unique_ranks = np.unique(ranks_data)
+    ybins = unique_ranks.size
+
+    # create a 2D histogram from the time and rank data, with the
+    # selected data as the weight
+    bins = [xbins, ybins]
+    H, _xedges, _yedges = np.histogram2d(
+        x=time_data, y=ranks_data, weights=bytes_data, bins=bins
+    )
+    Hmap_data = H.T
+
+    jgrid = sns.jointplot(kind="hist", bins=bins, space=0.05)
+    jgrid.ax_marg_x.cla()
+    jgrid.ax_marg_y.cla()
+
+    colorbar_label = f"Data (B): {' + '.join(ops)}"
+    colorbar_kws = {"label": colorbar_label}
+    hmap = sns.heatmap(
+        Hmap_data,
+        ax=jgrid.ax_joint,
+        # choose a color map that is not white at any value
+        cmap="YlOrRd",
+        norm=LogNorm(),
+        # TODO: want to change the color bar label to use the key names for the
+        # specific report data we are mapping, or specialized keys for derived
+        # quantities (like bandwidth)
+        cbar_kws=colorbar_kws,
+    )
+
+    for _, spine in hmap.spines.items():
+        spine.set_visible(True)
+
+    if unique_ranks.size > 1:
+        jgrid.ax_marg_y.barh(
+            y=unique_ranks,
+            width=Hmap_data.sum(axis=1),
+            align="edge",
+            height=-0.99,
+            facecolor="black",
+            lw=0.5,
+        )
+    else:
+        jgrid.ax_marg_y.axis("off")
+
+    jgrid.ax_marg_x.bar(
+        x=np.arange(xbins),
+        height=Hmap_data.sum(axis=0),
+        facecolor="black",
+        align="edge",
+    )
+
+    # only create 4 x-axis tick marks, for figure clarity
+    n_xlabels = 4
+    # create x ticks that scale with the number of xbins in the 2D histogram
+    xticks = np.linspace(0, xbins, n_xlabels)
+    jgrid.ax_joint.set_xticks(xticks)
+    # for the x tick labels, start at 0 and end with the max time (converted to
+    # an integer)
+    max_time = np.max(time_data)
+    if max_time < 1:
+        x_ticklabels = np.around(np.linspace(0, max_time, n_xlabels), decimals=2)
+    elif (max_time > 1) & (max_time < 10):
+        x_ticklabels = np.around(np.linspace(0, max_time, n_xlabels), decimals=1)
+    else:
+        x_ticklabels = np.asarray(
+            np.linspace(0, np.ceil(max_time), n_xlabels), dtype=int
+        )
+
+    jgrid.ax_joint.set_xticklabels(x_ticklabels, minor=False)
+
+    if unique_ranks.size > 12:
+        # only use 6 labels if there are many ranks to label. Might want to
+        # do some checks on how many ranks there are earlier on since any
+        # file with 1000's of ranks is too messy to plot this way.
+        n_ylabels = 6
+        sns_yticks = jgrid.ax_joint.get_yticks()
+        yticks = np.linspace(sns_yticks.min(), sns_yticks.max(), n_ylabels)
+        jgrid.ax_joint.set_yticks(yticks)
+        yticklabels = np.asarray(
+            np.linspace(unique_ranks.min(), unique_ranks.max(), n_ylabels), dtype=int
+        )
+    else:
+        # if there are less than 12 unique ranks, just label each
+        # row with its rank index
+        yticklabels = np.asarray(unique_ranks, dtype=int)
+    jgrid.ax_joint.set_yticklabels(yticklabels, minor=False)
+
+    # remove ticks between heatmap and histograms
+    jgrid.ax_marg_x.tick_params(
+        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
+    )
+    jgrid.ax_marg_y.tick_params(
+        axis="y", left=False, labelleft=False, right=False, labelright=False
+    )
+    # remove ticks showing the heights of the histograms
+    jgrid.ax_marg_x.tick_params(
+        axis="y", left=False, labelleft=False, right=False, labelright=False
+    )
+    jgrid.ax_marg_y.tick_params(
+        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
+    )
+
+    # set the dimensions of the figure to 6.5" wide x 4.5" tall
+    jgrid.fig.set_size_inches(6.5, 4.5)
+
+    # set the spacing between subplots
+    hspace, wspace = 0.01, 0.02
+    # adjust the subplot so the x/y tick labels are legible
+    jgrid.fig.subplots_adjust(
+        left=0.1, bottom=0.15, top=0.9, hspace=hspace, wspace=wspace
+    )
+    if unique_ranks.size > 1:
+        # if there are multiple ranks we want to move the colorbar on the far
+        # right side of the horizontal bar graph
+
+        # set the location of the right side of the figure
+        jgrid.fig.subplots_adjust(right=0.84)
+        # get the positions of the joint and marginal x axes
+        pos_joint_ax = jgrid.ax_joint.get_position()
+        pos_marg_x_ax = jgrid.ax_marg_x.get_position()
+        # set the position and dimensions of the joint plot such that it fills
+        # the space as if there was no colorbar
+        jgrid.ax_joint.set_position(
+            [pos_joint_ax.x0, pos_joint_ax.y0, pos_marg_x_ax.width, pos_joint_ax.height]
+        )
+        # set the position of the colorbar such that it is on the
+        # right side of the horizontal bar graph, and set its dimensions
+        jgrid.fig.axes[-1].set_position(
+            [0.85, pos_joint_ax.y0, 0.9, pos_joint_ax.height]
+        )
+    else:
+        # if there is only 1 unique rank there is no horizontal bar graph,
+        # so set the subplot dimensions to fill the space
+
+        # set the location of the right side of the figure
+        jgrid.fig.subplots_adjust(right=0.92)
+        # get the positions of the joint and marginal x axes
+        pos_joint_ax = jgrid.ax_joint.get_position()
+        pos_marg_x_ax = jgrid.ax_marg_x.get_position()
+        # set the position and dimensions of the joint plot such that it fills
+        # the space as if there was no horizontal bar graph
+        jgrid.ax_joint.set_position(
+            [pos_joint_ax.x0, pos_joint_ax.y0, pos_marg_x_ax.width, pos_joint_ax.height]
+        )
+        # set the position of the colorbar such that it is on the
+        # right side of the heatmap, and set its dimensions
+        jgrid.fig.axes[-1].set_position(
+            [0.82, pos_joint_ax.y0, 0.9, pos_joint_ax.height]
+        )
+
+    # invert the y-axis so rank values are increasing
+    jgrid.ax_joint.invert_yaxis()
+
+    # turn the frame off for both marginal subplots
+    jgrid.ax_marg_x.axis("off")
+    jgrid.ax_marg_y.axis("off")
+
+    # set the axis labels
+    jgrid.ax_joint.set_xlabel("Time (s)")
+    jgrid.ax_joint.set_ylabel("Rank")
+
+    # set the figure title
+    title_str = " ,".join(mods)
+    jgrid.fig.suptitle(title_str, fontsize=11)
+    return jgrid
+
+
+if __name__ == "__main__":
+    # get the path to the file(s) to be read in
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "datapath",
+        nargs="?",
+        help="Specify path to darshan log file or directory with darshan logs",
+    )
+    args = parser.parse_args()
+    data_path = args.datapath
+
+    if os.path.isfile(data_path):
+        # individual file case
+        files_to_process = [data_path]
+    elif os.path.isdir(data_path):
+        # directory case
+        files_to_process = glob.glob(os.path.join(data_path, "*.darshan"))
+
+    for filepath in files_to_process:
+        # get the file name and the file path
+        filename = os.path.basename(filepath)
+        # generate the darshan report
+        report = darshan.DarshanReport(filepath, read_all=False)
+
+        if "DXT_POSIX" not in report.modules.keys():
+            print("\n" + f"Skipping -> No 'DXT_POSIX' module in {filename}")
+            continue
+
+        # generate the heatmap figure
+        hmap = plot_dxt_heatmap(
+            report=report,
+            mods=None,
+            ops=None,
+            xbins=200,
+        )
+
+        save_path = os.path.join(os.getcwd(), os.path.splitext(filename)[0] + ".png")
+        # save the figure at the specified location
+        print(f"Saving figure at location: {save_path}")
+        plt.savefig(save_path, dpi=300)
+        plt.close()

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -1,260 +1,347 @@
-import os
-import sys
-import glob
-import argparse
+"""
+Module for creating the ranks vs. time IO intensity
+heatmap figure for the Darshan job summary.
+"""
 
-import darshan
+from typing import Any, List, Sequence
+
 import numpy as np
+import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 
-
-def retrieve_flat_data(report, mods, ops):
-    # retrieve the flattened module data from the darshan report
-
-    # initialize an empty dictionary for storing
-    # module and read/write data
-    flat_data = {}
-    # iterate over the modules (i.e. DXT_POSIX)
-    for module_key in mods:
-
-        # read in the module data, update the name records, and
-        # collect the pandas dataframe from the report
-        report.mod_read_all_dxt_records(module_key, dtype="pandas")
-        report.update_name_records()
-        df = report.records[module_key].to_df()
-
-        # initialize an empty dictionary for each module
-        flat_data[module_key] = {}
-        # for each operation (read/write), initialize a dictionary
-        # with empty lists for storing data to be used
-        for op_key in ops:
-            # use the same keys that are used in the darshan report data
-            flat_data[module_key][op_key] = {
-                "rank": [],
-                "bytes": [],
-                "start_time": [],
-                "end_time": [],
-            }
-
-        # iterate over each record in the dataframe
-        for record in df:
-            # record keys: 'id', 'rank', 'hostname', 'write_count',
-            #       'read_count', 'write_segments', 'read_segments'
-            # get the rank used for this record
-            rank = record["rank"]
-            for op_key in ops:
-                # create the segment key: 'write_segments' or 'read_segments'
-                segment_key = op_key + "_segments"
-
-                # get the dataframe for the given segment
-                segment_df = record[segment_key]
-                if segment_df.size:
-                    # segment dataframe columns: 'offset', 'length',
-                    # 'start_time', 'end_time'
-
-                    # add the length, start/end times, and rank data to
-                    # the flat data dictionary
-                    flat_data[module_key][op_key]["bytes"].extend(
-                        segment_df["length"].values
-                    )
-                    flat_data[module_key][op_key]["start_time"].extend(
-                        segment_df["start_time"].values
-                    )
-                    flat_data[module_key][op_key]["end_time"].extend(
-                        segment_df["end_time"].values
-                    )
-                    # since the rank is only listed once per record, use the
-                    # rank and the start time array length to store a rank
-                    # value for each data point
-                    rank_arr = rank * np.ones(
-                        segment_df["start_time"].values.size, dtype=int
-                    )
-                    flat_data[module_key][op_key]["rank"].extend(rank_arr)
-
-    return flat_data
+import darshan
+from darshan.experimental.plots import heatmap_handling
 
 
-def aggregate_data(data, mods, ops):
-    # aggregates the data based on which
-    # modules and operations are selected
+def get_x_axis_ticks(ax: Any, n_xlabels: int = 4) -> np.ndarray:
+    """
+    Creates the x-axis tick mark locations.
 
-    # for now just retrieve `DXT_POSIX` and read data from that
-    module_key = mods[0]
+    Parameters
+    ----------
 
-    # iterate over the operations (i.e. read, write)
-    # create empty arrays to store arrays in
-    start_data = []
-    end_data = []
-    ranks_data = []
-    bytes_data = []
-    for op_key in ops:
-        # for each operation, extend the list with the corresponding data
-        start_data.extend(data[module_key][op_key]["start_time"])
-        end_data.extend(data[module_key][op_key]["end_time"])
-        ranks_data.extend(data[module_key][op_key]["rank"])
-        bytes_data.extend(data[module_key][op_key]["bytes"])
+    ax: a ``matplotlib`` axis object.
 
-    # convert the lists into arrays
-    start_data = np.asarray(start_data, dtype=float)
-    end_data = np.asarray(end_data, dtype=float)
-    ranks_data = np.asarray(ranks_data, dtype=int)
-    bytes_data = np.asarray(bytes_data, dtype=int)
+    n_xlabels: the number of x-axis tick marks to create. Default is 4.
 
-    # sort the data arrays in chronological order
-    sorted_idx = np.argsort(start_data)
-    start_data = start_data[sorted_idx]
-    end_data = end_data[sorted_idx]
-    ranks_data = ranks_data[sorted_idx]
-    bytes_data = bytes_data[sorted_idx]
+    Returns
+    -------
 
-    return start_data, end_data, ranks_data, bytes_data
+    xticks: array of x-axis tick mark locations of length ``n_xlabels``.
 
-
-def get_heatmap_data(start_time_data, end_time_data, ranks_data, data_arr, n_xbins):
-    # builds an array similar to a 2D-histogram, where the y data is the unique
-    # ranks and the x data is time. Each bin is populated with the data sum
-    # and/or proportionate data sum for all IO events read/written during the
-    # time spanned by the bin.
-
-    # get the unique ranks
-    unique_ranks = np.unique(ranks_data)
-
-    # generate the bin edges by generating an array of length n_bins+1, then
-    # taking pairs of data points as the min/max bin value
-    min_time = 0.0
-    max_time = end_time_data.max()
-    bin_edge_data = np.linspace(min_time, max_time, n_xbins + 1)
-
-    # calculated the elapsed time for each data point
-    elapsed_time_data = end_time_data - start_time_data
-
-    # generate an array for the heatmap data
-    hmap_data = np.zeros((unique_ranks.size, n_xbins), dtype=float)
-
-    # iterate over the unique ranks
-    for i, rank in enumerate(unique_ranks):
-        # for each rank, generate a mask to select only
-        # the data points that correspond to that rank
-        rank_mask = ranks_data == rank
-        start_data = start_time_data[rank_mask]
-        end_data = end_time_data[rank_mask]
-        elapsed_data = elapsed_time_data[rank_mask]
-        bytes_data = data_arr[rank_mask]
-
-        # iterate over the bins
-        for j, (bmin, bmax) in enumerate(zip(bin_edge_data[:-1], bin_edge_data[1:])):
-            # create a mask for all data with a start time greater than the
-            # bin minimum time
-            start_mask_min = start_data >= bmin
-            # create a mask for all data with an end time less than the
-            # bin maximum time
-            end_mask_max = end_data <= bmax
-            # now use the above masks to find the indices of all data with
-            # start/end times that fall within the bin min/max times
-            start_inside_idx = np.nonzero(start_mask_min & (start_data <= bmax))[0]
-            end_inside_idx = np.nonzero((end_data > bmin) & end_mask_max)[0]
-            # using the start/end indices, find all indices that both start
-            # and end within the bin min/max limits
-            inside_idx = np.intersect1d(start_inside_idx, end_inside_idx)
-            # use the original masks to find the indices of data that start
-            # before the bin minimum time and end after the bin maximum time
-            outside_idx = np.nonzero(~start_mask_min & ~end_mask_max)[0]
-
-            if inside_idx.size:
-                # for data that start/end inside the bin limits,
-                # add the sum of the correspondign data to the hmap data
-                hmap_data[i, j] += bytes_data[inside_idx].sum()
-                # now remove any indices from the start/end index arrays
-                # to prevent double counting
-                start_inside_idx = np.setdiff1d(start_inside_idx, inside_idx)
-                end_inside_idx = np.setdiff1d(end_inside_idx, inside_idx)
-
-            if outside_idx.size:
-                # for data that start before the bin min time and end
-                # after the bin max time (run longer than 1 bin time),
-                # calculate the proportionate data used in 1 bin time
-                # and add it to the hmap data
-                bin_elapsed_time = bmax - bmin
-                proportionate_time = bin_elapsed_time / elapsed_data[outside_idx]
-                proportionate_data = proportionate_time * bytes_data[outside_idx]
-                hmap_data[i, j] += proportionate_data.sum()
-
-            if start_inside_idx.size:
-                # for data with only a start time within the bin limits,
-                # calculate the elapsed time (from start to bin max), use the
-                # elapsed time to calculate the proportionate data read/written,
-                # and add the data sum to the hmap data
-                start_elapsed = bmax - start_data[start_inside_idx]
-                start_prop_time = start_elapsed / elapsed_data[start_inside_idx]
-                start_prop_data = start_prop_time * bytes_data[start_inside_idx]
-                hmap_data[i, j] += start_prop_data.sum()
-
-            if end_inside_idx.size:
-                # for data with only an end time within the bin limits,
-                # calculate the elapsed time (from bin min to end time), use the
-                # elapsed time to calculate the proportionate data read/written,
-                # and add the data sum to the hmap data
-                end_elapsed = end_data[end_inside_idx] - bmin
-                end_prop_time = end_elapsed / elapsed_data[end_inside_idx]
-                end_prop_data = end_prop_time * bytes_data[end_inside_idx]
-                hmap_data[i, j] += end_prop_data.sum()
-
-    # check that the sum of the heatmap data is
-    # close to the sum of the input data
-    if not np.isclose(hmap_data.sum(), data_arr.sum()):
-        raise ValueError(
-            f"Heatmap data size does not match input data size. "
-            f"Calculated {hmap_data.sum()}, expected {data_arr.sum()}"
+    """
+    # get the original x-axis tick locations
+    initial_xticks = ax.get_xticks()
+    if len(initial_xticks) < n_xlabels:
+        # if there are too few initial x-axis tick locations, generate
+        # a new array with 0 as the minimum and the same maximum as
+        # the original x-axis ticks
+        xticks = np.linspace(0, np.max(initial_xticks), n_xlabels)
+    else:
+        # use the original tick marks to make new arrays that
+        # contain a subset of the original ticks/labels
+        tick_idx = np.round(np.linspace(0, initial_xticks.size - 1, n_xlabels)).astype(
+            int
         )
-    return hmap_data
+        xticks = initial_xticks[tick_idx]
+    return xticks
 
 
-def plot_dxt_heatmap(
-    report,
-    mods=None,
-    ops=None,
-    xbins=200,
+def get_x_axis_tick_labels(agg_df: pd.DataFrame, n_xlabels: int = 4) -> np.ndarray:
+    """
+    Creates the x-axis tick mark labels.
+
+    Parameters
+    ----------
+
+    agg_df: a ``pd.DataFrame`` containing the aggregated data determined
+    by the input modules and operations.
+
+    n_xlabels: the number of x-axis tick marks to create. Default is 4.
+
+    Returns
+    -------
+
+    x_ticklabels: array of x-axis tick mark labels of length ``n_xlabels``.
+
+    """
+    max_time = agg_df["end_time"].values.max()
+    # for the x tick labels, start at 0 and end with
+    # the max time (converted to an integer)
+    if max_time <= 1:
+        # use 2 decimal places for run times less than 1 second
+        x_ticklabels = np.around(np.linspace(0.0, max_time, n_xlabels), decimals=2)
+    elif (max_time > 1) & (max_time <= 10):
+        # use 1 decimal place for run times between 1 and 10 seconds
+        x_ticklabels = np.around(np.linspace(0.0, max_time, n_xlabels), decimals=1)
+    else:
+        # for run times greater than 10 seconds, round the max
+        # time up and round labels to the nearest integer
+        x_ticklabels = np.linspace(0.0, np.ceil(max_time), n_xlabels, dtype=int)
+    return x_ticklabels
+
+
+def get_y_axis_ticks(ax: Any, n_ylabels: int = 6) -> np.ndarray:
+    """
+    Creates the y-axis tick mark locations.
+
+    Parameters
+    ----------
+
+    ax: a ``matplotlib`` axis object.
+
+    n_ylabels: The number of y-axis tick mark labels to create. Default is 6.
+
+    Returns
+    -------
+
+    yticks: array of y-axis tick mark locations of length ``n_ylabels``.
+
+    """
+    # get the original y-axis tick locations
+    initial_yticks = ax.get_yticks()
+    if len(initial_yticks) < n_ylabels:
+        # if there are less tick marks available than requested,
+        # use the original tick mark locations
+        yticks = initial_yticks
+    else:
+        # use the original tick marks to make a new array that
+        # contains a subset of the original tick marks
+        tick_idx = np.round(np.linspace(0, initial_yticks.size - 1, n_ylabels)).astype(
+            int
+        )
+        yticks = initial_yticks[tick_idx]
+    return yticks
+
+
+def get_yticklabels(ax: Any) -> List[str]:
+    """
+    Utility function for ``get_y_axis_tick_labels`` that retrieves the
+    y-axis tick mark labels from the input axis.
+
+    Parameters
+    ----------
+
+    ax: a ``matplotlib`` axis object.
+
+    Returns
+    -------
+
+    y_ticklabels: array of y-axis tick mark labels of length ``n_ylabels``.
+
+    """
+    # retrieve the original y-axis tick label strings from the axis object
+    y_ticklabels = [tl.get_text() for tl in ax.get_yticklabels()]
+    return y_ticklabels
+
+
+def get_y_axis_tick_labels(ax: Any, n_ylabels: int = 6) -> np.ndarray:
+    """
+    Sets the y-axis tick mark labels.
+
+    Parameters
+    ----------
+
+    ax: a ``matplotlib`` axis object.
+
+    n_ylabels: The number of y-axis tick mark labels to create. Default is 6.
+
+    Returns
+    -------
+
+    y_ticklabels: array of y-axis tick mark labels of length ``n_ylabels``.
+
+    """
+    # get the original y-axis tick mark labels and convert them to an array
+    initial_yticklabels = np.asarray(get_yticklabels(ax=ax))
+    if initial_yticklabels.size < n_ylabels:
+        # if there are less tick marks available than requested,
+        # use the original tick mark labels
+        y_ticklabels = initial_yticklabels
+
+    else:
+        # use the original tick marks to make a new array that
+        # contains a subset of the original tick mark labels
+        tick_idx = np.round(
+            np.linspace(0, initial_yticklabels.size - 1, n_ylabels)
+        ).astype(int)
+        y_ticklabels = initial_yticklabels[tick_idx]
+    return y_ticklabels
+
+
+def set_x_axis_ticks_and_labels(
+    jointgrid: Any, agg_df: pd.DataFrame, n_xlabels: int = 4
 ):
-    if mods is None:
-        mods = ["DXT_POSIX"]
-    elif mods[0] != "DXT_POSIX":
+    """
+    Sets the x-axis tick mark locations and labels.
+
+    Parameters
+    ----------
+
+    jointgrid: a ``sns.axisgrid.JointGrid`` object.
+
+    agg_df: a ``pd.DataFrame`` containing the aggregated data determined
+    by the input modules and operations.
+
+    n_xlabels: the number of x-axis tick marks to create. Default is 4.
+
+    """
+    # retrieve the x-axis tick mark locations and labels
+    xticks = get_x_axis_ticks(ax=jointgrid.ax_joint, n_xlabels=n_xlabels)
+    xticklabels = get_x_axis_tick_labels(agg_df=agg_df, n_xlabels=n_xlabels)
+    # set the x-axis ticks and labels
+    jointgrid.ax_joint.set_xticks(xticks)
+    jointgrid.ax_joint.set_xticklabels(xticklabels, minor=False)
+
+
+def set_y_axis_ticks_and_labels(jointgrid: Any, n_ylabels: int = 6):
+    """
+    Sets the y-axis tick mark locations and labels.
+
+    Parameters
+    ----------
+    jointgrid: a ``sns.axisgrid.JointGrid`` object.
+
+    n_ylabels: The number of y-axis tick mark labels to create. Default is 6.
+
+    """
+    # retrieve the y-axis tick mark locations and labels
+    yticks = get_y_axis_ticks(ax=jointgrid.ax_joint, n_ylabels=n_ylabels)
+    yticklabels = get_y_axis_tick_labels(ax=jointgrid.ax_joint, n_ylabels=n_ylabels)
+    # set the new y-axis tick locations and labels
+    jointgrid.ax_joint.set_yticks(yticks)
+    jointgrid.ax_joint.set_yticklabels(yticklabels, minor=False)
+
+
+def remove_marginal_graph_ticks_and_labels(marg_x: Any, marg_y: Any):
+    """
+    Removes the frame, tick marks, and tick mark
+    labels for the marginal bar graphs.
+
+    Parameters
+    ----------
+    marg_x : a x-axis marginal bar graph object.
+
+    marg_y : a y-axis marginal bar graph object.
+    """
+    # turn the frame off for both bar graphs
+    marg_x.axis("off")
+    marg_y.axis("off")
+    # remove all tick mark labels for both bar graphs
+    marg_x.tick_params(
+        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
+    )
+    marg_y.tick_params(
+        axis="y", left=False, labelleft=False, right=False, labelright=False
+    )
+    marg_x.tick_params(
+        axis="y", left=False, labelleft=False, right=False, labelright=False
+    )
+    marg_y.tick_params(
+        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
+    )
+
+
+def adjust_for_colorbar(jointgrid: Any, fig_right: float, cbar_x0: float):
+    """
+    Makes various subplot location adjustments such that
+    a colorbar can fit in the overal figure panel.
+
+    Parameters
+    ----------
+
+    jointgrid: a ``sns.axisgrid.JointGrid`` object.
+
+    fig_right: the location to set for the right side of the heatmap figure.
+
+    cbar_x0: the x-axis location of the colorbar.
+
+    """
+    # adjust the subplot so the x/y tick labels are legible
+    jointgrid.fig.subplots_adjust(
+        left=0.1, bottom=0.15, top=0.9, hspace=0.03, wspace=0.04
+    )
+    # set the location of the right side of the figure
+    jointgrid.fig.subplots_adjust(right=fig_right)
+    # get the positions of the joint and marginal x axes
+    pos_joint_ax = jointgrid.ax_joint.get_position()
+    pos_marg_x_ax = jointgrid.ax_marg_x.get_position()
+    # set the position and dimensions of the joint plot such that it fills
+    # the space as if there was no colorbar
+    jointgrid.ax_joint.set_position(
+        [pos_joint_ax.x0, pos_joint_ax.y0, pos_marg_x_ax.width, pos_joint_ax.height]
+    )
+    # set the position of the colorbar such that it is on the
+    # right side of the horizontal bar graph, and set its dimensions
+    jointgrid.fig.axes[-1].set_position(
+        [cbar_x0, pos_joint_ax.y0, 0.9, pos_joint_ax.height]
+    )
+
+
+def plot_heatmap(
+    log_path: str,
+    mods: Sequence[str] = ["DXT_POSIX"],
+    ops: Sequence[str] = ["read", "write"],
+    xbins: int = 200,
+) -> Any:
+    """
+    Creates a heatmap with marginal bar graphs and colorbar.
+
+    Parameters
+    ----------
+
+    log_path: path to a darshan log file.
+
+    mods: a list of keys designating which Darshan modules to use for
+    data aggregation. Default is ``["DXT_POSIX"]``.
+
+    ops: a list of keys designating which Darshan operations to use for
+    data aggregation. Default is ``["read", "write"]``.
+
+    xbins: the number of x-axis bins to create.
+
+    Returns
+    -------
+
+    jgrid: a ``sns.axisgrid.JointGrid`` object containing a heat
+    map of IO data, marginal bar graphs, and a colobar.
+
+    Raises
+    ------
+
+    NotImplementedError: raised if "DXT_POSIX" is not in the input modules.
+
+    """
+    # generate the darshan report
+    report = darshan.DarshanReport(log_path, read_all=False)
+
+    if "DXT_POSIX" not in mods:
         # TODO: for the moment reject any cases that don't input "DXT_POSIX"
         # until we can properly aggregate the data
-        raise NotImplementedError(f"DXT heatmap not implemented for module {mods[0]}")
-    if ops is None:
-        ops = ["read", "write"]
+        raise NotImplementedError("DXT_POSIX module is required.")
 
-    # generate the flattened data dictionary from the report data
-    flat_data_dict = retrieve_flat_data(report=report, mods=mods, ops=ops)
     # aggregate the data according to the selected modules and operations
-    start_time_data, end_time_data, ranks_data, bytes_data = aggregate_data(
-        data=flat_data_dict, mods=mods, ops=ops
-    )
+    agg_df = heatmap_handling.get_aggregate_data(report=report, mods=mods, ops=ops)
 
     # get the heatmap data array
-    Hmap_data = get_heatmap_data(
-        start_time_data=start_time_data,
-        end_time_data=end_time_data,
-        ranks_data=ranks_data,
-        data_arr=bytes_data,
-        n_xbins=xbins,
-    )
+    Hmap_data = heatmap_handling.get_heatmap_data(agg_df=agg_df, xbins=xbins)
 
     # get the unique ranks
-    unique_ranks = np.unique(ranks_data)
+    unique_ranks = np.unique(agg_df["rank"].values)
     ybins = unique_ranks.size
 
-    # create a 2D histogram from the time and rank data, with the
-    # selected data as the weight
-    bins = [xbins, ybins]
-    jgrid = sns.jointplot(kind="hist", bins=bins, space=0.05)
+    # build the joint plot with marginal histograms
+    jgrid = sns.jointplot(kind="hist", bins=[xbins, ybins], space=0.05)
+    # clear the x and y axis marginal graphs
     jgrid.ax_marg_x.cla()
     jgrid.ax_marg_y.cla()
 
+    # create the label for the colorbar
     colorbar_label = f"Data (B): {', '.join(ops)}"
     colorbar_kws = {"label": colorbar_label}
+    # create the heatmap object using the heatmap data,
+    # and assign it to the jointplot main figure
     hmap = sns.heatmap(
         Hmap_data,
         ax=jgrid.ax_joint,
@@ -264,9 +351,12 @@ def plot_dxt_heatmap(
         cbar_kws=colorbar_kws,
     )
 
+    # make the heatmap border visible
     for _, spine in hmap.spines.items():
         spine.set_visible(True)
 
+    # if there are more than 1 unique rank,
+    # create the horizontal bar graph
     if unique_ranks.size > 1:
         jgrid.ax_marg_y.barh(
             y=unique_ranks,
@@ -276,8 +366,10 @@ def plot_dxt_heatmap(
             lw=0.5,
         )
     else:
+        # if there is only 1 rank turn the axis off
         jgrid.ax_marg_y.axis("off")
 
+    # create the vertical bar graph
     jgrid.ax_marg_x.bar(
         x=np.arange(xbins),
         height=Hmap_data.sum(axis=0),
@@ -285,121 +377,30 @@ def plot_dxt_heatmap(
         align="edge",
     )
 
-    # only create 4 x-axis tick marks, for figure clarity
-    n_xlabels = 4
-    # create x ticks that scale with the number of xbins in the 2D histogram
-    xticks = np.linspace(0, xbins, n_xlabels)
-    jgrid.ax_joint.set_xticks(xticks)
-    # for the x tick labels, start at 0 and end with
-    # the max time (converted to an integer)
-    min_time = 0.0
-    max_time = np.max(end_time_data)
-    if max_time <= 1:
-        # use 2 decimal places for run times less than 1 second
-        x_ticklabels = np.around(np.linspace(min_time, max_time, n_xlabels), decimals=2)
-    elif (max_time > 1) & (max_time <= 10):
-        # use 1 decimal place for run times between 1 and 10 seconds
-        x_ticklabels = np.around(np.linspace(min_time, max_time, n_xlabels), decimals=1)
-    else:
-        # for run times greater than 10 seconds, round the max
-        # time up and round labels to the nearest integer
-        x_ticklabels = np.linspace(min_time, np.ceil(max_time), n_xlabels, dtype=int)
+    # set the x and y tick locations and labels
+    set_x_axis_ticks_and_labels(jointgrid=jgrid, agg_df=agg_df, n_xlabels=4)
+    set_y_axis_ticks_and_labels(jointgrid=jgrid, n_ylabels=6)
 
-    jgrid.ax_joint.set_xticklabels(x_ticklabels, minor=False)
-
-    if unique_ranks.size > 12:
-        # only use 6 labels if there are many ranks to label. Might want to
-        # do some checks on how many ranks there are earlier on since any
-        # file with 1000's of ranks is too messy to plot this way.
-        n_ylabels = 6
-        # get the y tick marks and labels
-        sns_yticks = jgrid.ax_joint.get_yticks()
-        sns_yticklabels = np.zeros_like(sns_yticks, dtype=int)
-        for i, tlabel in enumerate(jgrid.ax_joint.get_yticklabels()):
-            sns_yticklabels[i] = int(tlabel.get_text())
-
-        # use the original tick marks to make new arrays that
-        # contain a subset (6) of the original ticks/labels
-        yticks = np.linspace(sns_yticks.min(), sns_yticks.max(), n_ylabels)
-        yticklabels = np.linspace(
-            sns_yticklabels.min(), sns_yticklabels.max(), n_ylabels, dtype=int
-        )
-        jgrid.ax_joint.set_yticks(yticks)
-    else:
-        # if there are less than 12 unique ranks, just label each
-        # row with its rank index
-        yticklabels = np.asarray(unique_ranks, dtype=int)
-    jgrid.ax_joint.set_yticklabels(yticklabels, minor=False)
-
-    # remove ticks between heatmap and histograms
-    jgrid.ax_marg_x.tick_params(
-        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
-    )
-    jgrid.ax_marg_y.tick_params(
-        axis="y", left=False, labelleft=False, right=False, labelright=False
-    )
-    # remove ticks showing the heights of the histograms
-    jgrid.ax_marg_x.tick_params(
-        axis="y", left=False, labelleft=False, right=False, labelright=False
-    )
-    jgrid.ax_marg_y.tick_params(
-        axis="x", bottom=False, labelbottom=False, top=False, labeltop=False
+    # cleanup the marginal bar graph ticks and tick labels
+    remove_marginal_graph_ticks_and_labels(
+        marg_x=jgrid.ax_marg_x, marg_y=jgrid.ax_marg_y
     )
 
     # set the dimensions of the figure to 6.5" wide x 4.5" tall
     jgrid.fig.set_size_inches(6.5, 4.5)
 
-    # set the spacing between subplots
-    hspace, wspace = 0.03, 0.04
-    # adjust the subplot so the x/y tick labels are legible
-    jgrid.fig.subplots_adjust(
-        left=0.1, bottom=0.15, top=0.9, hspace=hspace, wspace=wspace
-    )
     if unique_ranks.size > 1:
         # if there are multiple ranks we want to move the colorbar on the far
         # right side of the horizontal bar graph
+        adjust_for_colorbar(jointgrid=jgrid, fig_right=0.84, cbar_x0=0.85)
 
-        # set the location of the right side of the figure
-        jgrid.fig.subplots_adjust(right=0.84)
-        # get the positions of the joint and marginal x axes
-        pos_joint_ax = jgrid.ax_joint.get_position()
-        pos_marg_x_ax = jgrid.ax_marg_x.get_position()
-        # set the position and dimensions of the joint plot such that it fills
-        # the space as if there was no colorbar
-        jgrid.ax_joint.set_position(
-            [pos_joint_ax.x0, pos_joint_ax.y0, pos_marg_x_ax.width, pos_joint_ax.height]
-        )
-        # set the position of the colorbar such that it is on the
-        # right side of the horizontal bar graph, and set its dimensions
-        jgrid.fig.axes[-1].set_position(
-            [0.85, pos_joint_ax.y0, 0.9, pos_joint_ax.height]
-        )
     else:
         # if there is only 1 unique rank there is no horizontal bar graph,
         # so set the subplot dimensions to fill the space
-
-        # set the location of the right side of the figure
-        jgrid.fig.subplots_adjust(right=0.92)
-        # get the positions of the joint and marginal x axes
-        pos_joint_ax = jgrid.ax_joint.get_position()
-        pos_marg_x_ax = jgrid.ax_marg_x.get_position()
-        # set the position and dimensions of the joint plot such that it fills
-        # the space as if there was no horizontal bar graph
-        jgrid.ax_joint.set_position(
-            [pos_joint_ax.x0, pos_joint_ax.y0, pos_marg_x_ax.width, pos_joint_ax.height]
-        )
-        # set the position of the colorbar such that it is on the
-        # right side of the heatmap, and set its dimensions
-        jgrid.fig.axes[-1].set_position(
-            [0.82, pos_joint_ax.y0, 0.9, pos_joint_ax.height]
-        )
+        adjust_for_colorbar(jointgrid=jgrid, fig_right=0.92, cbar_x0=0.82)
 
     # invert the y-axis so rank values are increasing
     jgrid.ax_joint.invert_yaxis()
-
-    # turn the frame off for both marginal subplots
-    jgrid.ax_marg_x.axis("off")
-    jgrid.ax_marg_y.axis("off")
 
     # set the axis labels
     jgrid.ax_joint.set_xlabel("Time (s)")
@@ -409,41 +410,3 @@ def plot_dxt_heatmap(
     title_str = "Module(s): " + ", ".join(mods)
     jgrid.fig.suptitle(title_str, fontsize=11)
     return jgrid
-
-
-if __name__ == "__main__":
-    # get the path to the file(s) to be read in
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "datapath",
-        nargs="?",
-        help="Specify path to darshan log file or directory with darshan logs",
-    )
-    args = parser.parse_args()
-    data_path = args.datapath
-
-    if os.path.isfile(data_path):
-        # individual file case
-        files_to_process = [data_path]
-    elif os.path.isdir(data_path):
-        # directory case
-        files_to_process = glob.glob(os.path.join(data_path, "*.darshan"))
-
-    for filepath in files_to_process:
-        # get the file name and the file path
-        filename = os.path.basename(filepath)
-        # generate the darshan report
-        report = darshan.DarshanReport(filepath, read_all=False)
-
-        if "DXT_POSIX" not in report.modules.keys():
-            print(f"Skipping -> No 'DXT_POSIX' module in {filename}")
-            continue
-
-        # generate the heatmap figure
-        hmap = plot_dxt_heatmap(report=report)
-
-        save_path = os.path.join(os.getcwd(), os.path.splitext(filename)[0] + ".png")
-        # save the figure at the specified location
-        print(f"Saving figure at location: {save_path}")
-        plt.savefig(save_path, dpi=300)
-        plt.close()

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -291,17 +291,20 @@ def plot_dxt_heatmap(
     # create x ticks that scale with the number of xbins in the 2D histogram
     xticks = np.linspace(0, xbins, n_xlabels)
     jgrid.ax_joint.set_xticks(xticks)
-    # for the x tick labels, start at 0 and end with the max time (converted to
-    # an integer)
+    # for the x tick labels, start at 0 and end with
+    # the max time (converted to an integer)
+    min_time = 0.0
     max_time = np.max(end_time_data)
-    if max_time < 1:
-        x_ticklabels = np.around(np.linspace(0, max_time, n_xlabels), decimals=2)
-    elif (max_time > 1) & (max_time < 10):
-        x_ticklabels = np.around(np.linspace(0, max_time, n_xlabels), decimals=1)
+    if max_time <= 1:
+        # use 2 decimal places for run times less than 1 second
+        x_ticklabels = np.around(np.linspace(min_time, max_time, n_xlabels), decimals=2)
+    elif (max_time > 1) & (max_time <= 10):
+        # use 1 decimal place for run times between 1 and 10 seconds
+        x_ticklabels = np.around(np.linspace(min_time, max_time, n_xlabels), decimals=1)
     else:
-        x_ticklabels = np.asarray(
-            np.linspace(0, np.ceil(max_time), n_xlabels), dtype=int
-        )
+        # for run times greater than 10 seconds, round the max
+        # time up and round labels to the nearest integer
+        x_ticklabels = np.linspace(min_time, np.ceil(max_time), n_xlabels, dtype=int)
 
     jgrid.ax_joint.set_xticklabels(x_ticklabels, minor=False)
 
@@ -313,8 +316,8 @@ def plot_dxt_heatmap(
         sns_yticks = jgrid.ax_joint.get_yticks()
         yticks = np.linspace(sns_yticks.min(), sns_yticks.max(), n_ylabels)
         jgrid.ax_joint.set_yticks(yticks)
-        yticklabels = np.asarray(
-            np.linspace(unique_ranks.min(), unique_ranks.max(), n_ylabels), dtype=int
+        yticklabels = np.linspace(
+            unique_ranks.min(), unique_ranks.max(), n_ylabels, dtype=int
         )
     else:
         # if there are less than 12 unique ranks, just label each

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 
-requirements = ["cffi", "numpy", "pandas", "matplotlib"]
+requirements = ["cffi", "numpy", "pandas", "matplotlib", "seaborn"]
 setup_requirements = [
     "pytest-runner",
 ]
@@ -20,8 +20,8 @@ test_requirements = ["pytest"]
 # NOTE: The Python C extension is currently only used to automate
 # the build process of binary wheels for distribution via PyPi.
 #
-# If you are building darshan yourself and make libdarshan-util.so 
-# discoverable in the environment by means of LD_LIBRARY_PATH or 
+# If you are building darshan yourself and make libdarshan-util.so
+# discoverable in the environment by means of LD_LIBRARY_PATH or
 # pkg-config there is no need to build the extension.
 ext_modules = []
 if "--with-extension" in sys.argv:

--- a/darshan-util/pydarshan/tests/test_heatmap_handling.py
+++ b/darshan-util/pydarshan/tests/test_heatmap_handling.py
@@ -522,13 +522,13 @@ def test_get_aggregate_data(expected_agg_data, mods, ops):
         ),
     ],
 )
-def test_get_heatmap_data(
+def test_get_heatmap_df(
     filepath,
     expected_hmap_data,
     xbins,
     ops,
 ):
-    # regression test for `heatmap_handling.get_heatmap_data()`
+    # regression test for `heatmap_handling.get_heatmap_df()`
 
     # generate the report and use it to obtain the aggregated data
     report = darshan.DarshanReport(filepath)
@@ -536,40 +536,40 @@ def test_get_heatmap_data(
         report=report, mods=["DXT_POSIX"], ops=ops
     )
     # run the aggregated data through the heatmap data code
-    actual_hmap_data = heatmap_handling.get_heatmap_data(agg_df=agg_df, xbins=xbins)
+    actual_hmap_data = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)
 
     if filepath == "tests/input/sample-dxt-simple.darshan":
         # check the data is conserved
-        assert actual_hmap_data.sum() == 4040
+        assert actual_hmap_data.values.sum() == 4040
         # make sure the output array is the correct shape
         assert actual_hmap_data.shape == (1, xbins)
         # make sure the output data contains identical values
-        assert_allclose(actual_hmap_data, expected_hmap_data)
+        assert_allclose(actual_hmap_data.values, expected_hmap_data)
 
     elif filepath == "examples/example-logs/dxt.darshan":
         # make sure the output array is the correct shape
         assert actual_hmap_data.shape == (1, xbins)
         # make sure the output data contains identical values
-        assert_allclose(actual_hmap_data, expected_hmap_data)
+        assert_allclose(actual_hmap_data.values, expected_hmap_data)
 
         # for each combination of operations, make sure the sum is correct
         if len(ops) == 2:
-            assert actual_hmap_data.sum() == 35539507
+            assert actual_hmap_data.values.sum() == 35539507
         elif ops[0] == "read":
-            assert actual_hmap_data.sum() == 22517726
+            assert actual_hmap_data.values.sum() == 22517726
         elif ops[0] == "write":
-            assert actual_hmap_data.sum() == 13021781
+            assert actual_hmap_data.values.sum() == 13021781
 
     elif filepath == "examples/example-logs/ior_hdf5_example.darshan":
         # make sure the output array is the correct shape
         assert actual_hmap_data.shape == (4, xbins)
         # make sure the output data contains identical values
-        assert_allclose(actual_hmap_data, expected_hmap_data)
+        assert_allclose(actual_hmap_data.values, expected_hmap_data)
 
         # for each combination of operations, make sure the sum is correct
         if len(ops) == 2:
-            assert actual_hmap_data.sum() == 8398304
+            assert actual_hmap_data.values.sum() == 8398304
         elif ops[0] == "read":
-            assert actual_hmap_data.sum() == 4202504
+            assert actual_hmap_data.values.sum() == 4202504
         elif ops[0] == "write":
-            assert actual_hmap_data.sum() == 4195800
+            assert actual_hmap_data.values.sum() == 4195800

--- a/darshan-util/pydarshan/tests/test_heatmap_handling.py
+++ b/darshan-util/pydarshan/tests/test_heatmap_handling.py
@@ -1,0 +1,561 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
+import pandas as pd
+
+import darshan
+from darshan.experimental.plots import heatmap_handling
+
+
+@pytest.fixture(scope="function")
+def dict_list():
+    # mock data structure created to test `heatmap_handling.get_rd_wr_dfs()`
+    # generates a list of python dictionaries which each contain dataframes
+    # for read/write events
+
+    # create a small data set to store in a dataframe
+    n_data_points = 10
+    start_arr = np.linspace(0, 3, n_data_points)
+    end_arr = start_arr + 0.5
+    len_arr = np.arange(1, n_data_points + 1)
+    offset_arr = np.arange(n_data_points) + n_data_points
+
+    # use the data above to create a base dataframe to use
+    # for creating the dictionary list
+    base_df = pd.DataFrame(
+        data=np.column_stack((start_arr, end_arr, len_arr, offset_arr)),
+        columns=["length", "start_time", "end_time", "offset"],
+    )
+
+    # initialize an empty list for storing dictionaries (containing dataframes)
+    dict_list = []
+    # only iterate 3 times to keep data structure simple
+    for i in range(1, 4):
+        # create a dictionary with a rank index, a read segment (dataframe)
+        # and a write segment (dataframe)
+        _dict = {}
+        # assign the rank using the index
+        _dict["rank"] = i
+        # for the read segment, multiply the dataframe data by the index so
+        # each segment has distinguishable values
+        _dict["read_segments"] = i * base_df
+        # do the same for the write segments, but only for the middle iteration
+        if i == 2:
+            # again, assign a modified dataframe for uniqueness
+            _dict["write_segments"] = i * (base_df + 10)
+        else:
+            # assign an empty dataframe for first and last iterations
+            _dict["write_segments"] = pd.DataFrame()
+        dict_list.append(_dict)
+
+    return dict_list
+
+
+@pytest.fixture(scope="function")
+def dict_list_no_writes():
+    # Similar to `dict_list`, this fixture is targeted at creating a
+    # dictionary list for `heatmap_handling.get_rd_wr_dfs()` such that
+    # the returned `write_df` is an empty dataframe
+
+    # create a small data set to store in a dataframe
+    n_data_points = 10
+    start_arr = np.linspace(0, 3, n_data_points)
+    end_arr = start_arr + 0.5
+    len_arr = np.arange(1, n_data_points + 1)
+    offset_arr = np.arange(n_data_points) + n_data_points
+
+    # use the data above to create a base dataframe to use
+    # for creating the dictionary list
+    base_df = pd.DataFrame(
+        data=np.column_stack((start_arr, end_arr, len_arr, offset_arr)),
+        columns=["length", "start_time", "end_time", "offset"],
+    )
+
+    # initialize an empty list for storing dictionaries (containing dataframes)
+    dict_list = []
+    # only iterate 3 times to keep data structure simple
+    for i in range(1, 4):
+        # create a dictionary with a rank index, a read segment (dataframe)
+        # and a write segment (dataframe)
+        _dict = {}
+        # assign the rank using the index
+        _dict["rank"] = i
+        # for the read segment, multiply the dataframe data by the index so
+        # each segment has distinguishable values
+        _dict["read_segments"] = i * base_df
+        # for the write segments assign an empty dataframe
+        _dict["write_segments"] = pd.DataFrame()
+        dict_list.append(_dict)
+
+    return dict_list
+
+
+def test_get_rd_wr_dfs(dict_list):
+    read_df, write_df = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list)
+    # check that we get the correct data shape after
+    # combining the read/write dataframes
+    assert read_df.shape == (30, 4)
+    assert write_df.shape == (10, 4)
+
+    # check that the correct column names are generated. We expect "offset"
+    # to be missing and "rank" to be added
+    df_keys = ["length", "start_time", "end_time", "rank"]
+    assert list(read_df.columns) == df_keys
+    assert list(write_df.columns) == df_keys
+
+    # verify the correct rank values are displayed. Since a read segment was
+    # generated for each iteration, there should be ranks 1-3, and since
+    # a write segment was only generated for the middle iteration we should
+    # only get 2
+    assert_array_equal(np.unique(read_df["rank"].values), [1, 2, 3])
+    assert_array_equal(np.unique(write_df["rank"].values), [2])
+
+    # since we ignore the original row indices in the individual dataframes
+    # make sure we get the correct indices (0-29) and (0-9) for read and write,
+    # respectively
+    assert_array_equal(read_df.index, np.arange(30))
+    assert_array_equal(write_df.index, np.arange(10))
+
+
+def test_get_rd_wr_dfs_no_write(dict_list_no_writes):
+    # based on `test_get_rd_wr_dfs`
+
+    read_df, write_df = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list_no_writes)
+    # since there are no write dataframes we should get an empty write dataframe
+    assert write_df.empty
+    # check that we get the correct data shape after
+    # combining the read dataframes
+    assert read_df.shape == (30, 4)
+
+    # check that the correct column names are generated. We expect "offset"
+    # to be missing and "rank" to be added
+    df_keys = ["length", "start_time", "end_time", "rank"]
+    assert list(read_df.columns) == df_keys
+
+    # verify the correct rank values are displayed. Since a read segment was
+    # generated for each iteration, there should be ranks 1-3
+    assert_array_equal(np.unique(read_df["rank"].values), [1, 2, 3])
+
+    # since we ignore the original row indices in the individual dataframes
+    # make sure we get the correct indices (0-29) for read
+    assert_array_equal(read_df.index, np.arange(30))
+
+
+@pytest.mark.parametrize(
+    # all 3 test cases are based on the outputs for
+    # `tests/input/sample-dxt-simple.darshan`, which only has write data
+    "ops, expected_df_dict",
+    [
+        (
+            # check the result using both operations
+            ["read", "write"],
+            {
+                "DXT_POSIX": {
+                    "read": pd.DataFrame(),
+                    "write": pd.DataFrame(
+                        columns=["length", "start_time", "end_time", "rank"],
+                        data=np.array(
+                            [
+                                [40, 0.10337884305045009, 0.10338771319948137, 0],
+                                [4000, 0.10421665315516293, 0.10423145908862352, 0],
+                            ]
+                        ),
+                    ),
+                },
+            },
+        ),
+        (
+            # check the result for only the "read" operation, should be empty
+            ["read"],
+            {"DXT_POSIX": {"read": pd.DataFrame()}},
+        ),
+        (
+            # the results for only checking the "write" data should be the same
+            # as checking both operations
+            ["write"],
+            {
+                "DXT_POSIX": {
+                    "write": pd.DataFrame(
+                        columns=["length", "start_time", "end_time", "rank"],
+                        data=np.array(
+                            [
+                                [40, 0.10337884305045009, 0.10338771319948137, 0],
+                                [4000, 0.10421665315516293, 0.10423145908862352, 0],
+                            ]
+                        ),
+                    ),
+                },
+            },
+        ),
+    ],
+)
+def test_get_single_df_dict(expected_df_dict, ops):
+    # regression test for `heatmap_handling.get_single_df_dict()`
+
+    report = darshan.DarshanReport("tests/input/sample-dxt-simple.darshan")
+
+    actual_df_dict = heatmap_handling.get_single_df_dict(
+        report=report, mods=["DXT_POSIX"], ops=ops
+    )
+
+    # make sure we get the same key(s) ("DXT_POSIX")
+    assert actual_df_dict.keys() == expected_df_dict.keys()
+    # make sure we get the correct key(s)
+    assert actual_df_dict["DXT_POSIX"].keys() == expected_df_dict["DXT_POSIX"].keys()
+    # also check that we only get the key(s) we requested
+    assert list(actual_df_dict["DXT_POSIX"].keys()) == ops
+
+    if "read" in ops:
+        # for the read case, check that we get an empty dataframe
+        assert actual_df_dict["DXT_POSIX"]["read"].empty
+
+    if "write" in ops:
+        # check that we get the same column names
+        assert_array_equal(
+            actual_df_dict["DXT_POSIX"]["write"].columns,
+            expected_df_dict["DXT_POSIX"]["write"].columns,
+        )
+
+        # verify the returned values are the same
+        assert_array_equal(
+            actual_df_dict["DXT_POSIX"]["write"].values,
+            expected_df_dict["DXT_POSIX"]["write"].values,
+        )
+
+
+@pytest.mark.parametrize(
+    "mods, ops, expected_agg_data",
+    [
+        # all 3 test cases are based on the outputs for
+        # `tests/input/sample-dxt-simple.darshan`, which only has write data
+        (
+            ["DXT_POSIX"],
+            ["read", "write"],
+            np.array(
+                [
+                    [40, 0.10337884305045009, 0.10338771319948137, 0],
+                    [4000, 0.10421665315516293, 0.10423145908862352, 0],
+                ]
+            ),
+        ),
+        # for "read" case input None since there is no data to compare
+        (["DXT_POSIX"], ["read"], None),
+        (["DXT_MPIIO"], ["read"], None),
+        (
+            ["DXT_POSIX"],
+            ["write"],
+            np.array(
+                [
+                    [40, 0.10337884305045009, 0.10338771319948137, 0],
+                    [4000, 0.10421665315516293, 0.10423145908862352, 0],
+                ]
+            ),
+        ),
+    ],
+)
+def test_get_aggregate_data(expected_agg_data, mods, ops):
+    # regression test for `heatmap_handling.get_aggregate_data()`
+
+    report = darshan.DarshanReport("tests/input/sample-dxt-simple.darshan")
+
+    if ops == ["read"]:
+        if mods == ["DXT_POSIX"]:
+            expected_msg = (
+                "No data available for selected module\\(s\\) and operation\\(s\\)."
+            )
+            with pytest.raises(ValueError, match=expected_msg):
+                # expect an error because there are no read segments
+                # in sample-dxt-simple.darshan
+                actual_agg_data = heatmap_handling.get_aggregate_data(
+                    report=report, mods=mods, ops=ops
+                )
+        elif mods == ["DXT_MPIIO"]:
+            with pytest.raises(KeyError, match="'DXT_POSIX'"):
+                # expect an error because there are no read segments
+                # in sample-dxt-simple.darshan
+                actual_agg_data = heatmap_handling.get_aggregate_data(
+                    report=report, mods=mods, ops=ops
+                )
+    else:
+        actual_agg_data = heatmap_handling.get_aggregate_data(
+            report=report, mods=mods, ops=ops
+        )
+        # for other cases, make sure the value arrays are identically valued
+        assert_array_equal(actual_agg_data.values, expected_agg_data)
+
+
+@pytest.mark.parametrize(
+    "filepath, xbins, ops, expected_hmap_data",
+    [
+        # iterate over 3 different darshan logs, various bin counts, and
+        # combinations of operations, checking the heatmap data array
+        # output for each case.
+        # For `sample-dxt-simple.darshan` the selected
+        # operations are not changed because there is no "read" data
+        (
+            "tests/input/sample-dxt-simple.darshan",
+            1,
+            ["read", "write"],
+            np.array([[4040]]),
+        ),
+        (
+            "tests/input/sample-dxt-simple.darshan",
+            4,
+            ["read", "write"],
+            np.array([[0, 0, 0, 4040]]),
+        ),
+        (
+            "tests/input/sample-dxt-simple.darshan",
+            10,
+            ["read", "write"],
+            np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 4040]]),
+        ),
+        # `dxt.darshan` is complex enough to warrant changing the
+        # selected operations
+        ("examples/example-logs/dxt.darshan", 1, ["read"], np.array([[22517726]])),
+        (
+            "examples/example-logs/dxt.darshan",
+            4,
+            ["read"],
+            np.array([[10214363, 0, 8070137, 4233226]]),
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            10,
+            ["read"],
+            np.array([[10214363, 0, 0, 0, 0, 0, 8070137, 0, 0, 4233226]]),
+        ),
+        ("examples/example-logs/dxt.darshan", 1, ["write"], np.array([[13021781]])),
+        (
+            "examples/example-logs/dxt.darshan",
+            4,
+            ["write"],
+            np.array([[4381, 0, 10915913, 2101487]]),
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            10,
+            ["write"],
+            np.array([[4381, 0, 0, 0, 0, 0, 10915913, 0, 0, 2101487]]),
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            1,
+            ["read", "write"],
+            np.array([[35539507]]),
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            4,
+            ["read", "write"],
+            np.array([[10218744, 0, 18986050, 6334713]]),
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            10,
+            ["read", "write"],
+            np.array([[10218744, 0, 0, 0, 0, 0, 18986050, 0, 0, 6334713]]),
+        ),
+        # `ior_hdf5_example.darshan` is the only log with multiple ranks (4),
+        # so it also gets different operation combinations
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            1,
+            ["read"],
+            np.array([[1051088], [1050472], [1050472], [1050472]]),
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            10,
+            ["read"],
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 1051088, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 107988.68001937, 942483.31998063],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 1050472, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 1050472, 0],
+                ]
+            ),
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            1,
+            ["write"],
+            np.array(
+                [
+                    [1048808],
+                    [1049240],
+                    [1048848],
+                    [1048904],
+                ]
+            ),
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            10,
+            ["write"],
+            np.array(
+                [
+                    [
+                        0,
+                        808091.3650729951,
+                        41175.65189967951,
+                        41175.6518996795,
+                        41175.6518996795,
+                        41175.65189967952,
+                        41175.65189967947,
+                        34606.37542860738,
+                        0,
+                        232,
+                    ],
+                    [
+                        0,
+                        288603.1671221,
+                        40689.00335231,
+                        40689.00335231,
+                        40689.00335231,
+                        40689.00335231,
+                        40689.00335231,
+                        556527.81611634,
+                        0,
+                        664,
+                    ],
+                    [
+                        0,
+                        548158.6819154,
+                        41120.86590861,
+                        41120.86590861,
+                        41120.86590861,
+                        41120.86590861,
+                        41120.86590861,
+                        63152.77796803,
+                        149027.37037175,
+                        82904.84020176,
+                    ],
+                    [0, 1048576, 0, 0, 0, 0, 0, 0, 0, 328],
+                ]
+            ),
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            1,
+            ["read", "write"],
+            np.array(
+                [
+                    [2099896],
+                    [2099712],
+                    [2099320],
+                    [2099376],
+                ]
+            ),
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            10,
+            ["read", "write"],
+            np.array(
+                [
+                    [
+                        0,
+                        827385.0734944909,
+                        50822.506110427385,
+                        50822.50611042739,
+                        50822.50611042739,
+                        50822.50611042737,
+                        17900.90206379957,
+                        30.830417529761142,
+                        1051289.1695824703,
+                        0,
+                    ],
+                    [
+                        0,
+                        307668.84624124144,
+                        50221.842911882275,
+                        50221.84291188228,
+                        50221.84291188228,
+                        50221.84291188226,
+                        540019.7821112294,
+                        418.49887595643366,
+                        108234.18114341467,
+                        942483.3199806289,
+                    ],
+                    [
+                        0,
+                        567426.7192208751,
+                        50754.88456134755,
+                        50754.88456134756,
+                        50754.88456134756,
+                        50754.884561347535,
+                        141846.72456250372,
+                        136490.77078712088,
+                        1050536.24718411,
+                        0,
+                    ],
+                    [
+                        0,
+                        1048576,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        251.0322619047617,
+                        1050548.9677380952,
+                        0,
+                    ],
+                ]
+            ),
+        ),
+    ],
+)
+def test_get_heatmap_data(
+    filepath,
+    expected_hmap_data,
+    xbins,
+    ops,
+):
+    # regression test for `heatmap_handling.get_heatmap_data()`
+
+    # generate the report and use it to obtain the aggregated data
+    report = darshan.DarshanReport(filepath)
+    agg_df = heatmap_handling.get_aggregate_data(
+        report=report, mods=["DXT_POSIX"], ops=ops
+    )
+    # run the aggregated data through the heatmap data code
+    actual_hmap_data = heatmap_handling.get_heatmap_data(agg_df=agg_df, xbins=xbins)
+
+    if filepath == "tests/input/sample-dxt-simple.darshan":
+        # check the data is conserved
+        assert actual_hmap_data.sum() == 4040
+        # make sure the output array is the correct shape
+        assert actual_hmap_data.shape == (1, xbins)
+        # make sure the output data contains identical values
+        assert_array_equal(actual_hmap_data, expected_hmap_data)
+
+    elif filepath == "examples/example-logs/dxt.darshan":
+        # make sure the output array is the correct shape
+        assert actual_hmap_data.shape == (1, xbins)
+        # make sure the output data contains identical values
+        assert_array_equal(actual_hmap_data, expected_hmap_data)
+
+        # for each combination of operations, make sure the sum is correct
+        if len(ops) == 2:
+            assert actual_hmap_data.sum() == 35539507
+        elif ops[0] == "read":
+            assert actual_hmap_data.sum() == 22517726
+        elif ops[0] == "write":
+            assert actual_hmap_data.sum() == 13021781
+
+    elif filepath == "examples/example-logs/ior_hdf5_example.darshan":
+        # make sure the output array is the correct shape
+        assert actual_hmap_data.shape == (4, xbins)
+        # make sure the output data contains identical values
+        assert np.allclose(actual_hmap_data, expected_hmap_data)
+
+        # for each combination of operations, make sure the sum is correct
+        if len(ops) == 2:
+            assert actual_hmap_data.sum() == 8398304
+        elif ops[0] == "read":
+            assert actual_hmap_data.sum() == 4202504
+        elif ops[0] == "write":
+            assert actual_hmap_data.sum() == 4195800

--- a/darshan-util/pydarshan/tests/test_heatmap_handling.py
+++ b/darshan-util/pydarshan/tests/test_heatmap_handling.py
@@ -93,7 +93,12 @@ def dict_list_no_writes():
 def test_get_rd_wr_dfs(dict_list):
     # regression test for `heatmap_handling.get_rd_wr_dfs()`
 
-    read_df, write_df = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list)
+    rd_wr_dfs = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list)
+
+    # retrieve read/write dataframes from the dictionary
+    read_df = rd_wr_dfs["read"]
+    write_df = rd_wr_dfs["write"]
+
     # check that we get the correct data shape after
     # combining the read/write dataframes
     assert read_df.shape == (30, 4)
@@ -124,7 +129,12 @@ def test_get_rd_wr_dfs_no_write(dict_list_no_writes):
     # `heatmap_handling.get_rd_wr_dfs()` to cover case
     # where there are no write events found
 
-    read_df, write_df = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list_no_writes)
+    rd_wr_dfs = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list_no_writes)
+
+    # retrieve read/write dataframes from the dictionary
+    read_df = rd_wr_dfs["read"]
+    write_df = rd_wr_dfs["write"]
+
     # since there are no write dataframes we should get an empty write dataframe
     assert write_df.empty
     # check that we get the correct data shape after
@@ -554,7 +564,7 @@ def test_get_heatmap_data(
         # make sure the output array is the correct shape
         assert actual_hmap_data.shape == (4, xbins)
         # make sure the output data contains identical values
-        assert np.allclose(actual_hmap_data, expected_hmap_data)
+        assert_allclose(actual_hmap_data, expected_hmap_data)
 
         # for each combination of operations, make sure the sum is correct
         if len(ops) == 2:

--- a/darshan-util/pydarshan/tests/test_heatmap_handling.py
+++ b/darshan-util/pydarshan/tests/test_heatmap_handling.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import pandas as pd
 
 import darshan
@@ -91,6 +91,8 @@ def dict_list_no_writes():
 
 
 def test_get_rd_wr_dfs(dict_list):
+    # regression test for `heatmap_handling.get_rd_wr_dfs()`
+
     read_df, write_df = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list)
     # check that we get the correct data shape after
     # combining the read/write dataframes
@@ -118,7 +120,9 @@ def test_get_rd_wr_dfs(dict_list):
 
 
 def test_get_rd_wr_dfs_no_write(dict_list_no_writes):
-    # based on `test_get_rd_wr_dfs`
+    # based on `test_get_rd_wr_dfs`, regression test for
+    # `heatmap_handling.get_rd_wr_dfs()` to cover case
+    # where there are no write events found
 
     read_df, write_df = heatmap_handling.get_rd_wr_dfs(dict_list=dict_list_no_writes)
     # since there are no write dataframes we should get an empty write dataframe
@@ -281,7 +285,7 @@ def test_get_aggregate_data(expected_agg_data, mods, ops):
             report=report, mods=mods, ops=ops
         )
         # for other cases, make sure the value arrays are identically valued
-        assert_array_equal(actual_agg_data.values, expected_agg_data)
+        assert_allclose(actual_agg_data.values, expected_agg_data)
 
 
 @pytest.mark.parametrize(
@@ -530,13 +534,13 @@ def test_get_heatmap_data(
         # make sure the output array is the correct shape
         assert actual_hmap_data.shape == (1, xbins)
         # make sure the output data contains identical values
-        assert_array_equal(actual_hmap_data, expected_hmap_data)
+        assert_allclose(actual_hmap_data, expected_hmap_data)
 
     elif filepath == "examples/example-logs/dxt.darshan":
         # make sure the output array is the correct shape
         assert actual_hmap_data.shape == (1, xbins)
         # make sure the output data contains identical values
-        assert_array_equal(actual_hmap_data, expected_hmap_data)
+        assert_allclose(actual_hmap_data, expected_hmap_data)
 
         # for each combination of operations, make sure the sum is correct
         if len(ops) == 2:

--- a/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
@@ -335,13 +335,15 @@ def test_remove_marginal_graph_ticks_and_labels(filepath):
     ],
 )
 def test_adjust_for_colorbar(filepath):
+    # regression test for `plot_dxt_heatmap.adjust_for_colorbar()`
+
     jgrid = plot_dxt_heatmap.plot_heatmap(log_path=filepath)
 
     # the plot positions change based on the number of unique ranks.
     # If there is only 1 rank, there is no horizontal bar graph
     # so the x-axis values are scaled accordingly.
 
-    # get heat map positions
+    # get heatmap positions
     hmap_positions = jgrid.ax_joint.get_position()
     assert hmap_positions.x0 == 0.1
     assert hmap_positions.y0 == 0.15000000000000002
@@ -407,6 +409,7 @@ def test_adjust_for_colorbar(filepath):
 @pytest.mark.parametrize("mods", [["DXT_POSIX"], ["DXT_MPIIO"]])
 @pytest.mark.parametrize("ops", [["read", "write"], ["read"], ["write"]])
 def test_plot_heatmap(filepath, mods, ops):
+    # test the primary plotting function, `plot_dxt_heatmap.plot_heatmap()`
 
     if mods == ["DXT_MPIIO"]:
         # if the input module is not "DXT_POSIX" check
@@ -435,7 +438,7 @@ def test_plot_heatmap(filepath, mods, ops):
         assert jgrid.ax_marg_x.margins() == (0.05, 0.05)
         assert jgrid.ax_marg_y.margins() == (0.05, 0.05)
 
-        # ensure the heat map spines are all visible
+        # ensure the heatmap spines are all visible
         for _, spine in jgrid.ax_joint.spines.items():
             assert spine.get_visible()
 

--- a/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
@@ -140,8 +140,8 @@ def test_set_x_axis_ticks_and_labels(
     plt.close()
 
     # verify the actual ticks/labels match the expected
-    assert np.allclose(actual_xticks, expected_xticks, atol=1e-14, rtol=1e-17)
-    assert np.allclose(actual_xticklabels, expected_xticklabels, atol=1e-14, rtol=1e-17)
+    assert_allclose(actual_xticks, expected_xticks, atol=1e-14, rtol=1e-17)
+    assert_allclose(actual_xticklabels, expected_xticklabels, atol=1e-14, rtol=1e-17)
 
 
 @pytest.mark.parametrize(
@@ -168,7 +168,7 @@ def test_get_y_axis_ticks(n_ylabels, expected_yticks, jointgrid):
     plt.close()
 
     # make sure the actual tick mark locations match the expected
-    assert np.allclose(actual_yticks, expected_yticks, atol=1e-14, rtol=1e-17)
+    assert_allclose(actual_yticks, expected_yticks, atol=1e-14, rtol=1e-17)
 
 
 @pytest.mark.parametrize(
@@ -290,8 +290,8 @@ def test_set_y_axis_ticks_and_labels(
     plt.close()
 
     # verify the actual ticks/labels match the expected
-    assert np.allclose(actual_yticks, expected_yticks, atol=1e-14, rtol=1e-17)
-    assert np.allclose(actual_yticklabels, expected_yticklabels, atol=1e-14, rtol=1e-17)
+    assert_allclose(actual_yticks, expected_yticks, atol=1e-14, rtol=1e-17)
+    assert_allclose(actual_yticklabels, expected_yticklabels, atol=1e-14, rtol=1e-17)
 
 
 @pytest.mark.parametrize(

--- a/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
@@ -266,7 +266,7 @@ def test_set_y_axis_ticks_and_labels(
     xbins = 100
 
     # generate the heatmap data
-    data = heatmap_handling.get_heatmap_data(agg_df=agg_df, xbins=xbins)
+    data = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)
 
     # use the unique ranks to get the number of y-axis bins to use
     unique_ranks = np.unique(agg_df["rank"].values)

--- a/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
@@ -1,0 +1,458 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+import darshan
+from darshan.experimental.plots import heatmap_handling
+from darshan.experimental.plots import plot_dxt_heatmap
+
+
+@pytest.fixture(scope="function")
+def jointgrid():
+    # generates a `sns.JointGrid` object
+    jgrid = sns.jointplot(kind="hist", bins=(4, 100))
+    return jgrid
+
+
+@pytest.mark.parametrize(
+    "filepath, n_xlabels, expected_xticks, expected_xticklabels",
+    [
+        ("examples/example-logs/ior_hdf5_example.darshan", 2, [0.0, 1.0], [0.0, 0.29]),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            4,
+            [0.0, 0.4, 0.6, 1.0],
+            [0.0, 0.1, 0.19, 0.29],
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            6,
+            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            [0.0, 0.06, 0.11, 0.17, 0.23, 0.29],
+        ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            10,
+            [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
+            [
+                0.0,
+                0.03,
+                0.06,
+                0.1,
+                0.13,
+                0.16,
+                0.19,
+                0.22,
+                0.25,
+                0.29,
+            ],
+        ),
+        ("examples/example-logs/dxt.darshan", 2, [0.0, 1.0], [0, 1468]),
+        (
+            "examples/example-logs/dxt.darshan",
+            4,
+            [0.0, 0.4, 0.6, 1.0],
+            [0, 489, 978, 1468],
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            6,
+            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            [0, 293, 587, 880, 1174, 1468],
+        ),
+        (
+            "examples/example-logs/dxt.darshan",
+            10,
+            [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
+            [0, 163, 326, 489, 652, 815, 978, 1141, 1304, 1468],
+        ),
+        ("tests/input/sample-dxt-simple.darshan", 2, [0.0, 1.0], [0.0, 0.1]),
+        (
+            "tests/input/sample-dxt-simple.darshan",
+            4,
+            [0.0, 0.4, 0.6, 1.0],
+            [0.0, 0.03, 0.07, 0.1],
+        ),
+        (
+            "tests/input/sample-dxt-simple.darshan",
+            6,
+            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            [0.0, 0.02, 0.04, 0.06, 0.08, 0.1],
+        ),
+        (
+            "tests/input/sample-dxt-simple.darshan",
+            10,
+            [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
+            [
+                0.0,
+                0.01,
+                0.02,
+                0.03,
+                0.05,
+                0.06,
+                0.07,
+                0.08,
+                0.09,
+                0.1,
+            ],
+        ),
+        (None, 2, [0.0, 1.0], [0.0, 1.0]),
+    ],
+)
+def test_set_x_axis_ticks_and_labels(
+    filepath,
+    n_xlabels,
+    expected_xticks,
+    expected_xticklabels,
+    jointgrid,
+):
+    # make sure the x-axis ticks and
+    # tick labels are generated appropriately
+
+    if filepath is None:
+        # don't have any data sets with a max time between 1 and 10, so
+        # create a synthetic one here
+        data = [[4, 1.03378843, 1.03387713, 0], [4000, 1.04216653, 1.04231459, 0]]
+        cols = ["length", "start_time", "end_time", "rank"]
+        agg_df = pd.DataFrame(data=data, columns=cols)
+
+    else:
+        # for all other data sets just load the data from the log file
+        report = darshan.DarshanReport(filepath)
+        agg_df = heatmap_handling.get_aggregate_data(
+            report=report, mods=["DXT_POSIX"], ops=["read", "write"]
+        )
+
+    # set the x-axis ticks and tick labels
+    plot_dxt_heatmap.set_x_axis_ticks_and_labels(
+        jointgrid=jointgrid, agg_df=agg_df, n_xlabels=n_xlabels
+    )
+
+    # collect the actual x-axis tick labels
+    actual_xticks = jointgrid.ax_joint.get_xticks()
+    actual_xticklabels = [tl.get_text() for tl in jointgrid.ax_joint.get_xticklabels()]
+    actual_xticklabels = np.asarray(actual_xticklabels, dtype=float)
+
+    # make sure the figure object gets closed
+    plt.close()
+
+    # verify the actual ticks/labels match the expected
+    assert np.allclose(actual_xticks, expected_xticks, atol=1e-14, rtol=1e-17)
+    assert np.allclose(actual_xticklabels, expected_xticklabels, atol=1e-14, rtol=1e-17)
+
+
+@pytest.mark.parametrize(
+    "n_ylabels, expected_yticks",
+    [
+        # try the minimum number of tick marks
+        (2, [0, 1]),
+        # request more y-axis tick marks than are available
+        (10, [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]),
+        (4, [0, 0.4, 0.6, 1]),
+        (6, [0, 0.2, 0.4, 0.6, 0.8, 1]),
+    ],
+)
+def test_get_y_axis_ticks(n_ylabels, expected_yticks, jointgrid):
+    # test some edge cases for the
+    # y-axis tick mark location code
+
+    # get the y-axis tick mark locations
+    actual_yticks = plot_dxt_heatmap.get_y_axis_ticks(
+        ax=jointgrid.ax_joint, n_ylabels=n_ylabels
+    )
+
+    # close the figure object
+    plt.close()
+
+    # make sure the actual tick mark locations match the expected
+    assert np.allclose(actual_yticks, expected_yticks, atol=1e-14, rtol=1e-17)
+
+
+@pytest.mark.parametrize(
+    "n_ylabels, unique_ranks, expected_yticklabels",
+    [
+        (2, np.arange(10), ["0", "9"]),
+        # request more y-axis tick labels than are available
+        (10, np.arange(4), ["0", "1", "2", "3"]),
+        (4, np.arange(10), ["0", "3", "6", "9"]),
+        (6, np.arange(10), ["0", "2", "4", "5", "7", "9"]),
+        (8, np.arange(10), ["0", "1", "3", "4", "5", "6", "8", "9"]),
+        (4, np.arange(100), ["0", "32", "64", "96"]),
+        (8, np.arange(100), ["0", "12", "28", "40", "56", "68", "84", "96"]),
+        (6, np.arange(1000), ["0", "192", "384", "608", "800", "992"]),
+    ],
+)
+def test_get_y_axis_tick_labels(
+    n_ylabels,
+    unique_ranks,
+    expected_yticklabels,
+):
+    # test some specific cases for
+    # the y-axis tick mark label function
+
+    # x-axis bins are arbitrary, y-axis bins are the number of unique ranks
+    xbins = 50
+    ybins = unique_ranks.size
+    bins = [xbins, ybins]
+
+    # generate a jointgrid object using the bin dimensions above
+    jointgrid = sns.jointplot(kind="hist", bins=bins)
+
+    # generate array of ones and put a heatmap as the main 'joint' plot
+    data = np.ones((ybins, xbins))
+    sns.heatmap(data, ax=jointgrid.ax_joint)
+
+    # retrieve the actual y-axis tick labels
+    actual_yticklabels = plot_dxt_heatmap.get_y_axis_tick_labels(
+        ax=jointgrid.ax_joint, n_ylabels=n_ylabels
+    )
+
+    # make sure the figure object gets closed
+    plt.close()
+
+    # make sure the actual tick mark labels match the expected
+    assert_array_equal(actual_yticklabels, expected_yticklabels)
+
+
+@pytest.mark.parametrize(
+    "filepath, n_ylabels, expected_yticks, expected_yticklabels",
+    [
+        # check that if less y-axis labels are input, we get the
+        # correct number of labels back
+        ("examples/example-logs/ior_hdf5_example.darshan", 2, [0.5, 3.5], [0.0, 3.0]),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            4,
+            [0.5, 1.5, 2.5, 3.5],
+            [0.0, 1.0, 2.0, 3.0],
+        ),
+        # check that if we input more y-axis labels than available,
+        # we just get back the maximum number available
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            8,
+            [0.5, 1.5, 2.5, 3.5],
+            [0.0, 1.0, 2.0, 3.0],
+        ),
+        ("examples/example-logs/dxt.darshan", 2, [0.5], [0]),
+        # check that if we ask for more y-axis labels than
+        # available, we still get the same output
+        ("examples/example-logs/dxt.darshan", 4, [0.5], [0]),
+        ("tests/input/sample-dxt-simple.darshan", 2, [0.5], [0.0]),
+        # check that if we ask for more y-axis labels than
+        # available, we still get the same output
+        ("tests/input/sample-dxt-simple.darshan", 4, [0.5], [0.0]),
+    ],
+)
+def test_set_y_axis_ticks_and_labels(
+    filepath,
+    n_ylabels,
+    expected_yticks,
+    expected_yticklabels,
+):
+    # make sure the x-axis ticks and
+    # tick labels are generated appropriately
+
+    # load the report and generate the aggregate data dataframe
+    report = darshan.DarshanReport(filepath)
+    agg_df = heatmap_handling.get_aggregate_data(
+        report=report, mods=["DXT_POSIX"], ops=["read", "write"]
+    )
+
+    # x-axis bins are arbitrary
+    xbins = 100
+
+    # generate the heatmap data
+    data = heatmap_handling.get_heatmap_data(agg_df=agg_df, xbins=xbins)
+
+    # use the unique ranks to get the number of y-axis bins to use
+    unique_ranks = np.unique(agg_df["rank"].values)
+    ybins = unique_ranks.size
+
+    # generate a joint plot object, then add the heatmap to it
+    jointgrid = sns.jointplot(kind="hist", bins=[xbins, ybins])
+    sns.heatmap(data, ax=jointgrid.ax_joint)
+
+    # set the x-axis ticks and tick labels
+    plot_dxt_heatmap.set_y_axis_ticks_and_labels(
+        jointgrid=jointgrid, n_ylabels=n_ylabels
+    )
+
+    # collect the actual x-axis tick labels
+    actual_yticks = jointgrid.ax_joint.get_yticks()
+    actual_yticklabels = [tl.get_text() for tl in jointgrid.ax_joint.get_yticklabels()]
+    actual_yticklabels = np.asarray(actual_yticklabels, dtype=float)
+
+    # make sure the figure object gets closed
+    plt.close()
+
+    # verify the actual ticks/labels match the expected
+    assert np.allclose(actual_yticks, expected_yticks, atol=1e-14, rtol=1e-17)
+    assert np.allclose(actual_yticklabels, expected_yticklabels, atol=1e-14, rtol=1e-17)
+
+
+@pytest.mark.parametrize(
+    "filepath",
+    [
+        "examples/example-logs/ior_hdf5_example.darshan",
+        "examples/example-logs/dxt.darshan",
+        "tests/input/sample-dxt-simple.darshan",
+    ],
+)
+def test_remove_marginal_graph_ticks_and_labels(filepath):
+    # regression test ensuring the marginal x/y bar graphs do
+    # not have any x/y tick labels or frames
+
+    jgrid = plot_dxt_heatmap.plot_heatmap(
+        log_path=filepath, mods=["DXT_POSIX"], ops=["read", "write"], xbins=100
+    )
+
+    # verify the heatmap axis is on
+    assert jgrid.ax_joint.axison
+    # verify the marginal axes are turned off
+    assert not jgrid.ax_marg_x.axison
+    assert not jgrid.ax_marg_y.axison
+
+    # make sure the label lists are empty
+    assert jgrid.ax_marg_x.get_xticklabels() == []
+    assert jgrid.ax_marg_x.get_yticklabels() == []
+    assert jgrid.ax_marg_y.get_xticklabels() == []
+    assert jgrid.ax_marg_y.get_yticklabels() == []
+
+    # close the figure object
+    plt.close()
+
+
+@pytest.mark.parametrize(
+    "filepath",
+    [
+        "examples/example-logs/ior_hdf5_example.darshan",
+        "examples/example-logs/dxt.darshan",
+        "tests/input/sample-dxt-simple.darshan",
+    ],
+)
+def test_adjust_for_colorbar(filepath):
+    jgrid = plot_dxt_heatmap.plot_heatmap(log_path=filepath)
+
+    # the plot positions change based on the number of unique ranks.
+    # If there is only 1 rank, there is no horizontal bar graph
+    # so the x-axis values are scaled accordingly.
+
+    # get heat map positions
+    hmap_positions = jgrid.ax_joint.get_position()
+    assert hmap_positions.x0 == 0.1
+    assert hmap_positions.y0 == 0.15000000000000002
+    assert hmap_positions.y1 == 0.774390243902439
+    if filepath == "examples/example-logs/ior_hdf5_example.darshan":
+        # since `ior_hdf5_example.darshan` has 4 ranks, it has
+        # different x max values because it needs room for
+        # the colorbar on the outside of the horizontal bar graph
+        assert hmap_positions.x1 == 0.7158709677419354
+    else:
+        assert hmap_positions.x1 == 0.7824516129032258
+
+    # get vertical bar graph positions
+    vert_bar_positions = jgrid.ax_marg_x.get_position()
+    assert vert_bar_positions.x0 == 0.1
+    assert vert_bar_positions.y0 == 0.7780487804878049
+    assert vert_bar_positions.y1 == 0.9
+    if filepath == "examples/example-logs/ior_hdf5_example.darshan":
+        # since `ior_hdf5_example.darshan` has 4 ranks, the vertical
+        # bar graph has a different x max value because it needs room for
+        # the colorbar on the outside of the horizontal bar graph
+        assert vert_bar_positions.x1 == 0.7158709677419354
+    else:
+        assert vert_bar_positions.x1 == 0.7824516129032258
+
+    # get horizontal bar graph positions
+    horiz_bar_positions = jgrid.ax_marg_y.get_position()
+    assert horiz_bar_positions.y0 == 0.15000000000000002
+    assert horiz_bar_positions.y1 == 0.774390243902439
+    if filepath == "examples/example-logs/ior_hdf5_example.darshan":
+        # since `ior_hdf5_example.darshan` has 4 ranks, the horizontal
+        # bar graph has different x min/max values because it has to
+        # make room for the colorbar
+        assert horiz_bar_positions.x0 == 0.7206451612903225
+        assert horiz_bar_positions.x1 == 0.84
+    else:
+        assert horiz_bar_positions.x0 == 0.7877419354838711
+        assert horiz_bar_positions.x1 == 0.92
+
+    # get the colorbar positions
+    cbar_positions = jgrid.fig.axes[-1].get_position()
+    assert cbar_positions.y0 == 0.15000000000000002
+    assert cbar_positions.y1 == 0.774390243902439
+    if filepath == "examples/example-logs/ior_hdf5_example.darshan":
+        # since `ior_hdf5_example.darshan` has 4 ranks, the colorbar has
+        # to go closer to the edge of the figure so the horizontal bar
+        # graph can fit in the panel
+        assert cbar_positions.x0 == 0.85
+        assert cbar_positions.x1 == 0.8716135084427767
+    else:
+        assert cbar_positions.x0 == 0.82
+        assert cbar_positions.x1 == 0.8416135084427767
+
+
+@pytest.mark.parametrize(
+    "filepath",
+    [
+        "examples/example-logs/ior_hdf5_example.darshan",
+        "examples/example-logs/dxt.darshan",
+        "tests/input/sample-dxt-simple.darshan",
+    ],
+)
+@pytest.mark.parametrize("mods", [["DXT_POSIX"], ["DXT_MPIIO"]])
+@pytest.mark.parametrize("ops", [["read", "write"], ["read"], ["write"]])
+def test_plot_heatmap(filepath, mods, ops):
+
+    if mods == ["DXT_MPIIO"]:
+        # if the input module is not "DXT_POSIX" check
+        # that we raise the appropriate error
+        with pytest.raises(NotImplementedError, match="DXT_POSIX module is required."):
+            jgrid = plot_dxt_heatmap.plot_heatmap(
+                log_path=filepath, mods=mods, ops=ops, xbins=100
+            )
+    elif (filepath == "tests/input/sample-dxt-simple.darshan") & (ops == ["read"]):
+        # this log file is known to not have any read data, so
+        # make sure we raise a ValueError here
+        expected_msg = (
+            "No data available for selected module\\(s\\) and operation\\(s\\)."
+        )
+        with pytest.raises(ValueError, match=expected_msg):
+            jgrid = plot_dxt_heatmap.plot_heatmap(
+                log_path=filepath, mods=mods, ops=ops, xbins=100
+            )
+    else:
+        jgrid = plot_dxt_heatmap.plot_heatmap(
+            log_path=filepath, mods=mods, ops=ops, xbins=100
+        )
+
+        # verify the margins for all plots
+        assert jgrid.ax_joint.margins() == (0.05, 0.05)
+        assert jgrid.ax_marg_x.margins() == (0.05, 0.05)
+        assert jgrid.ax_marg_y.margins() == (0.05, 0.05)
+
+        # ensure the heat map spines are all visible
+        for _, spine in jgrid.ax_joint.spines.items():
+            assert spine.get_visible()
+
+        # for single-rank files, check that the
+        # horizontal bar graph does not exist
+        assert jgrid.ax_marg_x.has_data()
+        assert jgrid.ax_joint.has_data()
+        if filepath == "examples/example-logs/ior_hdf5_example.darshan":
+            # verify the horizontal bar graph contains data since there
+            # are multiple ranks for this case
+            assert jgrid.ax_marg_y.has_data()
+        else:
+            # verify the horizontal bar graph does not contain data
+            assert not jgrid.ax_marg_y.has_data()
+
+        # check that the axis labels are as expected
+        assert jgrid.ax_joint.get_xlabel() == "Time (s)"
+        assert jgrid.ax_joint.get_ylabel() == "Rank"
+
+    plt.close()


### PR DESCRIPTION
DXT heatmap plotting code for potential use in updated job summary. Primarily uses `numpy`, `seaborn`, `matplotlib` for plotting, which are all pip installable.  

Summary
---------
At the moment it takes in logs with `DXT_POSIX` data, concatenates all of the read/write segment dataframes together,  then uses that data (along with the respective rank data) to create a 2D histogram, and plot a heat map with marginal bar graphs. Depending on which operations you include, it will plot only the `read` segment data, the `write` segment data, or both. It does not distinguish between operations. Each bin (in the heatmap) is populated with the data sum and/or proportionate data sum for all IO events read/written during the time spanned by the bin.The color bar was selected based on the fact that it is non-white at the minimum value so areas without data are visible.  

How to run
-----------
See: https://github.com/darshan-hpc/darshan/pull/396#issuecomment-879202907

TODO
------
- [x] Fix average time plotting -- need to span from start time to end time for accurate IO representation 
- [ ] ~~Find a way to aggregate data from other modules, if applicable~~
- [ ] ~~Differentiate between read/write data in heat map~~
- [x] Include number of bins in plot somewhere so you can get an idea of bandwidth (i.e. 100 bins w/ 100 s run time = 1 s/bin)
- [ ] Figure out if/how to utilize the figure title. At the moment it just states which modules are being used (may want to remove it entirely for the job summary)
- [x] Finish documentation/comments