### PR TITLE
CI: add MacOS to CI

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -26,6 +26,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pytest mypy asv pytest-cov codecov
+          # matplotlib is pinned because of
+          # gh-479
+          python -m pip install matplotlib==3.4.3
       - name: Install darshan-util
         run: |
           mkdir darshan_install

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,4 +1,4 @@
-name: Linux Python Tests
+name: Python Testing
 
 on:
   push:
@@ -10,12 +10,12 @@ on:
 
 jobs:
   test_pydarshan:
-    
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        platform: [ubuntu-latest,
+                   macos-latest]
         python-version: [3.7, 3.8, 3.9]
-
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -30,14 +30,16 @@ jobs:
         run: |
           mkdir darshan_install
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install
+          git submodule update --init
           cd darshan-util
-          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-pydarshan
+          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-pydarshan --enable-autoperf-apxc --enable-autoperf-apmpi
           make
           make install
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan
-          python -m pip install .
+          # TODO: use pip per gh-476
+          python setup.py install
       - name: Test with pytest
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -12,7 +12,8 @@ jobs:
   test_pydarshan:
     strategy:
       matrix:
-        platform: [macos-latest]
+        platform: [ubuntu-latest,
+                   macos-latest]
         python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -12,8 +12,7 @@ jobs:
   test_pydarshan:
     strategy:
       matrix:
-        platform: [ubuntu-latest,
-                   macos-latest]
+        platform: [macos-latest]
         python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/darshan-util/configure
+++ b/darshan-util/configure
@@ -4414,9 +4414,8 @@ fi
 
 
 if test x$enable_autoperf_apxc = xyes; then
-    abssrcdir=$(readlink -f ${srcdir})
-    as_ac_Header=`$as_echo "ac_cv_header_${abssrcdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h" | $as_tr_sh`
-ac_fn_c_check_header_preproc "$LINENO" "${abssrcdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h" "$as_ac_Header"
+    as_ac_Header=`$as_echo "ac_cv_header_${ac_abs_confdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h" | $as_tr_sh`
+ac_fn_c_check_header_preproc "$LINENO" "${ac_abs_confdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h" "$as_ac_Header"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   DARSHAN_USE_APXC=1
 else
@@ -4426,9 +4425,8 @@ fi
  # this last part tells it to only check for presence
 fi
 if test x$enable_autoperf_apmpi = xyes; then
-    abssrcdir=$(readlink -f ${srcdir})
-    as_ac_Header=`$as_echo "ac_cv_header_${abssrcdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h" | $as_tr_sh`
-ac_fn_c_check_header_preproc "$LINENO" "${abssrcdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h" "$as_ac_Header"
+    as_ac_Header=`$as_echo "ac_cv_header_${ac_abs_confdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h" | $as_tr_sh`
+ac_fn_c_check_header_preproc "$LINENO" "${ac_abs_confdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h" "$as_ac_Header"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   DARSHAN_USE_APMPI=1
 else

--- a/darshan-util/configure.in
+++ b/darshan-util/configure.in
@@ -129,15 +129,13 @@ AC_ARG_ENABLE(
 )
 
 if test x$enable_autoperf_apxc = xyes; then
-    abssrcdir=$(readlink -f ${srcdir})
-    AC_CHECK_HEADER([${abssrcdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h],
+    AC_CHECK_HEADER([${ac_abs_confdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h],
                     DARSHAN_USE_APXC=1,
                     [AC_MSG_ERROR([The autoperf APXC module is not present])],
                     [-]) # this last part tells it to only check for presence
 fi
 if test x$enable_autoperf_apmpi = xyes; then
-    abssrcdir=$(readlink -f ${srcdir})
-    AC_CHECK_HEADER([${abssrcdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h],
+    AC_CHECK_HEADER([${ac_abs_confdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h],
                     DARSHAN_USE_APMPI=1,
                     [AC_MSG_ERROR([The autoperf MPI module is not present])],
                     [-]) # this last part tells it to only check for presence


### PR DESCRIPTION
* expand the GitHub Actions CI to include MacOS, because
we've started to discover issues with building on this
platform

* activate APMPI and APXC modules in the build, since they
will be needed for some log files in the logs repo