### PR TITLE
ENH: Optimize cffi_backend.log_get_generic_record()

### DIFF
--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -604,13 +604,13 @@ class DarshanReport(object):
 
 
         # fetch records
-        rec = backend.log_get_generic_record(self.log, mod, c_cols=cn, fc_cols=fcn, dtype=dtype)
+        rec = backend.log_get_generic_record(self.log, mod, dtype=dtype)
         while rec != None:
             self.records[mod].append(rec)
             self._modules[mod]['num_records'] += 1
 
             # fetch next
-            rec = backend.log_get_generic_record(self.log, mod, c_cols=cn, fc_cols=fcn, dtype=dtype)
+            rec = backend.log_get_generic_record(self.log, mod, dtype=dtype)
 
 
         if self.lookup_name_records:

--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -604,13 +604,13 @@ class DarshanReport(object):
 
 
         # fetch records
-        rec = backend.log_get_generic_record(self.log, mod, dtype=dtype)
+        rec = backend.log_get_generic_record(self.log, mod, c_cols=cn, fc_cols=fcn, dtype=dtype)
         while rec != None:
             self.records[mod].append(rec)
             self._modules[mod]['num_records'] += 1
 
             # fetch next
-            rec = backend.log_get_generic_record(self.log, mod, dtype=dtype)
+            rec = backend.log_get_generic_record(self.log, mod, c_cols=cn, fc_cols=fcn, dtype=dtype)
 
 
         if self.lookup_name_records:

--- a/darshan-util/pydarshan/tests/test_cffi_misc.py
+++ b/darshan-util/pydarshan/tests/test_cffi_misc.py
@@ -65,85 +65,35 @@ def test_file_hash_type(log_path):
     assert rec_fcounters["id"].dtype == np.uint64
 
 
-@pytest.mark.parametrize("expected_counter_vals", [
-        np.asarray(
-            [
-                2049, -1, -1, 0, 16402, 16404, 0, 0, 0, 0, -1, -1, 0, 0, 0,
-                2199023259968, 0, 2199023261831, 0, 0, 0, 16384, 0, 0, 8,
-                16401, 1048576, 0, 134217728, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 4, 14, 0, 0, 0, 0, 0, 0, 16384, 0, 274743689216,
-                274743691264, 0, 0, 10240, 4096, 0, 0, 134217728, 272, 544,
-                328, 16384, 8, 2, 2, 597, 1073741824, 1312, 1073741824
-            ]
-        )
-    ]
-)
-@pytest.mark.parametrize("expected_fcounter_vals", [
-        np.asarray(
-            [
-                3.9191410541534424, 0.0, 3.940063953399658, 3.927093982696533,
-                3.936579942703247, 0.0, 115.0781660079956, 115.77035808563232,
-                0.0, 100397.60042190552, 11.300841808319092, 0.0,
-                17.940945863723755, 20.436099529266357, 85.47495031356812,
-                0.0, 0.0,
-            ]
-        )
-    ]
-)
-@pytest.mark.parametrize("expected_counter_names", [
-        [
-            'POSIX_OPENS', 'POSIX_FILENOS', 'POSIX_DUPS', 'POSIX_READS',
-            'POSIX_WRITES', 'POSIX_SEEKS', 'POSIX_STATS', 'POSIX_MMAPS',
-            'POSIX_FSYNCS', 'POSIX_FDSYNCS', 'POSIX_RENAME_SOURCES',
-            'POSIX_RENAME_TARGETS', 'POSIX_RENAMED_FROM', 'POSIX_MODE',
-            'POSIX_BYTES_READ', 'POSIX_BYTES_WRITTEN', 'POSIX_MAX_BYTE_READ',
-            'POSIX_MAX_BYTE_WRITTEN', 'POSIX_CONSEC_READS',
-            'POSIX_CONSEC_WRITES', 'POSIX_SEQ_READS', 'POSIX_SEQ_WRITES',
-            'POSIX_RW_SWITCHES', 'POSIX_MEM_NOT_ALIGNED',
-            'POSIX_MEM_ALIGNMENT', 'POSIX_FILE_NOT_ALIGNED',
-            'POSIX_FILE_ALIGNMENT', 'POSIX_MAX_READ_TIME_SIZE',
-            'POSIX_MAX_WRITE_TIME_SIZE', 'POSIX_SIZE_READ_0_100',
-            'POSIX_SIZE_READ_100_1K', 'POSIX_SIZE_READ_1K_10K',
-            'POSIX_SIZE_READ_10K_100K', 'POSIX_SIZE_READ_100K_1M',
-            'POSIX_SIZE_READ_1M_4M', 'POSIX_SIZE_READ_4M_10M',
-            'POSIX_SIZE_READ_10M_100M', 'POSIX_SIZE_READ_100M_1G',
-            'POSIX_SIZE_READ_1G_PLUS', 'POSIX_SIZE_WRITE_0_100',
-            'POSIX_SIZE_WRITE_100_1K', 'POSIX_SIZE_WRITE_1K_10K',
-            'POSIX_SIZE_WRITE_10K_100K', 'POSIX_SIZE_WRITE_100K_1M',
-            'POSIX_SIZE_WRITE_1M_4M', 'POSIX_SIZE_WRITE_4M_10M',
-            'POSIX_SIZE_WRITE_10M_100M', 'POSIX_SIZE_WRITE_100M_1G',
-            'POSIX_SIZE_WRITE_1G_PLUS', 'POSIX_STRIDE1_STRIDE',
-            'POSIX_STRIDE2_STRIDE', 'POSIX_STRIDE3_STRIDE',
-            'POSIX_STRIDE4_STRIDE', 'POSIX_STRIDE1_COUNT',
-            'POSIX_STRIDE2_COUNT', 'POSIX_STRIDE3_COUNT',
-            'POSIX_STRIDE4_COUNT', 'POSIX_ACCESS1_ACCESS',
-            'POSIX_ACCESS2_ACCESS', 'POSIX_ACCESS3_ACCESS',
-            'POSIX_ACCESS4_ACCESS', 'POSIX_ACCESS1_COUNT',
-            'POSIX_ACCESS2_COUNT', 'POSIX_ACCESS3_COUNT',
-            'POSIX_ACCESS4_COUNT', 'POSIX_FASTEST_RANK',
-            'POSIX_FASTEST_RANK_BYTES', 'POSIX_SLOWEST_RANK',
-            'POSIX_SLOWEST_RANK_BYTES',
-        ]
-    ]
-)
-@pytest.mark.parametrize("expected_fcounter_names", [
-        [
-            'POSIX_F_OPEN_START_TIMESTAMP', 'POSIX_F_READ_START_TIMESTAMP',
-            'POSIX_F_WRITE_START_TIMESTAMP', 'POSIX_F_CLOSE_START_TIMESTAMP',
-            'POSIX_F_OPEN_END_TIMESTAMP', 'POSIX_F_READ_END_TIMESTAMP',
-            'POSIX_F_WRITE_END_TIMESTAMP', 'POSIX_F_CLOSE_END_TIMESTAMP',
-            'POSIX_F_READ_TIME', 'POSIX_F_WRITE_TIME', 'POSIX_F_META_TIME',
-            'POSIX_F_MAX_READ_TIME', 'POSIX_F_MAX_WRITE_TIME',
-            'POSIX_F_FASTEST_RANK_TIME', 'POSIX_F_SLOWEST_RANK_TIME',
-            'POSIX_F_VARIANCE_RANK_TIME', 'POSIX_F_VARIANCE_RANK_BYTES',
-        ]
-
-    ]
-)
 @pytest.mark.parametrize("dtype", ["numpy", "dict", "pandas"])
