### PR TITLE
ENH: Add I/O cost figure module and tests

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/__init__.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/__init__.py
@@ -1,3 +1,4 @@
 from .plot_access_histogram import plot_access_histogram
 from .plot_opcounts import plot_opcounts
 from .plot_dxt_heatmap2 import plot_dxt_heatmap2
+from .plot_io_cost import plot_io_cost

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -1,0 +1,119 @@
+"""
+Module for creating the the I/O cost
+bar graph for the Darshan job summary.
+"""
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+
+import darshan
+
+
+def get_io_cost_df(report: darshan.DarshanReport, mod_key: str) -> Any:
+    """
+    Generates the I/O cost dataframe which contains the
+    raw data to plot the I/O cost stacked bar graph.
+
+    Parameters
+    ----------
+    report: a ``darshan.DarshanReport``.
+
+    mod_key: module to generate the I/O cost stacked
+    bar graph for (i.e. "POSIX", "MPI-IO", "STDIO").
+
+    Returns
+    -------
+    io_cost_df: a ``pd.DataFrame`` containing the
+    average read, write, and meta times.
+
+    """
+    # collect the records in dataframe form
+    recs = report.records[mod_key].to_df(attach=["rank"])
+    # correct the MPI module key
+    if mod_key == "MPI-IO":
+        mod_key = "MPIIO"
+    # filter out all except the following columns
+    cols = [
+        "rank",
+        f"{mod_key}_F_READ_TIME",
+        f"{mod_key}_F_WRITE_TIME",
+        f"{mod_key}_F_META_TIME",
+    ]
+    rd_wr_meta_df = recs["fcounters"].filter(cols, axis=1)
+    # locate any rows where "rank" == -1 and divide them by nprocs
+    nprocs = report.metadata["job"]["nprocs"]
+    rd_wr_meta_df.loc[rd_wr_meta_df["rank"] == -1] /= nprocs
+    # drop the "rank" column since it's no longer needed
+    rd_wr_meta_df.drop("rank", axis=1, inplace=True)
+    # rename the columns so the labels are automatically generated when plotting
+    name_dict = {cols[1]: "Read", cols[2]: "Write", cols[3]: "Meta"}
+    rd_wr_meta_df.rename(columns=name_dict, inplace=True)
+    # calculate the means and put the output `pd.Series` into a new dataframe
+    io_cost_df = pd.DataFrame({"Avg. Operation Time": rd_wr_meta_df.mean(axis=0)}).T
+    return io_cost_df
+
+
+def plot_io_cost(report: darshan.DarshanReport, mod_key: str) -> Any:
+    """
+    Creates a stacked bar graph illustrating the percentage of
+    runtime spent in read, write, and metadata operations.
+
+    Parameters
+    ----------
+    report: a ``darshan.DarshanReport``.
+
+    mod_key: module to generate the I/O cost stacked
+    bar graph for (i.e. "POSIX", "MPI-IO", "STDIO").
+
+    Returns
+    -------
+    io_cost_fig: a ``matplotlib.pyplot.figure`` object containing a
+    stacked bar graph of the average read, write, and metadata times.
+
+    Raises
+    ------
+    NotImplementedError: raised if the input module key is not "POSIX",
+    "MPI-IO", or "STDIO".
+
+    """
+    if mod_key not in ["POSIX", "MPI-IO", "STDIO"]:
+        # TODO: expand the scope of this function
+        # to include HDF5 module
+        raise NotImplementedError(f"{mod_key} module is not supported.")
+    # calculate the run time from the report metadata
+    runtime = report.metadata["job"]["end_time"] - report.metadata["job"]["start_time"]
+    if runtime == 0:
+        # for cases where runtime is < 1, just set it
+        # to 1 like the original perl code
+        runtime = 1
+    # get the I/O cost dataframe
+    io_cost_df = get_io_cost_df(report=report, mod_key=mod_key)
+    # generate a figure with 2 y axes
+    io_cost_fig = plt.figure(figsize=(4.5, 4))
+    ax_raw = io_cost_fig.add_subplot(111)
+    ax_norm = ax_raw.twinx()
+    # use the dataframe to plot the stacked bar graph
+    io_cost_df.plot.bar(stacked=True, rot=0, ax=ax_raw, legend=False, zorder=3)
+    ax_raw.grid(axis="y", zorder=0, alpha=0.6)
+    # set the y limits for both axes
+    ax_raw.set_ylim(0, runtime)
+    ax_norm.set_ylim(0, 100)
+    # convert the normalized axis y labels to percentages
+    ax_norm.yaxis.set_major_formatter(mtick.PercentFormatter())
+    # align both axes tick labels so the grid matches
+    # values on both sides of the bar graph
+    norm_yticks = ax_raw.get_yticks()
+    n_ticks = len(ax_norm.get_yticks())
+    yticks = np.linspace(norm_yticks[0], norm_yticks[-1], n_ticks)
+    ax_raw.set_yticks(yticks)
+    # add the legend and appropriate labels
+    ax_raw.set_ylabel("Runtime (s)")
+    handles, labels = ax_raw.get_legend_handles_labels()
+    ax_norm.legend(handles[::-1], labels[::-1], loc="upper left", bbox_to_anchor=(1.3, 1.02), title="Operation")
+    # adjust the figure to reduce white space
+    io_cost_fig.subplots_adjust(right=0.59)
+    io_cost_fig.tight_layout()
+    return io_cost_fig

