### PR TITLE
runtime heatmap generation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ Darshan Release Change Log
 
 Darshan-3.3.2
 =============
+* Add a new "heatmap" module that records histograms of I/O traffic over time
+  on each process
 * Performance optimizations to runtime wrappers to limit function call
   overhead and locking costs
 * Replace mutex locks with atomics in core library

--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -85,6 +85,9 @@ if test "x$enable_darshan_runtime" = xyes ; then
    dnl runtime libraries require zlib
    CHECK_ZLIB
 
+   dnl runtime libraries requires math library (for calculations in heatmap)
+   AC_SEARCH_LIBS([round], [m])
+
    AC_ARG_ENABLE([ld-preload],
       [AS_HELP_STRING([--disable-ld-preload],
                       [Disables support for LD_PRELOAD library])],

--- a/darshan-runtime/lib/Makefile.am
+++ b/darshan-runtime/lib/Makefile.am
@@ -14,6 +14,7 @@ endif
 C_SRCS = darshan-core-init-finalize.c \
          darshan-core.c \
          darshan-common.c \
+         darshan-heatmap.c \
          lookup3.c \
          lookup8.c
 
@@ -102,7 +103,8 @@ H_SRCS = darshan-common.h \
          darshan-dxt.h \
          uthash.h \
          darshan-dynamic.h \
-         utlist.h
+         utlist.h \
+	 darshan-heatmap.h
 
 EXTRA_DIST = $(H_SRCS) \
              darshan-null.c \
@@ -114,5 +116,6 @@ EXTRA_DIST = $(H_SRCS) \
              darshan-hdf5.c \
              darshan-bgq.c \
              darshan-lustre.c \
-             darshan-mdhim.c
+             darshan-mdhim.c \
+	     darshan-heatmap.c
 

--- a/darshan-runtime/lib/darshan-heatmap.c
+++ b/darshan-runtime/lib/darshan-heatmap.c
@@ -1,0 +1,417 @@
+/*
+ * Copyright (C) 2021 University of Chicago.
+ * See COPYRIGHT notice in top-level directory.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <darshan-runtime-config.h>
+#endif
+
+#define _XOPEN_SOURCE 500
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#ifdef HAVE_STDATOMIC_H
+#include <stdatomic.h>
+#endif
+
+#include "darshan.h"
+#include "darshan-heatmap.h"
+
+/* maximum number of bins per record */
+/* TODO: make this tunable at runtime */
+/* TODO: safety check that total record size plus trailing bins doesn't
+ * exceed DEF_MOD_BUF_SIZE.  If it does, the log will still be technically
+ * valid but the default darshan-parser will not be able to display it.
+ */
+#define DARSHAN_MAX_HEATMAP_BINS 200
+
+/* initial width of each bin, as floating point seconds */
+/* TODO: make this tunable at runtime */
+#define DARSHAN_INITIAL_BIN_WIDTH_SECONDS 0.1
+
+/* maximum number of distinct heatmaps that we will track (there is a
+ * heatmap per module that interacts with it, not per file, so we should not
+ * need many).  If this limit is exceeded then the darshan core will mark
+ * the "partial" flag for the log so that we will be able to tell that the
+ * limit has been hit.
+ */
+/* TODO: make this tunable at runtime */
+#define DARSHAN_MAX_HEATMAPS 8
+
+/* structure to track heatmaps at runtime */
+struct heatmap_record_ref
+{
+    struct darshan_heatmap_record* heatmap_rec;
+};
+
+/* The heatmap_runtime structure maintains necessary state for storing
+ * heatmap records and for coordinating with darshan-core at shutdown time.
+ */
+struct heatmap_runtime
+{
+    void *rec_id_hash;
+    int rec_count;
+    int frozen; /* flag to indicate that the counters should no longer be modified */
+};
+
+static struct heatmap_runtime *heatmap_runtime = NULL;
+static int my_rank = -1;
+
+static struct heatmap_record_ref *heatmap_track_new_record(
+    darshan_record_id rec_id, const char *name);
+
+#ifdef HAVE_STDATOMIC_H
+atomic_flag heatmap_runtime_mutex;
+#define HEATMAP_LOCK() \
+    while (atomic_flag_test_and_set(&heatmap_runtime_mutex))
+#define HEATMAP_UNLOCK() \
+    atomic_flag_clear(&heatmap_runtime_mutex)
+#else
+static pthread_mutex_t heatmap_runtime_mutex = PTHREAD_MUTEX_INITIALIZER;
+#define HEATMAP_LOCK() pthread_mutex_lock(&heatmap_runtime_mutex)
+#define HEATMAP_UNLOCK() pthread_mutex_unlock(&heatmap_runtime_mutex)
+#endif
+
+/* note that if the break condition is triggered in this macro, then it
+ * will exit the do/while loop holding a lock that will be released in
+ * POST_RECORD().  Otherwise it will release the lock here (if held) and
+ * return immediately without reaching the POST_RECORD() macro.
+ */
+/* NOTE: unlike other modules, the PRE_RECORD here does not attempt to
+ * initialize this module if it isn't already.  That should have been done
+ * in the _register() call before reaching this point.  Skipping the
+ * initialization attempt here makes it safe to use atomics or spinlocks
+ * in the critical wrapper path.
+ */
+#define HEATMAP_PRE_RECORD() do { \
+    HEATMAP_LOCK(); \
+    if(heatmap_runtime && !heatmap_runtime->frozen) break; \
+    HEATMAP_UNLOCK(); \
+    return(ret); \
+} while(0)
+
+/* same as above but for void fns */
+#define HEATMAP_PRE_RECORD_VOID() do { \
+    HEATMAP_LOCK(); \
+    if(heatmap_runtime && !heatmap_runtime->frozen) break; \
+    HEATMAP_UNLOCK(); \
+    return; \
+} while(0)
+
+#define HEATMAP_POST_RECORD() do { \
+    HEATMAP_UNLOCK(); \
+} while(0)
+
+static void heatmap_output(
+    void **heatmap_buf,
+    int *heatmap_buf_sz)
+{
+    struct darshan_heatmap_record* rec;
+    void* contig_buf_ptr;
+    int i;
+    double end_timestamp;
+    unsigned long this_size;
+    int tmp_nbins;
+
+    HEATMAP_LOCK();
+    assert(heatmap_runtime);
+
+    *heatmap_buf_sz = 0;
+
+    heatmap_runtime->frozen = 1;
+    end_timestamp = darshan_core_wtime();
+
+    contig_buf_ptr = *heatmap_buf;
+
+    /* iterate through records (heatmap histograms) */
+    for(i=0; i<heatmap_runtime->rec_count; i++)
+    {
+        rec = (struct darshan_heatmap_record*)((uintptr_t)*heatmap_buf + i*(sizeof(*rec) + DARSHAN_MAX_HEATMAP_BINS*2*sizeof(int64_t)));
+
+        tmp_nbins= ceil(end_timestamp/rec->bin_width_seconds);
+
+        /* are there bins beyond the execution time of the program? */
+        if(tmp_nbins < rec->nbins)
+        {
+            /* truncate bins so that we don't report any beyond the time when
+             * instrumentation stopped
+             */
+            rec->nbins = tmp_nbins;
+            /* shift read_bins down so that memory remains contiguous even
+             * if nbins has been reduced
+             */
+            memmove(&rec->write_bins[rec->nbins], rec->read_bins,
+                rec->nbins*sizeof(int64_t));
+            rec->read_bins = &rec->write_bins[rec->nbins];
+        }
+
+        /* now shift the entire record + bins as a contiguous block down in
+         * the buffer so that the entire buffer is contiguous
+         */
+        this_size = sizeof(*rec) + rec->nbins * 2 * sizeof(uint64_t);
+        memmove(contig_buf_ptr, rec, this_size);
+        contig_buf_ptr += this_size;
+        *heatmap_buf_sz += this_size;
+    }
+
+    HEATMAP_UNLOCK();
+
+    return;
+}
+
+static void heatmap_cleanup()
+{
+    HEATMAP_LOCK();
+    assert(heatmap_runtime);
+
+    /* cleanup internal structures used for instrumenting */
+    darshan_clear_record_refs(&(heatmap_runtime->rec_id_hash), 1);
+
+    free(heatmap_runtime);
+    heatmap_runtime = NULL;
+
+    HEATMAP_UNLOCK();
+    return;
+}
+
+struct heatmap_runtime* heatmap_runtime_initialize(void)
+{
+    struct heatmap_runtime* tmp_runtime;
+    /* NOTE: this module generates one record per module that uses it, so
+     * the memory requirements should be modest
+     */
+    size_t heatmap_buf_size = DARSHAN_MAX_HEATMAPS * (sizeof(struct darshan_heatmap_record) + 2*DARSHAN_MAX_HEATMAP_BINS*sizeof(int64_t));
+
+    darshan_module_funcs mod_funcs = {
+#ifdef HAVE_MPI
+        .mod_redux_func = NULL, /* no reduction; record each rank separately */
+#endif
+        .mod_output_func = heatmap_output,
+        .mod_cleanup_func = heatmap_cleanup
+    };
+
+    /* register the heatmap module with darshan core */
+    /* note that we aren't holding a lock in this module at this point, but
+     * the core will serialize internally and return if this module is
+     * already registered */
+    darshan_core_register_module(
+        DARSHAN_HEATMAP_MOD,
+        mod_funcs,
+        &heatmap_buf_size,
+        &my_rank,
+        NULL);
+
+    tmp_runtime = malloc(sizeof(*tmp_runtime));
+    if(!tmp_runtime)
+    {
+        darshan_core_unregister_module(DARSHAN_STDIO_MOD);
+        return(NULL);
+    }
+    memset(tmp_runtime, 0, sizeof(*tmp_runtime));
+
+    return(tmp_runtime);
+}
+
+darshan_record_id heatmap_register(const char* name)
+{
+    struct heatmap_record_ref *rec_ref;
+    darshan_record_id ret = 0;
+    struct heatmap_runtime* tmp_runtime;
+
+    HEATMAP_LOCK();
+
+    if(!heatmap_runtime) {
+        /* module not initialized. Drop atomic lock and try to do so */
+        HEATMAP_UNLOCK();
+
+        tmp_runtime = heatmap_runtime_initialize();
+
+        HEATMAP_LOCK();
+        /* see if someone beat us to it */
+        if(heatmap_runtime && tmp_runtime)
+            free(tmp_runtime);
+        else
+            heatmap_runtime = tmp_runtime;
+    }
+
+    /* if we exit the above logic without anyone initializing, then we
+     * silently return
+     */
+    if(!heatmap_runtime) {
+        HEATMAP_UNLOCK();
+        return(0);
+    }
+
+    /* generate id for this heatmap */
+    ret = darshan_core_gen_record_id(name);
+
+    /* go ahead and instantiate a record now, rather than waiting until the
+     * _update() call
+     */
+    rec_ref = darshan_lookup_record_ref(heatmap_runtime->rec_id_hash, &ret, sizeof(darshan_record_id));
+    if(!rec_ref) rec_ref = heatmap_track_new_record(ret, name);
+
+    HEATMAP_UNLOCK();
+
+    return(ret);
+}
+
+static void collapse_heatmap(struct darshan_heatmap_record *rec)
+{
+    int i;
+
+    /* collapse write bins */
+    for(i=0; i<DARSHAN_MAX_HEATMAP_BINS; i+=2)
+    {
+        rec->write_bins[i] += rec->write_bins[i+1]; /* accumulate adjacent bins */
+        rec->write_bins[i/2] = rec->write_bins[i];  /* shift down */
+    }
+    /* zero out second half of heatmap */
+    memset(&rec->write_bins[DARSHAN_MAX_HEATMAP_BINS/2], 0, (DARSHAN_MAX_HEATMAP_BINS/2)*sizeof(int64_t));
+
+    /* collapse read bins */
+    for(i=0; i<DARSHAN_MAX_HEATMAP_BINS; i+=2)
+    {
+        rec->read_bins[i] += rec->read_bins[i+1]; /* accumulate adjacent bins */
+        rec->read_bins[i/2] = rec->read_bins[i];  /* shift down */
+    }
+    /* zero out second half of heatmap */
+    memset(&rec->read_bins[DARSHAN_MAX_HEATMAP_BINS/2], 0, (DARSHAN_MAX_HEATMAP_BINS/2)*sizeof(int64_t));
+
+    /* double bin width */
+    rec->bin_width_seconds *= 2.0;
+
+    return;
+}
+
+void heatmap_update(darshan_record_id heatmap_id, int rw_flag,
+    int64_t size, double start_time, double end_time)
+{
+    struct heatmap_record_ref *rec_ref;
+    int bin_index = 0;
+    double top_boundary, bottom_boundary, seconds_in_bin;
+
+    HEATMAP_PRE_RECORD_VOID();
+
+    rec_ref = darshan_lookup_record_ref(heatmap_runtime->rec_id_hash, &heatmap_id, sizeof(darshan_record_id));
+    /* the heatmap should have already been instantiated in the register
+     * function; something is wrong if we can't find it now
+     */
+    if(!rec_ref) { HEATMAP_POST_RECORD(); return; }
+
+    /* is current update out of bounds with histogram size?  if so, collapse */
+    while(end_time > rec_ref->heatmap_rec->bin_width_seconds * DARSHAN_MAX_HEATMAP_BINS)
+        collapse_heatmap(rec_ref->heatmap_rec);
+
+    /* once we fall through to this point, we know that the current heatmap
+     * granularity is sufficiently large to hold this update
+     */
+
+    /* loop through bins to be updated (a given access may cross bin
+     * boundaries) */
+    /* note: counting on the below type conversion to round down to lower
+     * integer */
+    for(bin_index = start_time/rec_ref->heatmap_rec->bin_width_seconds; bin_index < (int)(end_time/rec_ref->heatmap_rec->bin_width_seconds + 1); bin_index++)
+    {
+        /* starting assumption about how much time this update spent in
+         * current bin
+         */
+        seconds_in_bin = rec_ref->heatmap_rec->bin_width_seconds;
+        /* calculate where bin starts and stops */
+        bottom_boundary = bin_index * rec_ref->heatmap_rec->bin_width_seconds;
+        top_boundary = bottom_boundary + rec_ref->heatmap_rec->bin_width_seconds;
+        /* truncate if update started after bottom boundary */
+        if(start_time > bottom_boundary)
+            seconds_in_bin -= start_time-bottom_boundary;
+        /* truncate if update ended before top boundary */
+        if(end_time < top_boundary)
+            seconds_in_bin -= top_boundary-end_time;
+
+        if(seconds_in_bin < 0){
+            /* this should never happen; really this is an assertion
+             * condition but here we just bail out to avoid disrupting the
+             * application.
+             */
+            HEATMAP_POST_RECORD();
+            return;
+        }
+
+        /* proportionally assign bytes to this bin */
+        if(rw_flag == HEATMAP_WRITE)
+            rec_ref->heatmap_rec->write_bins[bin_index] +=
+                round(size * (seconds_in_bin/(end_time-start_time)));
+        else
+            rec_ref->heatmap_rec->read_bins[bin_index] +=
+                round(size * (seconds_in_bin/(end_time-start_time)));
+    }
+
+    HEATMAP_POST_RECORD();
+
+    return;
+}
+
+static struct heatmap_record_ref *heatmap_track_new_record(
+    darshan_record_id rec_id, const char *name)
+{
+    struct darshan_heatmap_record *heatmap_rec = NULL;
+    struct heatmap_record_ref *rec_ref = NULL;
+    int ret;
+
+    rec_ref = malloc(sizeof(*rec_ref));
+    if(!rec_ref)
+        return(NULL);
+    memset(rec_ref, 0, sizeof(*rec_ref));
+
+    /* add a reference to this record */
+    ret = darshan_add_record_ref(&(heatmap_runtime->rec_id_hash), &rec_id,
+        sizeof(darshan_record_id), rec_ref);
+    if(ret == 0)
+    {
+        free(rec_ref);
+        return(NULL);
+    }
+
+    /* register with darshan-core so it is persisted in the log file */
+    /* include enough space for 2x number of heatmap bins (read and write) */
+    heatmap_rec = darshan_core_register_record(
+        rec_id,
+        name,
+        DARSHAN_HEATMAP_MOD,
+        sizeof(struct darshan_heatmap_record)+(2*DARSHAN_MAX_HEATMAP_BINS*sizeof(int64_t)),
+        NULL);
+
+    if(!heatmap_rec)
+    {
+        darshan_delete_record_ref(&(heatmap_runtime->rec_id_hash),
+            &rec_id, sizeof(darshan_record_id));
+        free(rec_ref);
+        return(NULL);
+    }
+
+    /* registering this file record was successful, so initialize some fields */
+    heatmap_rec->base_rec.id = rec_id;
+    heatmap_rec->base_rec.rank = my_rank;
+    heatmap_rec->bin_width_seconds = DARSHAN_INITIAL_BIN_WIDTH_SECONDS;
+    heatmap_rec->nbins = DARSHAN_MAX_HEATMAP_BINS;
+    heatmap_rec->write_bins = (int64_t*)((uintptr_t)heatmap_rec + sizeof(*heatmap_rec));
+    heatmap_rec->read_bins = (int64_t*)((uintptr_t)heatmap_rec + sizeof(*heatmap_rec) + heatmap_rec->nbins*sizeof(int64_t));
+    rec_ref->heatmap_rec = heatmap_rec;
+    heatmap_runtime->rec_count++;
+
+    return(rec_ref);
+}
+
+/*
+ * Local variables:
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ * End:
+ *
+ * vim: ts=8 sts=4 sw=4 expandtab
+ */

