### PR TITLE
MAINT: use github labeler

### DIFF
--- a/.github/pr_path_labeler.yml
+++ b/.github/pr_path_labeler.yml
@@ -1,0 +1,11 @@
+# Labeler triggered by .github/workflows/labels.yml
+
+pydarshan:
+- any: ["darshan-util/pydarshan/**/*"]
+
+performance:
+- any: ["darshan-util/pydarshan/benchmarks/**/*"]
+
+CI:
+- any: ["**/*.yml"]
+- any: ["**/*.yaml"]

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,16 @@
+# Triage PRs based on modified paths
+# Rely on .github/pr_path_labeler.yml
+# https://github.com/marketplace/actions/labeler
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage-on-file-paths:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/pr_path_labeler.yml"
+        sync-labels: true  # remove labels if file not modified anymore


### PR DESCRIPTION
* for simple PR labels, leverage the github actions bot
to apply labels based on filepaths that are adjusted

* docs are here:
https://github.com/marketplace/actions/labeler

* based on example upstream:
https://github.com/scipy/scipy/pull/14677

* this is only leveraging a small subset of our
labels to begin with; can be built up later to do
more if desired