### PR TITLE
BUG, TST: Fix summary report header string for dxt.darshan & add test

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -97,12 +97,10 @@ class ReportData:
         Builds the header string for the summary report.
         """
         command = self.get_full_command(report=self.report)
-        if command != "Anonymized":
-            # when the command line hasn't been anonymized
-            # extract the application from the command line
-            app_name = os.path.basename(command.split()[0])
-        else:
+        if command in ["Anonymized", "N/A"]:
             app_name = command
+        else:
+            app_name = os.path.basename(command.split()[0])
         # collect the date from the time stamp
         date = datetime.date.fromtimestamp(self.report.metadata["job"]["start_time"])
         # the header is the application name and the log date

--- a/darshan-util/pydarshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/tests/test_summary.py
@@ -155,6 +155,7 @@ class TestReportData:
             ("tests/input/noposix.darshan", "Anonymized (2018-01-02)"),
             ("tests/input/sample-badost.darshan", "ior (2017-06-20)"),
             ("tests/input/sample-dxt-simple.darshan", "a.out (2021-04-22)"),
+            ("examples/example-logs/dxt.darshan", "N/A (2020-04-21)"),
         ],
     )
     def test_header_and_footer(self, log_path, expected_header):


### PR DESCRIPTION
* Correct logic in `ReportData.get_header()`
to allow for "N/A" possibility

* Add test case to `TestReportData.test_header_and_footer`
to act as regression guard

* Fix #503