### PR TITLE
MAINT: Replace overly broad type hint

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -169,7 +169,7 @@ class ReportData:
                 self.stylesheet = "".join(f.readlines())
 
 
-def setup_parser(parser: Any):
+def setup_parser(parser: argparse.ArgumentParser):
     """
     Configures the command line arguments.
 


### PR DESCRIPTION
* Replace `Any` type hint in `setup_parser()`
with `argparse.ArgumentParser`

* Fix gh-494