### PR TITLE
BENCH: add better log file to `time_record_collection_to_df` for `LUSTRE` performance

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/report.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/report.py
@@ -2,7 +2,7 @@ import importlib
 import os
 
 example_logs = importlib.import_module("examples.example-logs")
-from tests.input import test_data_files_dxt
+from tests.input import test_data_files_dxt, test_data_files
 import darshan
 
 
@@ -86,6 +86,8 @@ class RecordCollectionToDF:
         filename = os.path.basename(darshan_logfile)
         if "examples" in darshan_logfile:
             self.logfile = example_logs.example_data_files_dxt[filename]
+        elif "sample-badost" in darshan_logfile:
+            self.logfile = test_data_files[filename]
         else:
             self.logfile = test_data_files_dxt[filename]
 

--- a/darshan-util/pydarshan/benchmarks/benchmarks/report.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/report.py
@@ -67,6 +67,7 @@ class RecordCollectionToDF:
     params = [["examples/example-logs/ior_hdf5_example.darshan",
                "examples/example-logs/dxt.darshan",
                "tests/input/sample-dxt-simple.darshan",
+               "tests/input/sample-badost.darshan",
               ],
               ["POSIX",
                "STDIO",

--- a/darshan-util/pydarshan/tests/input/__init__.py
+++ b/darshan-util/pydarshan/tests/input/__init__.py
@@ -6,6 +6,8 @@ def installed_path(filename):
 
 test_data_files_dxt = {
     "sample-dxt-simple.darshan": installed_path("sample-dxt-simple.darshan"),
-    "sample-badost.darshan": installed_path("sample-badost.darshan")
 }
 
+test_data_files = {
+    "sample-badost.darshan": installed_path("sample-badost.darshan")
+}

--- a/darshan-util/pydarshan/tests/input/__init__.py
+++ b/darshan-util/pydarshan/tests/input/__init__.py
@@ -6,5 +6,6 @@ def installed_path(filename):
 
 test_data_files_dxt = {
     "sample-dxt-simple.darshan": installed_path("sample-dxt-simple.darshan"),
+    "sample-badost.darshan": installed_path("sample-badost.darshan")
 }
 


### PR DESCRIPTION
* Add `sample-badost.darshan` to `test_data_files_dxt` since it
contains `LUSTRE` records

* Add `sample-badost.darshan` to `time_record_collection_to_df`
benchmark so the `LUSTRE` record performance can be probed
more accurately