### PR TITLE
MAINT, CI: more actions labels

### DIFF
--- a/.github/pr_path_labeler.yml
+++ b/.github/pr_path_labeler.yml
@@ -9,3 +9,7 @@ performance:
 CI:
 - any: ["**/*.yml"]
 - any: ["**/*.yaml"]
+- any: [".github/workflows/*.yml"]
+- any: [".github/workflows/*.yaml"]
+- any: [".github/*.yml"]
+- any: [".github/*.yaml"]


### PR DESCRIPTION
* a few more labels for the label bot
because it looks like GitHub actions treats
its own config paths separately per the bot
activity in gh-471