### PR TITLE
CI: build wheels in CI

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov
+          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov wheel
           # matplotlib is pinned because of
           # gh-479
           python -m pip install matplotlib==3.4.3
@@ -46,8 +46,8 @@ jobs:
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan
-          # TODO: use pip per gh-476
-          python setup.py install
+          make add-modules
+          python -m pip install .
       # shim for importlib.resources on Python < 3.9
       - if: ${{matrix.python-version < 3.9}}
         name: Install importlib_resources


### PR DESCRIPTION
Fixes #476

* build wheels in CI instead of using the discouraged
`python setup.py install`

* not only is this the preferred way to do things these days
(because i.e., `setup.py` can have arbitrary code and the
wheel build is PEP compliant, etc.), but it also represents
how most of our end users are likely to install the package
if they use `pip`