### PR TITLE
BENCH: benchmark get_heatmap_df()

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
@@ -1,7 +1,9 @@
 import os
 import importlib
 
-from darshan.experimental.plots import plot_dxt_heatmap
+import pandas as pd
+
+from darshan.experimental.plots import plot_dxt_heatmap, heatmap_handling
 # TODO: no good reason pydarshan should have hyphenated module
 # names... for now I hack around it...
 example_logs = importlib.import_module("examples.example-logs")
@@ -38,3 +40,22 @@ class PlotDXTHeatMapSmall:
             mods=["DXT_POSIX"],
             ops=["read", "write"],
             xbins=xbins)
+
+
+class GetHeatMapDf:
+    params = [[50, 1000, 10000], [10, 50, 250]]
+    param_names = ['unique_ranks', 'bin_count']
+
+
+    def setup(self, unique_ranks, bin_count):
+        self.agg_df = pd.DataFrame({'length': [10] * unique_ranks,
+                                    'start_time': [0.1] * unique_ranks,
+                                    'end_time': [0.9] * unique_ranks,
+                                    'rank': range(unique_ranks),
+                                   })
+
+
+    def time_get_heatmap_df(self, unique_ranks, bin_count):
+        # benchmark get_heatmap_df() handling of variable
+        # numbers of unique ranks/bins
+        heatmap_handling.get_heatmap_df(self.agg_df, xbins=bin_count)


### PR DESCRIPTION
* add initial `asv` benchmarks for `get_heatmap_df()`, one of the
workhorse functions for the DXT heatmap handling code

* sample run: `asv run -e -b "time_get_heatmap_df"`

```
· Creating environments
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] · For pydarshan commit 0de2d06f <pydarshan-devel>:
[  0.00%] ·· Benchmarking virtualenv-py3.8-cffi-numpy-pytest
[ 50.00%] ··· Running (dxt_heatmap.GetHeatMapDf.time_get_heatmap_df--).
[100.00%] ··· dxt_heatmap.GetHeatMapDf.time_get_heatmap_df                                                                                                                                                                                                                                                                ok
[100.00%] ··· ============== ============ ============ ============
              --                           bin_count               
              -------------- --------------------------------------
               unique_ranks       10           50          250     
              ============== ============ ============ ============
                    50        16.2±0.5ms   25.6±0.4ms   70.4±0.2ms 
                   1000        70.5±7ms     86.1±2ms     172±1ms   
                  10000        559±3ms      678±5ms     1.18±0.01s 
              ============== ============ ============ ============


```