### PR TITLE
ignore .h.in~ files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.s
 *.swp
 *.h.in
+*.h.in~
 autom4te.cache/
 config.log
 config.status


### PR DESCRIPTION
Maybe it depends on what version of autotools you are using as to whether these show up or not, but I'm seeing `*config.h.in~` files now.  Adding wildcard to ignore them.