### PR TITLE
MAINT: Remove `dtype="pandas"` usage from DXT heat map modules

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -201,10 +201,8 @@ def get_single_df_dict(
     flat_data_dict = {}  # type: Dict[str, Dict[str, pd.DataFrame]]
     # iterate over the modules (i.e. DXT_POSIX)
     for module_key in mods:
-        # read in the module data, update the name records
-        report.mod_read_all_dxt_records(module_key, dtype="pandas")
         # retrieve the list of records in pd.DataFrame() form
-        dict_list = report.records[module_key]
+        dict_list = report.records[module_key].to_df()
         # retrieve the list of read/write dataframes from the list of records
         rd_wr_dfs = get_rd_wr_dfs(dict_list=dict_list, ops=ops)
         # create empty dictionary for each module

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -324,7 +324,7 @@ def plot_heatmap(
 
     """
     # generate the darshan report
-    report = darshan.DarshanReport(log_path, read_all=False)
+    report = darshan.DarshanReport(log_path)
 
     if "DXT_POSIX" not in mods:
         # TODO: for the moment reject any cases that don't input "DXT_POSIX"


### PR DESCRIPTION
* Change heat map plotting code record loading
method from `dtype="pandas"` to `to_df()`

* Contributes to [#490](https://github.com/darshan-hpc/darshan/issues/490)