### PR TITLE
MAINT: backport ignore .h.in~ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.s
 *.swp
 *.h.in
+*.h.in~
 autom4te.cache/
 config.log
 config.status


### PR DESCRIPTION
backport gh-544 for `git status` sanity reasons