### PR TITLE
BLD: add simple pyproject.toml

### DIFF
--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+]


### PR DESCRIPTION
A small part of #507 standards adoption

* add a very simple `pyproject.toml` to move us closer
to adoption of PEP517 and PEP518

* if working properly, we should see output like this
for the `pydarshan` install in CI:
- `Building wheel for darshan (PEP 517)`
- instead of the old, less standards-compliant version:
`Building wheel for darshan (setup.py)`

* for an informal discussion of the advantages see:
https://snarky.ca/what-the-heck-is-pyproject-toml/

* I suspect some gradual cleanup of what we actually
need in `setup.py` would be needed to take real
advantage of the benefits here, but I've avoided messing
around there initially