### PR TITLE
modify pydarshan bindings to pull additional job/module data

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -2160,10 +2160,11 @@ void darshan_log_get_modules (darshan_fd fd,
     {
         if (fd->mod_map[i].len)
         {
-            (*mods)[j].name = darshan_module_names[i];
-            (*mods)[j].len  = fd->mod_map[i].len;
-            (*mods)[j].ver  = fd->mod_ver[i];
-            (*mods)[j].idx  = i;
+            (*mods)[j].name          = darshan_module_names[i];
+            (*mods)[j].len           = fd->mod_map[i].len;
+            (*mods)[j].ver           = fd->mod_ver[i];
+            (*mods)[j].partial_flag  = DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i);
+            (*mods)[j].idx           = i;
             j += 1;
         }
     }

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -74,6 +74,7 @@ struct darshan_mod_info
     int  len;
     int  ver;
     int  idx;
+    int partial_flag;
 };
 
 struct darshan_name_record_info

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -20,6 +20,7 @@ struct darshan_mod_info
     int	len;
     int	ver;
     int	idx;
+    int partial_flag;
 };
 
 /* from darshan-log-format.h */

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -129,6 +129,11 @@ def log_get_job(log):
     job['nprocs'] = jobrec[0].nprocs
     job['jobid'] = jobrec[0].jobid
 
+    # dirty hack to get log format version -- we know it's currently stored at the
+    # very beginning of the log handle structure, so we just cast the struct
+    # pointer as a string...
+    job['log_ver'] = ffi.string(ffi.cast("char *", log['handle'])).decode("utf-8")
+
     mstr = ffi.string(jobrec[0].metadata).decode("utf-8")
     md = {}
 
@@ -200,7 +205,8 @@ def log_get_modules(log):
     libdutil.darshan_log_get_modules(log['handle'], mods, cnt)
     for i in range(0, cnt[0]):
         modules[ffi.string(mods[0][i].name).decode("utf-8")] = \
-                {'len': mods[0][i].len, 'ver': mods[0][i].ver, 'idx': mods[0][i].idx}
+                {'len': mods[0][i].len, 'ver': mods[0][i].ver, 'idx': mods[0][i].idx,
+                 'partial_flag': bool(mods[0][i].partial_flag)}
 
     # add to cache
     log['modules'] = modules

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -116,8 +116,6 @@ class ReportData:
         """
         # assign the metadata dictionary
         job_data = self.report.metadata["job"]
-        # TODO: once this is exposed, add the correct entry
-        log_fmt_ver = "N/A"
         # build a dictionary with the appropriate metadata
         metadata_dict = {
             "Job ID": job_data["jobid"],
@@ -129,7 +127,7 @@ class ReportData:
             "Command": self.get_full_command(report=self.report),
             "Log Filename": os.path.basename(self.log_path),
             "Runtime Library Version": job_data["metadata"]["lib_ver"],
-            "Log Format Version": log_fmt_ver,
+            "Log Format Version": job_data["log_ver"],
         }
         # convert the dictionary into a dataframe
         metadata_df = pd.DataFrame.from_dict(data=metadata_dict, orient="index")
@@ -151,6 +149,8 @@ class ReportData:
             # create the key/value pairs for the dictionary
             key = f"{mod} (ver={mod_version})"
             val = f"{mod_buf_size:.2f} KiB"
+            if self.report.modules[mod]["partial_flag"]:
+                val += " (partial data)"
             module_dict[key] = val
 
         # convert the module dictionary into a dataframe

--- a/darshan-util/pydarshan/tests/test_report.py
+++ b/darshan-util/pydarshan/tests/test_report.py
@@ -32,6 +32,11 @@ def test_jobid_type_all_logs_repo_files(log_repo_files):
         report = darshan.DarshanReport(log_filepath)
         assert isinstance(report.metadata['job']['jobid'], int)
 
+def test_job():
+    """Sample for expected job data."""
+    report = darshan.DarshanReport("tests/input/sample.darshan")
+
+    assert report.metadata["job"]["log_ver"] == "3.10"
 
 def test_metadata():
     """Sample for an expected property in counters."""
@@ -50,7 +55,7 @@ def test_modules():
     # check if number of modules matches
     assert 4 == len(report.modules)
     assert 154 == report.modules['MPI-IO']['len']
-
+    assert False == report.modules['MPI-IO']['partial_flag']
 
 def test_load_records():
     """Test if loaded records match."""


### PR DESCRIPTION
This PR includes the following changes:
- Modifiy darshan-util C library's `darshan_log_get_modules()` function to additionally return whether a module ran out of memory (via `partial_flag` parameter)
- Extend CFFI backend to expose log format version and per-module partial flag
- Extend new Darshan job summary module to display newly exposed parameters (log format version and per-module flags on whether memory was exhausted)
- Add tests to check for new log format version and partial flag parameters on a sample Darshan log

Here's some sample output of the job summary tool with these changes: [imbalanced-io_report.html.tar.gz](https://github.com/darshan-hpc/darshan/files/7307677/imbalanced-io_report.html.tar.gz). This example successfully extracts the log format version as well as successfully detects that the POSIX module ran out of memory on this job.

Nothing elaborate, but happy to iterate on it here or as part of broader aesthetic changes there.