--- a/darshan-runtime/lib/darshan-heatmap.h
+++ b/darshan-runtime/lib/darshan-heatmap.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 University of Chicago.
+ * See COPYRIGHT notice in top-level directory.
+ *
+ */
+
+#ifndef __DARSHAN_HEATMAP_H
+#define __DARSHAN_HEATMAP_H
+
+#include <stdint.h>
+
+#define HEATMAP_READ 1
+#define HEATMAP_WRITE 2
+
+/* heatmap_register()
+ *
+ * registers a heatmap with specified name.  Returns record id to use for
+ * subsequent updates
+ */
+darshan_record_id heatmap_register(const char* name);
+
+/* heatmap_read()
+ *
+ * functions to record read and write traffic
+ */
+void heatmap_update(darshan_record_id heatmap_id, int rw_flag,
+    int64_t size, double start_time, double end_time);
+
+#endif /* __DARSHAN_HEATMAP_H */

--- a/darshan-runtime/lib/darshan.h
+++ b/darshan-runtime/lib/darshan.h
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <pthread.h>
+#include <stdio.h>
 
 #ifdef HAVE_MPI
 #include <mpi.h>

--- a/darshan-util/Makefile.am
+++ b/darshan-util/Makefile.am
@@ -20,6 +20,7 @@ libdarshan_util_la_SOURCES = darshan-null-logutils.c \
                              darshan-lustre-logutils.c \
                              darshan-stdio-logutils.c \
                              darshan-dxt-logutils.c \