--- a/darshan-util/pydarshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/tests/test_plot_io_cost.py
@@ -2,11 +2,14 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pandas as pd
-from pandas.testing import assert_frame_equal # type: ignore
+from pandas.testing import assert_frame_equal, assert_series_equal # type: ignore
 
 import darshan
-from darshan.experimental.plots.plot_io_cost import get_io_cost_df, plot_io_cost
-
+from darshan.experimental.plots.plot_io_cost import (
+    get_by_avg_series,
+    get_io_cost_df,
+    plot_io_cost,
+)
 
 @pytest.mark.parametrize(
     "report, mod, expected_df",
@@ -16,7 +19,7 @@ from darshan.experimental.plots.plot_io_cost import get_io_cost_df, plot_io_cost
             "POSIX",
             pd.DataFrame(
                 np.array([[0.0196126699, 0.134203, 0.0074423551]]),
-                ["Avg. Operation Time"],
+                ["by-average"],
                 ["Read", "Write", "Meta"],
             ),
         ),
@@ -25,7 +28,7 @@ from darshan.experimental.plots.plot_io_cost import get_io_cost_df, plot_io_cost
             "MPI-IO",
             pd.DataFrame(
                 np.array([[0.0196372866, 0.134251, 0.0475]]),
-                ["Avg. Operation Time"],
+                ["by-average"],
                 ["Read", "Write", "Meta"],
             ),
         ),
@@ -34,25 +37,25 @@ from darshan.experimental.plots.plot_io_cost import get_io_cost_df, plot_io_cost
             "STDIO",
             pd.DataFrame(
                 np.array([[0.0, 0.0001022815, 0.0]]),
-                ["Avg. Operation Time"],
+                ["by-average"],
                 ["Read", "Write", "Meta"],
             ),
         ),
         (
-            darshan.DarshanReport("examples/example-logs/sample.darshan"),
+            darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
             "POSIX",
             pd.DataFrame(
-                np.array([[0.0, 49.022266, 0.005518]]),
-                ["Avg. Operation Time"],
+                np.array([[0.0, 33.48587587394286, 0.5547398688504472]]),
+                ["by-average"],
                 ["Read", "Write", "Meta"],
             ),
         ),
         (
-            darshan.DarshanReport("examples/example-logs/sample.darshan"),
-            "MPI-IO",
+            darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
+            "STDIO",
             pd.DataFrame(
-                np.array([[0.0, 49.022411, 0.023936]]),
-                ["Avg. Operation Time"],
+                np.array([[0.0037345244005943337, 1.544055218497912e-07, 0.045062407424362995]]),
+                ["by-average"],
                 ["Read", "Write", "Meta"],
             ),
         ),
