### PR TITLE
BENCH: asv mod_read_all_dxt_records

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/report.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/report.py
@@ -33,3 +33,31 @@ class ModReadAllRecords:
     def time_mod_read_all_records(self, dtype, darshan_logfile, mod, read_all):
         self.report.mod_read_all_records(mod=mod,
                                          dtype=dtype)
+
+
+
+class ModReadAllDXTRecords:
+
+    params = [['numpy', 'dict', 'pandas'],
+              ["examples/example-logs/dxt.darshan",
+               "tests/input/sample-dxt-simple.darshan",
+              ],
+              ["DXT_POSIX",
+               "DXT_MPIIO",
+              ],
+              [True, False],
+              ]
+    param_names = ['dtype', 'darshan_logfile', 'mod', 'read_all']
+
+    def setup(self, dtype, darshan_logfile, mod, read_all):
+        filename = os.path.basename(darshan_logfile)
+        if "examples" in darshan_logfile:
+            self.logfile = example_logs.example_data_files_dxt[filename]
+        else:
+            self.logfile = test_data_files_dxt[filename]
+
+        self.report = darshan.DarshanReport(self.logfile, read_all=read_all)
+
+    def time_mod_read_all_dxt_records(self, dtype, darshan_logfile, mod, read_all):
+        self.report.mod_read_all_dxt_records(mod=mod,
+                                             dtype=dtype)


### PR DESCRIPTION
* add draft `asv` benchmarks for `mod_read_all_dxt_records()`

* probably needs more log file diversity to be robust, but
lays the groundwork and runs...

`asv run -b "time_mod_read_all_dxt_records"`

```
[100.00%] ··· report.ModReadAllDXTRecords.time_mod_read_all_dxt_records                                                                                                                                                                                                                                                   ok
[100.00%] ··· ======== ======================================= ================== =================== ================== ===================
              --                                                                               mod / read_all                               
              ------------------------------------------------ -----------------------------------------------------------------------------
               dtype               darshan_logfile              DXT_POSIX / True   DXT_POSIX / False   DXT_MPIIO / True   DXT_MPIIO / False 
              ======== ======================================= ================== =================== ================== ===================
               numpy      examples/example-logs/dxt.darshan         357±10μs            288±2μs            359±6μs             297±3μs      
               numpy    tests/input/sample-dxt-simple.darshan       463±10μs            258±4μs            450±5μs             245±1μs      
                dict      examples/example-logs/dxt.darshan         356±4μs             296±7μs            358±6μs             296±2μs      
                dict    tests/input/sample-dxt-simple.darshan       456±4μs             272±6μs            461±10μs            189±70μs     
               pandas     examples/example-logs/dxt.darshan        2.61±0.2ms          2.47±0.2ms        2.58±0.06ms         2.50±0.04ms    
               pandas   tests/input/sample-dxt-simple.darshan     1.31±0.01ms           1.07±0ms           871±10μs            697±40μs     
              ======== ======================================= ================== =================== ================== ===================


```