### PR TITLE
CI: test installed pydarshan

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -65,7 +65,7 @@ jobs:
           # the test suite is sensitive to
           # relative dir for test file paths
           cd darshan-util/pydarshan
-          pytest --cov-report xml --cov=darshan --cov=tests
+          pytest --import-mode=importlib --cov-report xml --cov=darshan --cov=tests
       # Python 3.6 doesn't have access to some
       # dependencies needed for our type hints
       - if: ${{matrix.python-version > 3.6}}


### PR DESCRIPTION
* for strictly testing the installed version of a wheel/package,
and not providing access to the source `darshan` paths, follow
the `importlib` convention that will eventually become the default
based on `pytest` documentation:
https://docs.pytest.org/en/6.2.x/pythonpath.html