### PR TITLE
MAINT, CI: add mypy to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          python -m pip install --upgrade pytest mypy
       - name: Install darshan-util
         run: |
           mkdir darshan_install
@@ -45,3 +45,9 @@ jobs:
           # relative dir for test file paths
           cd darshan-util/pydarshan
           pytest
+      - name: mypy check
+        run: |
+          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          cd darshan-util/pydarshan
+          mypy darshan
+          mypy tests

--- a/darshan-util/pydarshan/darshan/__init__.py
+++ b/darshan-util/pydarshan/darshan/__init__.py
@@ -10,9 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-options = {
-
-}
+options = {} # type: ignore
 
 
 #from darshan.backend.cffi_backend import *

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -125,7 +125,7 @@ def get_rd_wr_dfs(
     for op_key in ops:
         # mypy can't tell that these keys are in fact
         # in the ``SegDict``, so just ignore the type
-        seg_key = op_key + "_segments"  # type: ignore
+        seg_key = op_key + "_segments"
         # create empty list to store each dataframe
         df_list = []
         # iterate over all records/dictionaries

--- a/darshan-util/pydarshan/mypy.ini
+++ b/darshan-util/pydarshan/mypy.ini
@@ -1,0 +1,35 @@
+[mypy]
+warn_redundant_casts = True
+warn_unused_ignores = True
+show_error_codes = True
+plugins = numpy.typing.mypy_plugin
+
+# Third party dependencies that don't have types.
+
+[mypy-cffi]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-pandas]
+ignore_missing_imports = True
+
+[mypy-seaborn]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-mpl_toolkits.*]
+ignore_missing_imports = True
+
+[mypy-PIL]
+ignore_missing_imports = True
+
+# pydarshan modules that lack types
+# or currently have errors
+
+[mypy-darshan.backend.cffi_backend]
+ignore_errors = True
+


### PR DESCRIPTION
Fixes #418

* add a basic `mypy.ini` config file, based on
similar type checking config files in other Python
OSS projects (to keep type checking consistent on the
project)

* add type checking to CI matrix

* fix a few minor typing issues in the source
to get `mypy` passing