### PR TITLE
BUG: Make summary report generation compliant with python 3.9

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -215,11 +215,9 @@ def main(args: Union[Any, None] = None):
     # collect the report data to feed into the template
     report_data = ReportData(log_path=log_path)
 
-    with importlib_resources.path(darshan.cli, "") as path:
-        # get the path to the base template
-        base_path = os.path.join(str(path), "base.html")
+    with importlib_resources.path(darshan.cli, "base.html") as base_path:
         # load a template object using the base template
-        template = Template(filename=base_path)
+        template = Template(filename=str(base_path))
         # render the base template
         stream = template.render(report_data=report_data)
         with open(report_filename, "w") as f:


### PR DESCRIPTION
* Fix `importlib_resources.path()` to work for python version 3.9
by pointing to actual resource instead of an empty path

* Fixes #502