### PR TITLE
MAINT: rm `wheel` from CI deps

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov wheel lxml
+          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml
           # matplotlib is pinned because of
           # gh-479
           python -m pip install 'matplotlib<3.5'


### PR DESCRIPTION
* this dependency should already be handled by `pyproject.toml`
now (we'll see if the CI agrees with me...)