+                             darshan-heatmap-logutils.c \
                              darshan-mdhim-logutils.c
 
 include_HEADERS = darshan-null-logutils.h \
@@ -32,9 +33,11 @@ include_HEADERS = darshan-null-logutils.h \
                   darshan-lustre-logutils.h \
                   darshan-stdio-logutils.h \
                   darshan-dxt-logutils.h \
+                  darshan-heatmap-logutils.h \
                   darshan-mdhim-logutils.h \
 		  ../include/darshan-bgq-log-format.h \
                   ../include/darshan-dxt-log-format.h \
+                  ../include/darshan-heatmap-log-format.h \
                   ../include/darshan-hdf5-log-format.h \
                   ../include/darshan-log-format.h \
                   ../include/darshan-lustre-log-format.h \

--- a/darshan-util/darshan-heatmap-logutils.c
+++ b/darshan-util/darshan-heatmap-logutils.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2015 University of Chicago.
+ * See COPYRIGHT notice in top-level directory.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "darshan-util-config.h"
+#endif
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "darshan-logutils.h"
+
+/* prototypes for each of the heatmap module's logutil functions */
+static int darshan_log_get_heatmap_record(darshan_fd fd, void** heatmap_buf_p);
+static int darshan_log_put_heatmap_record(darshan_fd fd, void* heatmap_buf);
+static void darshan_log_print_heatmap_record(void *file_rec,
+    char *file_name, char *mnt_pt, char *fs_type);
+static void darshan_log_print_heatmap_description(int ver);
+
+/* structure storing each function needed for implementing the darshan
+ * logutil interface. these functions are used for reading, writing, and
+ * printing module data in a consistent manner.
+ */
+struct darshan_mod_logutil_funcs heatmap_logutils =
+{
+    .log_get_record = &darshan_log_get_heatmap_record,
+    .log_put_record = &darshan_log_put_heatmap_record,
+    .log_print_record = &darshan_log_print_heatmap_record,
+    .log_print_description = &darshan_log_print_heatmap_description,
+    /* _diff is deliberately not implelmented; it's not clear what a heatmap
+     * diff would represent or how it might be used.
+     */
+    .log_print_diff = NULL,
+    /* _agg is deliberately not implemented; there are no shared records in
+     * the heatmap; it is always reported per process
+     */
+    .log_agg_records = NULL
+};
+
+/* retrieve a heatmap record from log file descriptor 'fd', storing the
+ * data in the buffer address pointed to by 'heatmap_buf_p'. Return 1 on
+ * successful record read, 0 on no more data, and -1 on error.
+ */
+static int darshan_log_get_heatmap_record(darshan_fd fd, void** heatmap_buf_p)
+{
+    struct darshan_heatmap_record *rec = *((struct darshan_heatmap_record **)heatmap_buf_p);
+    struct darshan_heatmap_record static_rec = {0};
+    void* trailing;
+    int ret;
+    int i;
+    int total_rec_size;
+
+    if(fd->mod_map[DARSHAN_HEATMAP_MOD].len == 0)
+        return(0);
+
+    if(fd->mod_ver[DARSHAN_HEATMAP_MOD] == 0 ||
+        fd->mod_ver[DARSHAN_HEATMAP_MOD] > DARSHAN_HEATMAP_VER)
+    {
+        fprintf(stderr, "Error: Invalid HEATMAP module version number (got %d)\n",
+            fd->mod_ver[DARSHAN_HEATMAP_MOD]);
+        return(-1);
+    }
+
+    if(*heatmap_buf_p == NULL)
+        rec = &static_rec;
+
+    /* read base record; it is a fixed size */
+    ret = darshan_log_get_mod(fd, DARSHAN_HEATMAP_MOD, rec,
+        sizeof(struct darshan_heatmap_record));
+    if(ret < 0)
+        return(-1);
+    else if(ret < sizeof(struct darshan_heatmap_record))
+        return(0);
+
+    /* do byte swapping if necessary */
+    if(fd->swap_flag)
+    {
+        DARSHAN_BSWAP64(&rec->base_rec.id);
+        DARSHAN_BSWAP64(&rec->base_rec.rank);
+        DARSHAN_BSWAP64(&rec->bin_width_seconds);
+        DARSHAN_BSWAP64(&rec->nbins);
+    }
+
+    /* if buffer was provided by caller, then it is implied that it is
+     * DEF_MOD_BUF_SIZE bytes in size.  Make sure it is big enough, or if we
+     * are allocating the buffer malloc enough size */
+    total_rec_size = sizeof(struct darshan_heatmap_record) + rec->nbins*2*sizeof(int64_t);
+    if(*heatmap_buf_p)
+    {
+        if(total_rec_size > DEF_MOD_BUF_SIZE)
+        {
+            fprintf(stderr, "Error: HEATMAP record is %d bytes, but DEF_MOD_BUF_SIZE is only %d bytes\n", total_rec_size, DEF_MOD_BUF_SIZE);
+            return(-1);
+        }
+    }
+    else
+    {
+        *heatmap_buf_p = malloc(total_rec_size);
+        if(!(*heatmap_buf_p))
+            return(-1);
+        memcpy(*heatmap_buf_p, rec, sizeof(*rec));
+        rec = *heatmap_buf_p;
+    }
+
+    /* set pointer for trailing data */
+    trailing = (void*)((intptr_t)(*heatmap_buf_p) + sizeof(*rec));
+    ret = darshan_log_get_mod(fd, DARSHAN_HEATMAP_MOD, trailing,
+        rec->nbins*2*sizeof(int64_t));
+    if(ret < rec->nbins*2*sizeof(int64_t))
+        return(-1);
+
+    /* set pointers and byteswap trailing data */
+    rec->write_bins = (int64_t*)((uintptr_t)rec + sizeof(*rec));
+    rec->read_bins = (int64_t*)((uintptr_t)rec + sizeof(*rec) + rec->nbins*sizeof(uint64_t));
+    if(fd->swap_flag)
+    {
+        for(i=0; i<rec->nbins; i++)
+        {
+            DARSHAN_BSWAP64(&rec->write_bins[i]);
+            DARSHAN_BSWAP64(&rec->read_bins[i]);
+        }
+    }
+
+    return(1);
+}
+
+/* write the heatmap record stored in 'heatmap_buf' to log file descriptor 'fd'.
+ * Return 0 on success, -1 on failure
+ */
+static int darshan_log_put_heatmap_record(darshan_fd fd, void* heatmap_buf)
+{
+    struct darshan_heatmap_record *rec = (struct darshan_heatmap_record *)heatmap_buf;
+    int ret;
+
+    /* append heatmap record to darshan log file */
+    ret = darshan_log_put_mod(fd, DARSHAN_HEATMAP_MOD, rec,
+        sizeof(struct darshan_heatmap_record) + rec->nbins*2*sizeof(int64_t), DARSHAN_HEATMAP_VER);
+    if(ret < 0)
+        return(-1);
+
+    return(0);
+}
+
+/* print all I/O data record statistics for the given heatmap record */
+static void darshan_log_print_heatmap_record(void *file_rec, char *file_name,
+    char *mnt_pt, char *fs_type)
+{
+    struct darshan_heatmap_record *heatmap_rec =
+        (struct darshan_heatmap_record *)file_rec;
+    char counter_name_buffer[256];
+    int i;
+
+    DARSHAN_F_COUNTER_PRINT(darshan_module_names[DARSHAN_HEATMAP_MOD],
+        heatmap_rec->base_rec.rank, heatmap_rec->base_rec.id,
+        "HEATMAP_F_BIN_WIDTH_SECONDS",
+        heatmap_rec->bin_width_seconds, file_name, mnt_pt, fs_type);
+
+    for(i=0; i<heatmap_rec->nbins; i++)
+    {
+        snprintf(counter_name_buffer, 256, "HEATMAP_READ_BIN_%d", i);
+        DARSHAN_D_COUNTER_PRINT(darshan_module_names[DARSHAN_HEATMAP_MOD],
+            heatmap_rec->base_rec.rank, heatmap_rec->base_rec.id,
+            counter_name_buffer,
+            heatmap_rec->read_bins[i], file_name, mnt_pt, fs_type);
+    }
+
+    for(i=0; i<heatmap_rec->nbins; i++)
+    {
+        snprintf(counter_name_buffer, 256, "HEATMAP_WRITE_BIN_%d", i);
+        DARSHAN_D_COUNTER_PRINT(darshan_module_names[DARSHAN_HEATMAP_MOD],
+            heatmap_rec->base_rec.rank, heatmap_rec->base_rec.id,
+            counter_name_buffer,
+            heatmap_rec->write_bins[i], file_name, mnt_pt, fs_type);
+    }
+
+    return;
+}
+
+/* print out a description of the heatmap module record fields */
+static void darshan_log_print_heatmap_description(int ver)
+{
+    printf("\n# description of heatmap counters:\n");
+    printf("#   HEATMAP_F_BIN_WIDTH_SECONDS: time duration of each heatmap bin\n");
+    printf("#   HEATMAP_{READ|WRITE}_BIN_{*}: number of bytes read or written within specified heatmap bin\n");
+
+    return;
+}
+
+/*
+ * Local variables:
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ * End:
+ *
+ * vim: ts=8 sts=4 sw=4 expandtab
+ */