-def test_log_get_generic_record(dtype, expected_counter_vals, expected_fcounter_vals, expected_counter_names, expected_fcounter_names):
+def test_log_get_generic_record(dtype):
     # regression test for issue #440
     # see: https://github.com/darshan-hpc/darshan/issues/440
+
+    # collect the expected counter/fcounter column names
+    expected_counter_names = backend.counter_names("POSIX")
+    expected_fcounter_names = backend.fcounter_names("POSIX")
+
+    # assign the expected counter/fcounter values
+    expected_counter_vals = np.asarray(
+        [
+            2049, -1, -1, 0, 16402, 16404, 0, 0, 0, 0, -1, -1, 0, 0, 0,
+            2199023259968, 0, 2199023261831, 0, 0, 0, 16384, 0, 0, 8,
+            16401, 1048576, 0, 134217728, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 4, 14, 0, 0, 0, 0, 0, 0, 16384, 0, 274743689216,
+            274743691264, 0, 0, 10240, 4096, 0, 0, 134217728, 272, 544,
+            328, 16384, 8, 2, 2, 597, 1073741824, 1312, 1073741824,
+        ]
+    )
+    expected_fcounter_vals = np.asarray(
+        [
+            3.9191410541534424, 0.0, 3.940063953399658, 3.927093982696533,
+            3.936579942703247, 0.0, 115.0781660079956, 115.77035808563232,
+            0.0, 100397.60042190552, 11.300841808319092, 0.0,
+            17.940945863723755, 20.436099529266357, 85.47495031356812,
+            0.0, 0.0,
+        ]
+    )
 
     # generate a record from sample log
     log = backend.log_open("tests/input/sample.darshan")

--- a/darshan-util/pydarshan/tests/test_cffi_misc.py
+++ b/darshan-util/pydarshan/tests/test_cffi_misc.py
@@ -6,6 +6,7 @@ import re
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
 import darshan
 import darshan.backend.cffi_backend as backend
 
