### PR TITLE
Minor fix to ensure --help is propagated to subcommands. Show human-r…

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/__init__.py
+++ b/darshan-util/pydarshan/darshan/cli/__init__.py
@@ -23,7 +23,7 @@ class CustomHelpFormatter(argparse.HelpFormatter):
             help_text = ""
 
             for name, choice in action.choices.items():
-                help_text += "  {:21} {}\n".format(name, choice)
+                help_text += "  {:21} {}\n".format(name, choice.description)
 
             return help_text
 
@@ -82,7 +82,11 @@ def main():
     """
 
     # early parsing for selected arguments
-    preparser = argparse.ArgumentParser(usage="darshan <command>", description='PyDarshan CLI Utilities', formatter_class=CustomHelpFormatter)
+    preparser = argparse.ArgumentParser(
+            usage="darshan <command>", 
+            description='PyDarshan CLI Utilities', 
+            add_help=False,
+            formatter_class=CustomHelpFormatter)
 
     preparser.add_argument('--debug', help='', action='store_true', default=False)
     preparser.add_argument('--version', help='', action='store_true', default=False)

--- a/darshan-util/pydarshan/darshan/cli/info.py
+++ b/darshan-util/pydarshan/darshan/cli/info.py
@@ -11,6 +11,7 @@ import darshan
 def setup_parser(parser=None):
     # setup nested actions/subcommands?
     #actions = parser.add_subparsers(dest='api')
+    parser.description = "Display basic information about the Darshan log"
 
     # setup arguments
     parser.add_argument('input', help='darshan log file', nargs='?', default='example.darshan')

--- a/darshan-util/pydarshan/darshan/cli/name_records.py
+++ b/darshan-util/pydarshan/darshan/cli/name_records.py
@@ -11,6 +11,7 @@ import darshan
 def setup_parser(parser=None):
     # setup nested actions/subcommands?
     #actions = parser.add_subparsers(dest='api')
+    parser.description = "List all name records in Darshan log"
 
     # setup arguments
     parser.add_argument('input', help='darshan log file', nargs='?', default='example.darshan')

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -178,6 +178,8 @@ def setup_parser(parser: Any):
     parser : command line argument parser.
 
     """
+    parser.description = "Generates a Darshan Summary Report"
+    
     parser.add_argument(
         "log_path",
         type=str,

--- a/darshan-util/pydarshan/darshan/cli/to_json.py
+++ b/darshan-util/pydarshan/darshan/cli/to_json.py
@@ -10,6 +10,7 @@ import darshan
 def setup_parser(parser=None):
     # setup nested actions/subcommands?
     #actions = parser.add_subparsers(dest='api')
+    parser.description = "Convert Darshan log into report in JSON format"
 
     # setup arguments
     parser.add_argument('input', help='darshan log file', nargs='?', default='example.darshan')


### PR DESCRIPTION
As raised in https://github.com/darshan-hpc/darshan/issues/495 this ensures that "--help" is propagated also to subcommands.
(The preparser simply terminates the whole program early, if argparse is allowed in this stage to generate a help text.)

(A minor additional change is, that the subcommands now also show human readable descriptions of the subcommand)