--- a/darshan-util/darshan-heatmap-logutils.h
+++ b/darshan-util/darshan-heatmap-logutils.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2015 University of Chicago.
+ * See COPYRIGHT notice in top-level directory.
+ *
+ */
+
+#ifndef __DARSHAN_HEATMAP_LOGUTILS_H
+#define __DARSHAN_HEATMAP_LOGUTILS_H
+
+extern struct darshan_mod_logutil_funcs heatmap_logutils;
+
+#endif

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -18,7 +18,7 @@
 #include "darshan-log-format.h"
 
 /* Maximum size of a record - Lustre OST lists can get huge, but 81920 is enough
- * for 10K OSTs 
+ * for 10K OSTs
  */
 #define DEF_MOD_BUF_SIZE 81920
 
@@ -150,6 +150,7 @@ extern struct darshan_mod_logutil_funcs *mod_logutils[];
 #include "darshan-bgq-logutils.h"
 #include "darshan-lustre-logutils.h"
 #include "darshan-stdio-logutils.h"
+#include "darshan-heatmap-logutils.h"
 
 /* DXT */
 #include "darshan-dxt-logutils.h"

--- a/darshan-util/doc/darshan-util.txt
+++ b/darshan-util/doc/darshan-util.txt
@@ -444,7 +444,30 @@ value of 1 MiB for optimal file alignment.
 | PNETCDF_F_*_END_TIMESTAMP | Timestamp that the last PNETCDF file open/close operation ended
 |====
 
