### PR TITLE
ENH: Add `DXT_MPIIO` heat map to Darshan Summary Report

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -312,9 +312,6 @@ class ReportData:
         ############################
         ## Add the DXT heat map(s)
         ############################
-        # initialize binary to determine when to include
-        # DXT tracing disabled message/error
-        no_dxt_mods_present = True
         # if either or both modules are present, register their figures
         hmap_description = (
             "Heat map of I/O (in bytes) over time broken down by MPI rank. "
@@ -324,21 +321,18 @@ class ReportData:
             "horizontal bar graph sums all I/O events for each rank to "
             "illustrate how the I/O was distributed across ranks."
         )
-        for mod in ["DXT_POSIX", "DXT_MPIIO"]:
-            if mod in self.report.modules:
-                dxt_heatmap_fig = ReportFigure(
-                    section_title="I/O Operations",
-                    fig_title=f"Heat Map: {mod}",
-                    fig_func=plot_dxt_heatmap.plot_heatmap,
-                    fig_args=dict(report=self.report, mod=mod),
-                    fig_description=hmap_description,
-                )
-                self.figures.append(dxt_heatmap_fig)
-                no_dxt_mods_present = False
-
-        # if neither DXT module is available, add message explaining
-        # how to enable DXT tracing
-        if no_dxt_mods_present:
+        if "DXT" in "\t".join(self.report.modules):
+            for mod in ["DXT_POSIX", "DXT_MPIIO"]:
+                if mod in self.report.modules:
+                    dxt_heatmap_fig = ReportFigure(
+                        section_title="I/O Operations",
+                        fig_title=f"Heat Map: {mod}",
+                        fig_func=plot_dxt_heatmap.plot_heatmap,
+                        fig_args=dict(report=self.report, mod=mod),
+                        fig_description=hmap_description,
+                    )
+                    self.figures.append(dxt_heatmap_fig)
+        else:
             # temporary message to direct users to DXT tracing
             # documentation until DXT tracing is enabled by default
             url = (

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -310,43 +310,54 @@ class ReportData:
         self.figures = []
 
         ############################
-        ## Add the DXT heat map
+        ## Add the DXT heat map(s)
         ############################
-        if "DXT_POSIX" in self.report.modules:
-            hmap_func = plot_dxt_heatmap.plot_heatmap
-            hmap_args = dict(report=self.report)
-            hmap_description = (
-                "Heat map of I/O (in bytes) over time broken down by MPI rank. "
-                "Bins are populated based on the number of bytes read/written in "
-                "the given time interval. The vertical bar graph sums each time "
-                "slice across all ranks to show the total I/O over time, while the "
-                "horizontal bar graph sums all I/O events for each rank to "
-                "illustrate how the I/O was distributed across ranks."
-            )
-        else:
-            hmap_func = None
-            hmap_args = None
+        # initialize binary to determine when to include
+        # DXT tracing disabled message/error
+        no_dxt_mods_present = True
+        # if either or both modules are present, register their figures
+        hmap_description = (
+            "Heat map of I/O (in bytes) over time broken down by MPI rank. "
+            "Bins are populated based on the number of bytes read/written in "
+            "the given time interval. The vertical bar graph sums each time "
+            "slice across all ranks to show the total I/O over time, while the "
+            "horizontal bar graph sums all I/O events for each rank to "
+            "illustrate how the I/O was distributed across ranks."
+        )
+        for mod in ["DXT_POSIX", "DXT_MPIIO"]:
+            if mod in self.report.modules:
+                dxt_heatmap_fig = ReportFigure(
+                    section_title="I/O Operations",
+                    fig_title=f"Heat Map: {mod}",
+                    fig_func=plot_dxt_heatmap.plot_heatmap,
+                    fig_args=dict(report=self.report, mod=mod),
+                    fig_description=hmap_description,
+                )
+                self.figures.append(dxt_heatmap_fig)
+                no_dxt_mods_present = False
+
+        # if neither DXT module is available, add message explaining
+        # how to enable DXT tracing
+        if no_dxt_mods_present:
             # temporary message to direct users to DXT tracing
             # documentation until DXT tracing is enabled by default
             url = (
                 "https://www.mcs.anl.gov/research/projects/darshan/docs/darshan"
                 "-runtime.html#_using_the_darshan_extended_tracing_dxt_module"
             )
-            hmap_description = (
+            temp_message = (
                 f"Heat map is not available for this job as DXT was not "
                 f"enabled at run time. For details on how to enable DXT visit "
                 f"the <a href={url}>Darshan-runtime documentation</a>."
             )
-
-        dxt_heatmap_params = {
-            "section_title": "I/O Operations",
-            "fig_title": "Heat Map",
-            "fig_func": hmap_func,
-            "fig_args": hmap_args,
-            "fig_description": hmap_description,
-        }
-        dxt_heatmap_fig = ReportFigure(**dxt_heatmap_params)
-        self.figures.append(dxt_heatmap_fig)
+            fig = ReportFigure(
+                section_title="I/O Operations",
+                fig_title="Heat Map",
+                fig_func=None,
+                fig_args=None,
+                fig_description=temp_message,
+            )
+            self.figures.append(fig)
 
     def build_sections(self):
         """

--- a/darshan-util/pydarshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/tests/test_summary.py
@@ -98,6 +98,18 @@ def test_main_without_args(tmpdir, argv):
                 # verify the HTML file was generated
                 assert os.path.exists(expected_save_path)
 
+                # verify DXT figures are present for each DXT module
+                report = darshan.DarshanReport(filename=argv[0], read_all=False)
+                with open(expected_save_path) as html_report:
+                    report_str = html_report.read()
+                    if "DXT" in "\t".join(report.modules):
+                        for dxt_mod in ["DXT_POSIX", "DXT_MPIIO"]:
+                            if dxt_mod in report.modules:
+                                assert f"Heat Map: {dxt_mod}" in report_str
+                    else:
+                        # check that help message is present
+                        assert "Heat map is not available for this job" in report_str
+
         else:
             # if no log path is given expect a runtime error
             # due to a failure to open the file
@@ -127,6 +139,17 @@ def test_main_all_logs_repo_files(tmpdir, log_repo_files):
                 # verify the HTML file was generated
                 assert os.path.exists(expected_save_path)
 
+                # verify DXT figures are present for each DXT module
+                report = darshan.DarshanReport(log_filepath, read_all=False)
+                with open(expected_save_path) as html_report:
+                    report_str = html_report.read()
+                    if "DXT" in "\t".join(report.modules):
+                        for dxt_mod in ["DXT_POSIX", "DXT_MPIIO"]:
+                            if dxt_mod in report.modules:
+                                assert f"Heat Map: {dxt_mod}" in report_str
+                    else:
+                        # check that help message is present
+                        assert "Heat map is not available for this job" in report_str
 
 class TestReportData:
 


### PR DESCRIPTION
* Adjust `DXT_POSIX` heat map figure registration to incorporate
`DXT_MPIIO` such that either/both will be plotted when present

* Change logic such that DXT help message will only
be displayed if no DXT modules are present

* Fixes issue #538