### PR TITLE
CI, MAINT: simplify pip command

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan
-          python -m pip install . --use-feature=in-tree-build
+          python -m pip install .
       # shim for importlib.resources on Python < 3.9
       - if: ${{matrix.python-version < 3.9}}
         name: Install importlib_resources


### PR DESCRIPTION
Fixes #512

* `pip 21.3` is out so we can simplify the
command used in CI

* this does not mean we expect users to have bleeding
edge `pip`, just that for developers generating/testing
wheels we can simplify the process as in CI