### PR TITLE
CI: add basic Python CI for pydarshan-devel

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,47 @@
+name: Linux Python Tests
+
+on:
+  push:
+    branches:
+      - pydarshan-devel
+  pull_request:
+    branches:
+      - pydarshan-devel
+
+jobs:
+  test_pydarshan:
+    
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Install darshan-util
+        run: |
+          mkdir darshan_install
+          export DARSHAN_INSTALL_PATH=$PWD/darshan_install
+          cd darshan-util
+          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-pydarshan
+          make
+          make install
+      - name: Install pydarshan
+        run: |
+          cd darshan-util/pydarshan
+          python -m pip install .
+      - name: Test with pytest
+        run: |
+          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          # the test suite is sensitive to
+          # relative dir for test file paths
+          cd darshan-util/pydarshan
+          pytest


### PR DESCRIPTION
Fixes #407

* add basic CI testing for `pydarshan` with the three most recent stable versions of Python on Linux; only applies to PRs to `pydarshan-devel` branch for now, which is probably fine

* there are various additional settings/static analyses/test matrix entries and so on that we'll likely want to add over time, but this basic CI setup seems to work just fine already when [tested on my fork](https://github.com/tylerjereddy/darshan/pull/1)