-===== Additional modules 
+===== Heatmap fields
+
+Each heatmap module record reports a histogram of the number of bytes read
+or written, per process, over time, for a given I/O API.  It provides
+a synopsis of I/O intensity regardless of how many files are accessed.
+Heatmap records are never aggregated across ranks.
+
+The file name field is used to indicate the API that produced the
+histogram record.  For exmaple, "heatmap:POSIX" indicates that the record is
+reporting I/O traffic that passed through the POSIX module.
+
+The number of BIN fields present in each record may vary depending on the
+job's execution time and the configurable maximum number of bins chosen at
+execution time.
+
+.HEATMAP module
+[cols="40%,60%",options="header"]
+|====
+| counter name | description
+| HEATMAP_F_BIN_WIDTH_SECONDS | time duration of each heatmap bin
+| HEATMAP_READ\|WRITE_BIN_* | number of bytes read or written within specified heatmap bin
+|====
+
+===== Additional modules
 
 .Lustre module (if enabled, for Lustre file systems)
 [cols="40%,60%",options="header"]

--- a/include/darshan-heatmap-log-format.h
+++ b/include/darshan-heatmap-log-format.h
@@ -1,0 +1,25 @@
+/*
+ *  (C) 2009 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef __DARSHAN_HEATMAP_LOG_FORMAT_H
+#define __DARSHAN_HEATMAP_LOG_FORMAT_H
+
+/* current HEATMAP log format version */
+#define DARSHAN_HEATMAP_VER 1
+
+/* record structure for a Darshan heatmap.  These should be one per
+ * API/category that registers heatmap data.  Each is variable size
+ * according to the nbins field.
+ */
+struct darshan_heatmap_record
+{
+    struct darshan_base_record base_rec;
+    double  bin_width_seconds; /* time duration of each bin */
+    int64_t nbins;             /* number of bins */
+    int64_t *write_bins;       /* pointer to write bin array (trails struct in log */
+    int64_t *read_bins;        /* pointer to read bin array (trails write bin array in log */
+};
+
+#endif /* __DARSHAN_HEATMAP_LOG_FORMAT_H */