@@ -64,72 +67,78 @@ def test_get_io_cost_df(report, mod, expected_df):
     assert_frame_equal(actual_df, expected_df)
 
 
-@pytest.mark.parametrize("mod", ["POSIX", "MPI-IO", "STDIO"])
 @pytest.mark.parametrize(
-    "report, expected_ylims", [
+    "report, expected_ylims, mods", [
         (
             darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
             [0.0, 1.0],
+            ["POSIX", "MPI-IO", "STDIO"],
         ),
         (
-            darshan.DarshanReport("examples/example-logs/sample.darshan"),
-            [0.0, 120.0],
+            darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
+            [0.0, 800.0],
+            ["POSIX", "STDIO"],
         ),
     ],
 )
-def test_plot_io_cost_ylims(report, expected_ylims, mod):
+def test_plot_io_cost_ylims(report, expected_ylims, mods):
     # test the y limits for both axes for the IO cost stacked bar graph
-    fig = plot_io_cost(report=report, mod_key=mod)
-    for i, ax in enumerate(fig.axes):
-        # there are only 2 axes, the first being the "raw" data
-        # and the second being the normalized data (percent)
-        actual_ylims = ax.get_ylim()
-        if i == 0:
-            assert_array_equal(actual_ylims, expected_ylims)
-        else:
-            # normalized data is always the same
-            assert_array_equal(actual_ylims, [0.0, 100.0])
 
-@pytest.mark.parametrize("mod", ["POSIX", "MPI-IO", "STDIO"])
+    for mod in mods:
+        fig = plot_io_cost(report=report, mod_key=mod)
+        for i, ax in enumerate(fig.axes):
+            # there are only 2 axes, the first being the "raw" data
+            # and the second being the normalized data (percent)
+            actual_ylims = ax.get_ylim()
+            if i == 0:
+                assert_allclose(actual_ylims, expected_ylims)
+            else:
+                # normalized data is always the same
+                assert_allclose(actual_ylims, [0.0, 100.0])
+
 @pytest.mark.parametrize(
-    "report, expected_yticks, expected_yticklabels", [
+    "report, expected_yticks, mods", [
         (
             darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
             [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
-            ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"],
+            ["POSIX", "MPI-IO", "STDIO"],
         ),
         (
-            darshan.DarshanReport("examples/example-logs/sample.darshan"),
-            [0, 24, 48, 72, 96, 120],
-            ["0", "24", "48", "72", "96", "120"],
+            darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
+            [0, 160, 320, 480, 640, 800],
+            ["POSIX", "STDIO"],
         ),
     ],
 )
 def test_plot_io_cost_y_ticks_and_labels(
         report,
         expected_yticks,
-        expected_yticklabels,
-        mod
+        mods
     ):
     # check the y-axis tick marks are at the appropriate
     # locations and the labels are as expected
-    fig = plot_io_cost(report=report, mod_key=mod)
-    for i, ax in enumerate(fig.axes):
-        # there are only 2 axes, the first being the "raw" data
-        # and the second being the normalized data (percent)
-        actual_yticks = ax.get_yticks()
-        yticklabels = ax.get_yticklabels()
-        actual_yticklabels = [tl.get_text() for tl in yticklabels]
-        if i == 0:
-            assert_allclose(actual_yticks, expected_yticks)
-            assert_array_equal(actual_yticklabels, expected_yticklabels)
-        else:
-            # normalized data always has the same 5 tick labels
-            assert_array_equal(actual_yticks, [0, 20, 40, 60, 80, 100])
-            assert_array_equal(
-                actual_yticklabels,
-                ["0%", "20%", "40%", "60%", "80%", "100%"],
-            )
+
+    # create the expected y-axis tick labels from the y ticks
+    expected_yticklabels = [str(i) for i in expected_yticks]
+
+    for mod in mods:
+        fig = plot_io_cost(report=report, mod_key=mod)
+        for i, ax in enumerate(fig.axes):
+            # there are only 2 axes, the first being the "raw" data
+            # and the second being the normalized data (percent)
+            actual_yticks = ax.get_yticks()
+            yticklabels = ax.get_yticklabels()
+            actual_yticklabels = [tl.get_text() for tl in yticklabels]
+            if i == 0:
+                assert_allclose(actual_yticks, expected_yticks)
+                assert_array_equal(actual_yticklabels, expected_yticklabels)
+            else:
+                # normalized data always has the same 5 tick labels
+                assert_array_equal(actual_yticks, [0, 20, 40, 60, 80, 100])
+                assert_array_equal(
+                    actual_yticklabels,
+                    ["0%", "20%", "40%", "60%", "80%", "100%"],
+                )
 
 def test_plot_io_cost_unsupported_modules():
     # test that using an unsupported module raises the appropriate error
@@ -137,3 +146,68 @@ def test_plot_io_cost_unsupported_modules():
     with pytest.raises(NotImplementedError) as err:
         plot_io_cost(report=report, mod_key="LUSTRE")
         assert "module is not supported." in str(err)
+
+@pytest.mark.parametrize("mod_key, input_df, expected_series", [
+    (
+        # generate a dataframe that has easy-to-calculate average values
+        # to check if the averages are being calculated appropriately
+        "POSIX",
+        pd.DataFrame(
+            data=[
+                [0, 0, 1, 10, 3],
+                [1, 12, 5, 20, 3]
+            ],
+            columns=[
+                "rank", "POSIX_F_READ_TIME", "POSIX_F_WRITE_TIME",
+                "POSIX_F_META_TIME", "TEST"
+            ],
+        ),
+        pd.Series(
+            data=[6.0, 3.0, 15.0],
+            index=["Read", "Write", "Meta"],
+        ),
+    ),
+    (
+        # generate a dataframe similar to a shared-record-enabled log
+        # where there is a single entry that needs to be divided through
+        # by `nprocs`
+        "STDIO",
+        pd.DataFrame(
+            data=[
+                [-1, 30000, 3000, 300, 10],
+            ],
+            columns=[
+                "rank", "STDIO_F_READ_TIME", "STDIO_F_WRITE_TIME",
+                "STDIO_F_META_TIME", "TEST"
+            ],
+        ),
+        pd.Series(
+            data=[3000.0, 300.0, 30.0],
+            index=["Read", "Write", "Meta"],
+        ),
+    ),
+    (
+        # combine 2 previous cases to check if
+        # calculations are being done appropriately
+        "MPIIO",
+        pd.DataFrame(
+            data=[
+                [0, 0, 1, 10, 3],
+                [1, 12, 5, 20, 3],
+                [-1, 30000, 3000, 300, 10],
+            ],
+            columns=[
+                "rank", "MPIIO_F_READ_TIME", "MPIIO_F_WRITE_TIME",
+                "MPIIO_F_META_TIME", "TEST"
+            ],
+        ),
+        pd.Series(
+            data=[1004.0, 102.0, 20.0],
+            index=["Read", "Write", "Meta"],
+        ),
+    )
+])
+def test_get_by_avg_series(mod_key, input_df, expected_series):
+    # unit test for `plot_io_cost.get_by_avg_series`
+    actual_series = get_by_avg_series(df=input_df, mod_key=mod_key, nprocs=10)
+    assert_series_equal(actual_series, expected_series)

--- a/darshan-util/pydarshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/tests/test_plot_io_cost.py
@@ -1,0 +1,139 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+import pandas as pd
+from pandas.testing import assert_frame_equal # type: ignore
+
+import darshan
+from darshan.experimental.plots.plot_io_cost import get_io_cost_df, plot_io_cost
+
+
+@pytest.mark.parametrize(
+    "report, mod, expected_df",
+    [
+        (
+            darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
+            "POSIX",
+            pd.DataFrame(
+                np.array([[0.0196126699, 0.134203, 0.0074423551]]),
+                ["Avg. Operation Time"],
+                ["Read", "Write", "Meta"],
+            ),
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
+            "MPI-IO",
+            pd.DataFrame(
+                np.array([[0.0196372866, 0.134251, 0.0475]]),
+                ["Avg. Operation Time"],
+                ["Read", "Write", "Meta"],
+            ),
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
+            "STDIO",
+            pd.DataFrame(
+                np.array([[0.0, 0.0001022815, 0.0]]),
+                ["Avg. Operation Time"],
+                ["Read", "Write", "Meta"],
+            ),
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/sample.darshan"),
+            "POSIX",
+            pd.DataFrame(
+                np.array([[0.0, 49.022266, 0.005518]]),
+                ["Avg. Operation Time"],
+                ["Read", "Write", "Meta"],
+            ),
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/sample.darshan"),
+            "MPI-IO",
+            pd.DataFrame(
+                np.array([[0.0, 49.022411, 0.023936]]),
+                ["Avg. Operation Time"],
+                ["Read", "Write", "Meta"],
+            ),
+        ),
+    ],
+)
+def test_get_io_cost_df(report, mod, expected_df):
+    # regression test for `plot_io_cost.get_io_cost_df()`
+    actual_df = get_io_cost_df(report=report, mod_key=mod)
+    assert_frame_equal(actual_df, expected_df)
+
+
+@pytest.mark.parametrize("mod", ["POSIX", "MPI-IO", "STDIO"])
+@pytest.mark.parametrize(
+    "report, expected_ylims", [
+        (
+            darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
+            [0.0, 1.0],
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/sample.darshan"),
+            [0.0, 120.0],
+        ),
+    ],
+)
+def test_plot_io_cost_ylims(report, expected_ylims, mod):
+    # test the y limits for both axes for the IO cost stacked bar graph
+    fig = plot_io_cost(report=report, mod_key=mod)
+    for i, ax in enumerate(fig.axes):
+        # there are only 2 axes, the first being the "raw" data
+        # and the second being the normalized data (percent)
+        actual_ylims = ax.get_ylim()
+        if i == 0:
+            assert_array_equal(actual_ylims, expected_ylims)
+        else:
+            # normalized data is always the same
+            assert_array_equal(actual_ylims, [0.0, 100.0])
+
+@pytest.mark.parametrize("mod", ["POSIX", "MPI-IO", "STDIO"])
+@pytest.mark.parametrize(
+    "report, expected_yticks, expected_yticklabels", [
+        (
+            darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
+            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"],
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/sample.darshan"),
+            [0, 24, 48, 72, 96, 120],
+            ["0", "24", "48", "72", "96", "120"],
+        ),
+    ],
+)
+def test_plot_io_cost_y_ticks_and_labels(
+        report,
+        expected_yticks,
+        expected_yticklabels,
+        mod
+    ):
+    # check the y-axis tick marks are at the appropriate
+    # locations and the labels are as expected
+    fig = plot_io_cost(report=report, mod_key=mod)
+    for i, ax in enumerate(fig.axes):
+        # there are only 2 axes, the first being the "raw" data
+        # and the second being the normalized data (percent)
+        actual_yticks = ax.get_yticks()
+        yticklabels = ax.get_yticklabels()
+        actual_yticklabels = [tl.get_text() for tl in yticklabels]
+        if i == 0:
+            assert_allclose(actual_yticks, expected_yticks)
+            assert_array_equal(actual_yticklabels, expected_yticklabels)
+        else:
+            # normalized data always has the same 5 tick labels
+            assert_array_equal(actual_yticks, [0, 20, 40, 60, 80, 100])
+            assert_array_equal(
+                actual_yticklabels,
+                ["0%", "20%", "40%", "60%", "80%", "100%"],
+            )
+
+def test_plot_io_cost_unsupported_modules():
+    # test that using an unsupported module raises the appropriate error
+    report = darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan")
+    with pytest.raises(NotImplementedError) as err:
+        plot_io_cost(report=report, mod_key="LUSTRE")
+        assert "module is not supported." in str(err)


### PR DESCRIPTION
* Add module for I/O cost figure

* Add testing module to cover I/O cost functions

* Add import to `__init__.py` to ease in importing all
plotting functions in summary report code

* Contributes to #465