### PR TITLE
ENH: add infrastructure for adding figures, job i/o activity section

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -28,6 +28,27 @@
         ${report_data.module_table}
       </section>
 
+      <!-- Add sections and their figures  -->
+      % for sect_title in report_data.sections:
+          <section>
+          <h2>${sect_title}</h2>
+          % for fig_title, fig in report_data.sections[sect_title].items():
+            <h3>${fig_title}</h3>
+            <figure style="width: ${fig.fig_width}px;">
+            % if fig.img_str:
+              ${fig.img_str}
+              <figcaption>${fig.fig_description}</figcaption>
+            % else:
+              <!-- temporary handling for DXT-disabled cases -->
+              <figcaption style="font-weight: bold; color: red; width: 400px;">
+                ${fig.fig_description}
+              </figcaption>
+            % endif
+          </figure>
+          </section>
+          % endfor
+      % endfor
+
       <!-- Add the footer -->
       <div class="fixed-footer">
         <p>${report_data.footer}</p>

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -35,3 +35,10 @@ table {
 .fixed-footer{
     bottom: 0;
 }
+figure {
+  text-align: center;
+}
+figure figcaption {
+  font-size: 12px;
+  text-align: center;
+}

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -263,7 +263,7 @@ class ReportData:
         ############################
         if "DXT_POSIX" in self.report.modules:
             hmap_func = plot_dxt_heatmap.plot_heatmap
-            hmap_args = dict(log_path=self.log_path)
+            hmap_args = dict(report=self.report)
             hmap_description = (
                 "Heat map of I/O (in bytes) over time broken down by MPI rank. "
                 "Bins are populated based on the number of bytes read/written in "

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -45,7 +45,7 @@ class ReportFigure:
         section_title: str,
         fig_title: str,
         fig_func: Callable,
-        fig_args: dict = {},
+        fig_args: dict,
         fig_description: str = "",
         fig_width: int = 500,
     ):
@@ -254,7 +254,58 @@ class ReportData:
 
     def register_figures(self):
         """
-        Generates and registers all possible figures.
+        Collects and registers all figures in the report. This is the
+        method users can edit to alter the report contents.
+
+        Examples
+        --------
+        To add figures to the report, there are a few basic steps:
+
+        1. Make the function used to generate the desired figure
+           callable within the scope of this module.
+        2. Create an entry in this method that contains all of the required
+           information for the figure. This will be described in detail below.
+        3. Use the figure information to create a `ReportFigure`.
+        4. Add the `ReportFigure` to `ReportData.figures`.
+
+        Step #1 is handled by importing the function from the module it is
+        defined in. For step #2, each figure in the report must have the
+        following defined:
+
+        * Section title: the desired section for the figure to be placed.
+          If the section title is unique to the report, a new section
+          will be created for that figure.
+        * Figure title: the title of the figure
+        * Figure function: the function used to produce the figure. This
+          must be callable within the scope of this module (step #1).
+        * Figure arguments: the arguments for the figure function
+
+        Some additional details can be provided as well:
+
+        * Figure description: description of the figure used for the caption
+        * Figure width: width of the figure in pixels
+
+        To complete steps 2-4, an entry can be added to this method,
+        where a typical entry will look like the following:
+
+            # collect all of the info in a dictionary (step #2)
+            fig_params = {
+                "section_title": "Example Section Title",
+                "fig_title": f"Example Title",
+                "fig_func": example_module.example_function,
+                "fig_args": dict(report=self.report),
+                "fig_description": "Example Caption",
+                "fig_width": 500,
+            }
+            # feed the dictionary into ReportFigure (step #3)
+            example_fig = ReportFigure(**fig_params)
+            # add the ReportFigure to ReportData.figures (step #4)
+            self.figures.append(example_fig)
+
+        The order of the sections and figures is based on the order in which
+        they are placed in `self.figures`. Since the DXT figure(s) are added
+        first, they show up at the very top of the figure list.
+
         """
         self.figures = []
 


### PR DESCRIPTION
* Add `ReportFigure` to `summary.py` for collecting
figure information to simplify figure registration process

* Add infrastructure to darshan summary report
generation code that allows for adding figures
via a new method `ReportData.register_figures`

* Add entries to `style.css` to correct
formatting for figures and their captions

* Add nested loop to `base.html` to create the
figure sections and insert the encoded images

* Fix #463