--- a/include/darshan-log-format.h
+++ b/include/darshan-log-format.h
@@ -48,7 +48,7 @@ enum darshan_comp_type
 {
     DARSHAN_ZLIB_COMP,
     DARSHAN_BZIP2_COMP,
-    DARSHAN_NO_COMP, 
+    DARSHAN_NO_COMP,
 };
 
 typedef uint64_t darshan_record_id;
@@ -126,12 +126,13 @@ struct darshan_base_record
 #ifdef DARSHAN_USE_APMPI
 #include "darshan-apmpi-log-format.h"
 #endif
+#include "darshan-heatmap-log-format.h"
 
 /* X-macro for keeping module ordering consistent */
-/* NOTE: first val used to define module enum values, 
+/* NOTE: first val used to define module enum values,
  * second val used to define module name strings,
  * third val is the log format version for the module,
- * and fourth val is used to provide the name of a 
+ * and fourth val is used to provide the name of a
  * corresponding logutils structure for parsing module
  * data out of the log file (only used in darshan-util
  * component -- NULL can be passed if there are no
@@ -170,7 +171,8 @@ struct darshan_base_record
     X(DXT_MPIIO_MOD,        "DXT_MPIIO",  DXT_MPIIO_VER,         &dxt_mpiio_logutils) \
     X(DARSHAN_MDHIM_MOD,    "MDHIM",      DARSHAN_MDHIM_VER,     &mdhim_logutils) \
     X(DARSHAN_APXC_MOD,     "APXC", 	  __APXC_VER,            __apxc_logutils) \
-    X(DARSHAN_APMPI_MOD,    "APMPI",      __APMPI_VER,           __apmpi_logutils) 
+    X(DARSHAN_APMPI_MOD,    "APMPI",      __APMPI_VER,           __apmpi_logutils) \
+    X(DARSHAN_HEATMAP_MOD,  "HEATMAP",    DARSHAN_HEATMAP_VER,   &heatmap_logutils)
 
 /* unique identifiers to distinguish between available darshan modules */
 /* NOTES: - valid ids range from [0...DARSHAN_MAX_MODS-1]


### PR DESCRIPTION
This PR introduces an auto-scaling heatmap histogram at runtime; see darshan-heatmap.c.

Multiple APIs can register with it and keep independent histograms (each histogram is a separate Darshan record).  All of the histogram records are stored in a single dedicated histogram module from a log perspective.

PR currently just has the runtime library portion implemented, and it is only hooked up to the POSIX module.  Need to:

- [x] implement logutils portion
- [x] add support for variable number of bins in log format
- [x] test performance (probably repeat tests from recent ECP experiments)
- [x] implement (or at least stub in) the agg_records() logutils function for future use
- [x] documentation
- [x] squash commits
- [x] hook into mpi-io and stdio modules