### PR TITLE
BLD: handle MacOS dylib

### DIFF
--- a/darshan-util/pydarshan/darshan/discover_darshan.py
+++ b/darshan-util/pydarshan/darshan/discover_darshan.py
@@ -170,6 +170,12 @@ def find_utils(ffi, libdutil):
 
     if libdutil is None:
         try:
+            libdutil = ffi.dlopen("libdarshan-util.dylib")
+        except:
+            libdutil = None
+
+    if libdutil is None:
+        try:
             library_path = discover_darshan_shutil()
             logger.debug(f"Attempting library_path={library_path} via shutil discovery.")
             libdutil = ffi.dlopen(library_path + "/lib/libdarshan-util.so")


### PR DESCRIPTION
Fixes #475

* as part of the preparation for rebasing `pydarshan-devel`
on `main`, adjust the build system to search for the new
shared object library name that is built on MacOS

* Shane and Jakob seem "ok" with this patch based on discussion
in gh-475; in the future we probably want to avoid the generic
exception catching, and maybe reduce the duplication with the
`is None` blocks, but for now just keeping it simple and following
the current structure in the `discover_darshan.py` module