### PR TITLE
CI: Update pydarshan install to install in same directory

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan
-          make add-modules
-          python -m pip install .
+          python -m pip install . --use-feature=in-tree-build
       # shim for importlib.resources on Python < 3.9
       - if: ${{matrix.python-version < 3.9}}
         name: Install importlib_resources


### PR DESCRIPTION
* Add flag `--use-feature=in-tree-build` to pydarshan install
command so it installs in current directory instead of using
a temporary one. This creates the autoperf symlinks correctly.

* Remove `make add-modules` since it is unnecessary