@@ -62,3 +63,147 @@ def test_file_hash_type(log_path):
     # data type for the ids/hashes
     assert rec_counters["id"].dtype == np.uint64
     assert rec_fcounters["id"].dtype == np.uint64
+
+
+@pytest.mark.parametrize("expected_counter_vals", [
+        np.asarray(
+            [
+                2049, -1, -1, 0, 16402, 16404, 0, 0, 0, 0, -1, -1, 0, 0, 0,
+                2199023259968, 0, 2199023261831, 0, 0, 0, 16384, 0, 0, 8,
+                16401, 1048576, 0, 134217728, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 4, 14, 0, 0, 0, 0, 0, 0, 16384, 0, 274743689216,
+                274743691264, 0, 0, 10240, 4096, 0, 0, 134217728, 272, 544,
+                328, 16384, 8, 2, 2, 597, 1073741824, 1312, 1073741824
+            ]
+        )
+    ]
+)
+@pytest.mark.parametrize("expected_fcounter_vals", [
+        np.asarray(
+            [
+                3.9191410541534424, 0.0, 3.940063953399658, 3.927093982696533,
+                3.936579942703247, 0.0, 115.0781660079956, 115.77035808563232,
+                0.0, 100397.60042190552, 11.300841808319092, 0.0,
+                17.940945863723755, 20.436099529266357, 85.47495031356812,
+                0.0, 0.0,
+            ]
+        )
+    ]
+)
+@pytest.mark.parametrize("expected_counter_names", [
+        [
+            'POSIX_OPENS', 'POSIX_FILENOS', 'POSIX_DUPS', 'POSIX_READS',
+            'POSIX_WRITES', 'POSIX_SEEKS', 'POSIX_STATS', 'POSIX_MMAPS',
+            'POSIX_FSYNCS', 'POSIX_FDSYNCS', 'POSIX_RENAME_SOURCES',
+            'POSIX_RENAME_TARGETS', 'POSIX_RENAMED_FROM', 'POSIX_MODE',
+            'POSIX_BYTES_READ', 'POSIX_BYTES_WRITTEN', 'POSIX_MAX_BYTE_READ',
+            'POSIX_MAX_BYTE_WRITTEN', 'POSIX_CONSEC_READS',
+            'POSIX_CONSEC_WRITES', 'POSIX_SEQ_READS', 'POSIX_SEQ_WRITES',
+            'POSIX_RW_SWITCHES', 'POSIX_MEM_NOT_ALIGNED',
+            'POSIX_MEM_ALIGNMENT', 'POSIX_FILE_NOT_ALIGNED',
+            'POSIX_FILE_ALIGNMENT', 'POSIX_MAX_READ_TIME_SIZE',
+            'POSIX_MAX_WRITE_TIME_SIZE', 'POSIX_SIZE_READ_0_100',
+            'POSIX_SIZE_READ_100_1K', 'POSIX_SIZE_READ_1K_10K',
+            'POSIX_SIZE_READ_10K_100K', 'POSIX_SIZE_READ_100K_1M',
+            'POSIX_SIZE_READ_1M_4M', 'POSIX_SIZE_READ_4M_10M',
+            'POSIX_SIZE_READ_10M_100M', 'POSIX_SIZE_READ_100M_1G',
+            'POSIX_SIZE_READ_1G_PLUS', 'POSIX_SIZE_WRITE_0_100',
+            'POSIX_SIZE_WRITE_100_1K', 'POSIX_SIZE_WRITE_1K_10K',
+            'POSIX_SIZE_WRITE_10K_100K', 'POSIX_SIZE_WRITE_100K_1M',
+            'POSIX_SIZE_WRITE_1M_4M', 'POSIX_SIZE_WRITE_4M_10M',
+            'POSIX_SIZE_WRITE_10M_100M', 'POSIX_SIZE_WRITE_100M_1G',
+            'POSIX_SIZE_WRITE_1G_PLUS', 'POSIX_STRIDE1_STRIDE',
+            'POSIX_STRIDE2_STRIDE', 'POSIX_STRIDE3_STRIDE',
+            'POSIX_STRIDE4_STRIDE', 'POSIX_STRIDE1_COUNT',
+            'POSIX_STRIDE2_COUNT', 'POSIX_STRIDE3_COUNT',
+            'POSIX_STRIDE4_COUNT', 'POSIX_ACCESS1_ACCESS',
+            'POSIX_ACCESS2_ACCESS', 'POSIX_ACCESS3_ACCESS',
+            'POSIX_ACCESS4_ACCESS', 'POSIX_ACCESS1_COUNT',
+            'POSIX_ACCESS2_COUNT', 'POSIX_ACCESS3_COUNT',
+            'POSIX_ACCESS4_COUNT', 'POSIX_FASTEST_RANK',
+            'POSIX_FASTEST_RANK_BYTES', 'POSIX_SLOWEST_RANK',
+            'POSIX_SLOWEST_RANK_BYTES',
+        ]
+    ]
+)
+@pytest.mark.parametrize("expected_fcounter_names", [
+        [
+            'POSIX_F_OPEN_START_TIMESTAMP', 'POSIX_F_READ_START_TIMESTAMP',
+            'POSIX_F_WRITE_START_TIMESTAMP', 'POSIX_F_CLOSE_START_TIMESTAMP',
+            'POSIX_F_OPEN_END_TIMESTAMP', 'POSIX_F_READ_END_TIMESTAMP',
+            'POSIX_F_WRITE_END_TIMESTAMP', 'POSIX_F_CLOSE_END_TIMESTAMP',
+            'POSIX_F_READ_TIME', 'POSIX_F_WRITE_TIME', 'POSIX_F_META_TIME',
+            'POSIX_F_MAX_READ_TIME', 'POSIX_F_MAX_WRITE_TIME',
+            'POSIX_F_FASTEST_RANK_TIME', 'POSIX_F_SLOWEST_RANK_TIME',
+            'POSIX_F_VARIANCE_RANK_TIME', 'POSIX_F_VARIANCE_RANK_BYTES',
+        ]
+
+    ]
+)
+@pytest.mark.parametrize("dtype", ["numpy", "dict", "pandas"])
+def test_log_get_generic_record(dtype, expected_counter_vals, expected_fcounter_vals, expected_counter_names, expected_fcounter_names):
+    # regression test for issue #440
+    # see: https://github.com/darshan-hpc/darshan/issues/440
+
+    # generate a record from sample log
+    log = backend.log_open("tests/input/sample.darshan")
+    rec = backend.log_get_generic_record(log=log, mod_name="POSIX", dtype=dtype)
+
+    # each record should have the following keys
+    record_keys = ["id", "rank", "counters", "fcounters"]
+    assert list(rec.keys()) == record_keys
+    # check the file hash/id
+    assert rec["id"] == 6301063301082038805
+    # check the rank
+    assert rec["rank"] == -1
+
+    if dtype == "numpy":
+        # check the length of the returned arrays are correct
+        assert rec["counters"].size == 69
+        assert rec["fcounters"].size == 17
+        # collect the actual counter/fcounter values
+        actual_counter_vals = rec["counters"]
+        actual_fcounter_vals = rec["fcounters"]
+
+    elif dtype == "dict":
+        # check the length of the returned dictionaries are correct
+        assert len(rec["counters"]) == 69
+        assert len(rec["fcounters"]) == 17
+        # collect the actual counter/fcounter key names
+        actual_counter_names = list(rec["counters"].keys())
+        actual_fcounter_names = list(rec["fcounters"].keys())
+        # collect the actual counter/fcounter values
+        actual_counter_vals = np.asarray(list(rec["counters"].values()))
+        actual_fcounter_vals = np.asarray(list(rec["fcounters"].values()))
+
+    elif dtype == "pandas":
+        # make sure the added column keys are in the dataframes
+        for key in ["id", "rank"]:
+            assert key in rec["counters"].columns
+            assert key in rec["fcounters"].columns
+        # double check the id/rank values
+        assert rec["counters"]["id"].values == 6301063301082038805
+        assert rec["counters"]["rank"].values == -1
+        # make sure the dataframes are the expected shapes
+        # the shapes are 2 larger than the arrays since the id/rank
+        # columns are added to the dataframes
+        assert rec["counters"].shape == (1, 71)
+        assert rec["fcounters"].shape == (1, 19)
+        # collect the actual counter/fcounter key names
+        # don't include the id/rank columns
+        actual_counter_names = list(rec["counters"].columns)[2:]
+        actual_fcounter_names = list(rec["fcounters"].columns)[2:]
+        # collect the actual counter/fcounter values
+        # don't include the id/rank columns
+        actual_counter_vals = rec["counters"].values[0][2:]
+        actual_fcounter_vals = rec["fcounters"].values[0][2:]
+
+    # check the actual counter/fcounter values agree
+    # with the expected counter/fcounter values
+    assert_array_equal(expected_counter_vals, actual_counter_vals)
+    assert_allclose(expected_fcounter_vals, actual_fcounter_vals)
+
+    if dtype != "numpy":
+        # make sure the returned key/column names agree
+        assert actual_counter_names == expected_counter_names
+        assert actual_fcounter_names == expected_fcounter_names


### PR DESCRIPTION
* Performs several small changes to `log_get_generic_record`
to improve the performance of the `pandas` dataframe retrieval.
One of these optimizations is allowing the counter/fcounter
column names to be fed into the function instead of
generating them for each record.

* Add regression test `test_log_get_generic_record`
to `test_cffi_misc.py`

* Fix issue #440