### PR TITLE
WIP, CI: add Python 3.10

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* try adding Python `3.10` to CI--I suspect it may
work for Linux but not MacOS yet, depending on GA
availability

* if that is the case, I may try to selectively activate
for Linux, but we'll see..