### PR TITLE
CI: rm --enable-pydarshan

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -40,7 +40,7 @@ jobs:
           git submodule update --init
           ./prepare.sh
           cd darshan-util
-          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-pydarshan --enable-apxc-mod --enable-apmpi-mod
+          ./configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-apxc-mod --enable-apmpi-mod
           make
           make install
       - name: Install pydarshan


### PR DESCRIPTION
* the `--enable-pydarshan` config flag is removed from
CI because this adds an extra/redundant `python setup.py install`
which could confuse attempts to install a clean wheel
build in the environment, etc.

* some related discussion in gh-476, although this doesn't
solve that apart from avoiding automatic use of `python setup.py install`