### PR TITLE
ENH: Add `DXT_MPIIO` support to `plot_dxt_heatmap.plot_heatmap()`

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -154,7 +154,7 @@ def get_single_df_dict(
     report: Any,
     mod: str = "DXT_POSIX",
     ops: Sequence[str] = ["read", "write"],
-) -> Dict[str, Dict[str, pd.DataFrame]]:
+) -> Dict[str, pd.DataFrame]:
     """
     Reorganizes segmented read/write data into a single ``pd.DataFrame``
     and stores them in a dictionary with an entry for each DXT module.

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -152,7 +152,7 @@ def get_rd_wr_dfs(
 
 def get_single_df_dict(
     report: Any,
-    mods: Sequence[str] = ["DXT_POSIX"],
+    mod: str = "DXT_POSIX",
     ops: Sequence[str] = ["read", "write"],
 ) -> Dict[str, Dict[str, pd.DataFrame]]:
     """
@@ -164,8 +164,8 @@ def get_single_df_dict(
 
     report: a ``darshan.DarshanReport``.
 
-    mods: a sequence of keys designating which Darshan modules to use for
-    data aggregation. Default is ``["DXT_POSIX"]``.
+    mod: the DXT module to do analysis for (i.e. "DXT_POSIX"
+    or "DXT_MPIIO"). Default is ``"DXT_POSIX"``.
 
     ops: a sequence of keys designating which Darshan operations to use for
     data aggregation. Default is ``["read", "write"]``.
@@ -182,41 +182,36 @@ def get_single_df_dict(
     --------
     `flat_data_dict` generated from `tests/input/sample-dxt-simple.darshan`:
         {
-            'DXT_POSIX':
-                {
-                    'read':
-                        Empty DataFrame
-                        Columns: []
-                        Index: [],
-                    'write':
-                        length  start_time  end_time  rank
-                        0      40    0.103379  0.103388     0
-                        1    4000    0.104217  0.104231     0
-                }
+            'read':
+                Empty DataFrame
+                Columns: []
+                Index: [],
+            'write':
+                length  start_time  end_time  rank
+                0      40    0.103379  0.103388     0
+                1    4000    0.104217  0.104231     0
         }
 
     """
     # initialize an empty dictionary for storing
     # module and read/write data
     flat_data_dict = {}  # type: Dict[str, Dict[str, pd.DataFrame]]
-    # iterate over the modules (i.e. DXT_POSIX)
-    for module_key in mods:
-        # retrieve the list of records in pd.DataFrame() form
-        dict_list = report.records[module_key].to_df()
-        # retrieve the list of read/write dataframes from the list of records
-        rd_wr_dfs = get_rd_wr_dfs(dict_list=dict_list, ops=ops)
-        # create empty dictionary for each module
-        flat_data_dict[module_key] = {}
-        for op_key in ops:
-            # add the concatenated dataframe to the flat dictionary
-            flat_data_dict[module_key][op_key] = rd_wr_dfs[op_key]
+    # retrieve the list of records in pd.DataFrame() form
+    dict_list = report.records[mod].to_df()
+    # retrieve the list of read/write dataframes from the list of records
+    rd_wr_dfs = get_rd_wr_dfs(dict_list=dict_list, ops=ops)
+    # create empty dictionary
+    flat_data_dict = {}
+    for op_key in ops:
+        # add the concatenated dataframe to the flat dictionary
+        flat_data_dict[op_key] = rd_wr_dfs[op_key]
 
     return flat_data_dict
 
 
 def get_aggregate_data(
     report: Any,
-    mods: Sequence[str] = ["DXT_POSIX"],
+    mod: str = "DXT_POSIX",
     ops: Sequence[str] = ["read", "write"],
 ) -> pd.DataFrame:
     """
@@ -228,8 +223,8 @@ def get_aggregate_data(
 
     report: a ``darshan.DarshanReport``.
 
-    mods: a sequence of keys designating which Darshan modules to use for
-    data aggregation. Default is ``["DXT_POSIX"]``.
+    mod: the DXT module to do analysis for (i.e. "DXT_POSIX"
+    or "DXT_MPIIO"). Default is ``"DXT_POSIX"``.
 
     ops: a sequence of keys designating which Darshan operations to use for
     data aggregation. Default is ``["read", "write"]``.
@@ -261,12 +256,10 @@ def get_aggregate_data(
 
     """
     # collect the concatenated dataframe data from the darshan report
-    df_dict = get_single_df_dict(report=report, mods=mods, ops=ops)
-    # TODO: generalize for all DXT modules, for now manually set `DXT_POSIX`
-    module_key = "DXT_POSIX"
+    df_dict = get_single_df_dict(report=report, mod=mod, ops=ops)
     # iterate over each dataframe based on which operations are selected
     df_list = []
-    for op_key, op_df in df_dict[module_key].items():
+    for op_key, op_df in df_dict.items():
         # if the dataframe has data, append it to the list
         if op_df.size:
             df_list.append(op_df)

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -320,15 +320,16 @@ def plot_heatmap(
     Raises
     ------
 
-    NotImplementedError: if a DXT module is not input (i.e. "DXT_POSIX") or if
-    the module is not in the input ``DarshanReport``.
+    NotImplementedError: if a DXT module is not input (i.e. "DXT_POSIX").
+
+    ValueError: if the input module is not in the ``DarshanReport``.
 
     """
     if "DXT" not in mod:
-        raise NotImplementedError(f"Only DXT modules are supported.")
+        raise NotImplementedError("Only DXT modules are supported.")
 
     if mod not in report.modules:
-        raise NotImplementedError(f"Module {mod} not found in DarshanReport.")
+        raise ValueError(f"Module {mod} not found in DarshanReport.")
 
     # aggregate the data according to the selected modules and operations
     agg_df = heatmap_handling.get_aggregate_data(report=report, mod=mod, ops=ops)

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -291,7 +291,7 @@ def adjust_for_colorbar(jointgrid: Any, fig_right: float, cbar_x0: float):
 
 def plot_heatmap(
     report: darshan.DarshanReport,
-    mods: Sequence[str] = ["DXT_POSIX"],
+    mod: str = "DXT_POSIX",
     ops: Sequence[str] = ["read", "write"],
     xbins: int = 200,
 ) -> Any:
@@ -303,8 +303,8 @@ def plot_heatmap(
 
     report: a ``darshan.DarshanReport``.
 
-    mods: a sequence of keys designating which Darshan modules to use for
-    data aggregation. Default is ``["DXT_POSIX"]``.
+    mod: the DXT module to do analysis for (i.e. "DXT_POSIX"
+    or "DXT_MPIIO"). Default is ``"DXT_POSIX"``.
 
     ops: a sequence of keys designating which Darshan operations to use for
     data aggregation. Default is ``["read", "write"]``.
@@ -320,16 +320,18 @@ def plot_heatmap(
     Raises
     ------
 
-    NotImplementedError: raised if "DXT_POSIX" is not in the input modules.
+    NotImplementedError: if a DXT module is not input (i.e. "DXT_POSIX") or if
+    the module is not in the input ``DarshanReport``.
 
     """
-    if "DXT_POSIX" not in mods:
-        # TODO: for the moment reject any cases that don't input "DXT_POSIX"
-        # until we can properly aggregate the data
-        raise NotImplementedError("DXT_POSIX module is required.")
+    if "DXT" not in mod:
+        raise NotImplementedError(f"Only DXT modules are supported.")
+
+    if mod not in report.modules:
+        raise NotImplementedError(f"Module {mod} not found in DarshanReport.")
 
     # aggregate the data according to the selected modules and operations
-    agg_df = heatmap_handling.get_aggregate_data(report=report, mods=mods, ops=ops)
+    agg_df = heatmap_handling.get_aggregate_data(report=report, mod=mod, ops=ops)
 
     # get the heatmap data array
     hmap_df = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)

--- a/darshan-util/pydarshan/tests/test_heatmap_handling.py
+++ b/darshan-util/pydarshan/tests/test_heatmap_handling.py
@@ -232,11 +232,12 @@ def test_get_single_df_dict(expected_df_dict, ops):
 
 
 @pytest.mark.parametrize(
-    "mod, ops, expected_agg_data",
+    "log_file, mod, ops, expected_agg_data",
     [
         # all 3 test cases are based on the outputs for
         # `tests/input/sample-dxt-simple.darshan`, which only has write data
         (
+            "tests/input/sample-dxt-simple.darshan",
             "DXT_POSIX",
             ["read", "write"],
             np.array(
@@ -247,9 +248,10 @@ def test_get_single_df_dict(expected_df_dict, ops):
             ),
         ),
         # for "read" case input None since there is no data to compare
-        ("DXT_POSIX", ["read"], None),
-        ("DXT_MPIIO", ["read"], None),
+        ("tests/input/sample-dxt-simple.darshan", "DXT_POSIX", ["read"], None),
+        ("tests/input/sample-dxt-simple.darshan", "DXT_MPIIO", ["read"], None),
         (
+            "tests/input/sample-dxt-simple.darshan",
             "DXT_POSIX",
             ["write"],
             np.array(
@@ -259,12 +261,44 @@ def test_get_single_df_dict(expected_df_dict, ops):
                 ]
             ),
         ),
+        (
+            "examples/example-logs/ior_hdf5_example.darshan",
+            "DXT_MPIIO",
+            ["write"],
+            np.array(
+                [
+                    [262144, 0.029964923858642578, 0.033110857009887695, 0],
+                    [262144, 0.03313708305358887, 0.03374886512756348, 0],
+                    [262144, 0.03376293182373047, 0.03420686721801758, 0],
+                    [262144, 0.03422093391418457, 0.1820380687713623, 0],
+                    [40, 0.22188901901245117, 0.23144793510437012, 0],
+                    [96, 0.2314610481262207, 0.23147892951965332, 0],
+                    [96, 0.23216795921325684, 0.2321760654449463, 0],
+                    [262144, 0.0299680233001709, 0.03130483627319336, 1],
+                    [262144, 0.03133583068847656, 0.18091988563537598, 1],
+                    [262144, 0.1809389591217041, 0.18172383308410645, 1],
+                    [262144, 0.18174386024475098, 0.18261194229125977, 1],
+                    [544, 0.2218928337097168, 0.23146295547485352, 1],
+                    [120, 0.23146700859069824, 0.23148202896118164, 1],
+                    [262144, 0.0299680233001709, 0.03239917755126953, 2],
+                    [262144, 0.03243207931518555, 0.03294110298156738, 2],
+                    [262144, 0.03295707702636719, 0.1809689998626709, 2],
+                    [262144, 0.18098902702331543, 0.2218320369720459, 2],
+                    [272, 0.22189807891845703, 0.23153114318847656, 2],
+                    [262144, 0.029965877532958984, 0.031455039978027344, 3],
+                    [262144, 0.03148388862609863, 0.03171586990356445, 3],
+                    [262144, 0.03172898292541504, 0.03197503089904785, 3],
+                    [262144, 0.03198695182800293, 0.032212018966674805, 3],
+                    [328, 0.2218940258026123, 0.23151302337646484, 3],
+                ]
+            )
+        )
     ],
 )
-def test_get_aggregate_data(expected_agg_data, mod, ops):
+def test_get_aggregate_data(log_file, expected_agg_data, mod, ops):
     # regression test for `heatmap_handling.get_aggregate_data()`
 
-    report = darshan.DarshanReport("tests/input/sample-dxt-simple.darshan")
+    report = darshan.DarshanReport(log_file)
 
     if ops == ["read"]:
         expected_msg = (

--- a/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
@@ -409,17 +409,20 @@ def test_adjust_for_colorbar(filepath):
         "tests/input/sample-dxt-simple.darshan",
     ],
 )
-@pytest.mark.parametrize("mod", ["DXT_POSIX", "DXT_MPIIO"])
+@pytest.mark.parametrize("mod", ["DXT_POSIX", "DXT_MPIIO", "POSIX"])
 @pytest.mark.parametrize("ops", [["read", "write"], ["read"], ["write"]])
 def test_plot_heatmap(filepath, mod, ops):
     # test the primary plotting function, `plot_dxt_heatmap.plot_heatmap()`
 
     report = darshan.DarshanReport(filepath)
 
-    if ("dxt.darshan" in filepath) & (mod == "DXT_MPIIO"):
+    if mod == "POSIX":
+        with pytest.raises(NotImplementedError, match="Only DXT modules are supported."):
+            plot_dxt_heatmap.plot_heatmap(report=report, mod=mod)
+    elif ("dxt.darshan" in filepath) & (mod == "DXT_MPIIO"):
         # if the input module is not "DXT_POSIX" check
         # that we raise the appropriate error
-        with pytest.raises(NotImplementedError, match="DXT_MPIIO not found in"):
+        with pytest.raises(ValueError, match="DXT_MPIIO not found in"):
             jgrid = plot_dxt_heatmap.plot_heatmap(
                 report=report, mod=mod, ops=ops, xbins=100
             )

--- a/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/tests/test_plot_dxt_heatmap.py
@@ -122,7 +122,7 @@ def test_set_x_axis_ticks_and_labels(
         # for all other data sets just load the data from the log file
         report = darshan.DarshanReport(filepath)
         agg_df = heatmap_handling.get_aggregate_data(
-            report=report, mods=["DXT_POSIX"], ops=["read", "write"]
+            report=report, mod="DXT_POSIX", ops=["read", "write"]
         )
 
     # set the x-axis ticks and tick labels
@@ -258,7 +258,7 @@ def test_set_y_axis_ticks_and_labels(
     # load the report and generate the aggregate data dataframe
     report = darshan.DarshanReport(filepath)
     agg_df = heatmap_handling.get_aggregate_data(
-        report=report, mods=["DXT_POSIX"], ops=["read", "write"]
+        report=report, mod="DXT_POSIX", ops=["read", "write"]
     )
 
     # x-axis bins are arbitrary
@@ -308,7 +308,7 @@ def test_remove_marginal_graph_ticks_and_labels(filepath):
     report = darshan.DarshanReport(filepath)
 
     jgrid = plot_dxt_heatmap.plot_heatmap(
-        report=report, mods=["DXT_POSIX"], ops=["read", "write"], xbins=100
+        report=report, mod="DXT_POSIX", ops=["read", "write"], xbins=100
     )
 
     # verify the heatmap axis is on
@@ -409,19 +409,19 @@ def test_adjust_for_colorbar(filepath):
         "tests/input/sample-dxt-simple.darshan",
     ],
 )
-@pytest.mark.parametrize("mods", [["DXT_POSIX"], ["DXT_MPIIO"]])
+@pytest.mark.parametrize("mod", ["DXT_POSIX", "DXT_MPIIO"])
 @pytest.mark.parametrize("ops", [["read", "write"], ["read"], ["write"]])
-def test_plot_heatmap(filepath, mods, ops):
+def test_plot_heatmap(filepath, mod, ops):
     # test the primary plotting function, `plot_dxt_heatmap.plot_heatmap()`
 
     report = darshan.DarshanReport(filepath)
 
-    if mods == ["DXT_MPIIO"]:
+    if ("dxt.darshan" in filepath) & (mod == "DXT_MPIIO"):
         # if the input module is not "DXT_POSIX" check
         # that we raise the appropriate error
-        with pytest.raises(NotImplementedError, match="DXT_POSIX module is required."):
+        with pytest.raises(NotImplementedError, match="DXT_MPIIO not found in"):
             jgrid = plot_dxt_heatmap.plot_heatmap(
-                report=report, mods=mods, ops=ops, xbins=100
+                report=report, mod=mod, ops=ops, xbins=100
             )
     elif (filepath == "tests/input/sample-dxt-simple.darshan") & (ops == ["read"]):
         # this log file is known to not have any read data, so
@@ -431,11 +431,11 @@ def test_plot_heatmap(filepath, mods, ops):
         )
         with pytest.raises(ValueError, match=expected_msg):
             jgrid = plot_dxt_heatmap.plot_heatmap(
-                report=report, mods=mods, ops=ops, xbins=100
+                report=report, mod=mod, ops=ops, xbins=100
             )
     else:
         jgrid = plot_dxt_heatmap.plot_heatmap(
-            report=report, mods=mods, ops=ops, xbins=100
+            report=report, mod=mod, ops=ops, xbins=100
         )
 
         # verify the margins for all plots


### PR DESCRIPTION
`plot_heatmap()` changes:
    - Change "mods" parameter to "mod" to reflect the change to a single module key
    - Change "DXT" module check to allow for any module containing "DXT"  
    - Add check for input module to verify if it is in the input report

* Change "mods" parameter to "mod" for
`get_single_df_dict()` and `get_aggregate_data()`

* Update documentation for functions to reflect the parameter change

* Remove iteration over modules from
`heatmap_handling.get_single_df_dict()`

* Update documentation examples to reflect the new
data structures since aggregating data across
modules is no longer being considered

* Update `plot_heatmap()` and supporting function
call signatures to use "mod" parameter and single
key instead of list of module keys

* Correct data structures for expected
data in `test_get_rd_wr_dfs_no_write`

* Remove module key assertions in `test_get_rd_wr_dfs_no_write`
 since these are no longer stored

* Remove `KeyError` for `test_get_aggregate_data`
since it no longer applies for `DXT_MPIIO` cases

* Update `NotImplementedError` in `test_plot_heatmap`
to match the new error message

* Closes #536