### PR TITLE
(demo only) CI: show wheel portability failure (lack of data file install)

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -84,6 +84,13 @@ jobs:
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib
           cd darshan-util/pydarshan/benchmarks
           python -m asv check -E existing
+      - name: check wheel portability
+        run: |
+          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          mkdir ../scratch
+          cp darshan-util/pydarshan/examples/example-logs/ior_hdf5_example.darshan ../scratch
+          cd ../scratch
+          python -m darshan summary ior_hdf5_example.darshan
       - name: codecov check
         uses: codecov/codecov-action@v2
         with:

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 
-requirements = ["cffi", "numpy", "pandas", "matplotlib", "seaborn"]
+requirements = ["cffi", "numpy", "pandas", "matplotlib", "seaborn", "mako"]
 setup_requirements = [
     "pytest-runner",
 ]


### PR DESCRIPTION
(do not merge--for demo purposes only)

@nawtrey this is a demo-only PR intended to demonstrate a few things:

- the wheels are not portable, and this is not restricted to Python 3.9 (or any Python version, I've used 3.8 here to clearly show it is not just 3.9)
- an example of how you can test this in a clean environment, though it would be nice to have something more concise right in `pytest` (I don't have the bandwidth to come up with that at the moment..)