### PR TITLE
CI: add Python 3.6

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
           python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov wheel
           # matplotlib is pinned because of
           # gh-479
-          python -m pip install matplotlib==3.4.3
+          python -m pip install 'matplotlib<3.5'
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -67,7 +67,10 @@ jobs:
           # relative dir for test file paths
           cd darshan-util/pydarshan
           pytest --cov-report xml --cov=darshan --cov=tests
-      - name: mypy check
+      # Python 3.6 doesn't have access to some
+      # dependencies needed for our type hints
+      - if: ${{matrix.python-version > 3.6}}
+        name: mypy check
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib
           cd darshan-util/pydarshan

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -1,7 +1,6 @@
 """
 Module of data pre-processing functions for constructing the heatmap figure.
 """
-from __future__ import annotations
 
 from typing import Dict, Any, Tuple, Sequence, TYPE_CHECKING
 
@@ -387,6 +386,6 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int) -> pd.DataFrame:
     # each full or fractional bin event is now multiplied by
     # the bytes data
     cats = cats.mul(agg_df["length"], axis=0)
-    cats["rank"] = agg_df["rank"]
+    cats.index = agg_df["rank"]
     hmap_df = cats.groupby("rank").sum()
     return hmap_df

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -2,14 +2,24 @@
 Module for creating the ranks vs. time IO intensity
 heatmap figure for the Darshan job summary.
 """
-from __future__ import annotations
 
+import sys
 from typing import Any, List, Sequence, Union, TYPE_CHECKING
 
 import numpy as np
 
 if TYPE_CHECKING:
     import numpy.typing as npt
+
+# we can't use PEP563 delayed type
+# evaluations while we have to support
+# Python 3.6 because the __future__ import is not
+# available yet;
+# TODO: delete the mocking and restore the
+# from __future__ import annotations
+from unittest.mock import MagicMock
+npt = MagicMock()
+
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -3,7 +3,6 @@ Module for creating the ranks vs. time IO intensity
 heatmap figure for the Darshan job summary.
 """
 
-import sys
 from typing import Any, List, Sequence, Union, TYPE_CHECKING
 
 import numpy as np


### PR DESCRIPTION
* there's a request from Kevin to support Python 3.6 for
now so add it to the CI (see: https://github.com/darshan-hpc/darshan/issues/419#issuecomment-930540108 )

* note that Python 3.6 will be EOL in just a few months:
https://devguide.python.org/#status-of-python-branches

* I suggest revisiting this in the near future, also
to keep our support surface manageable