### PR TITLE
WIP, ENH: Add I/O cost figure to Darshan Summary Report

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -16,7 +16,7 @@ from mako.template import Template
 
 import darshan
 import darshan.cli
-from darshan.experimental.plots import plot_dxt_heatmap
+from darshan.experimental.plots import plot_dxt_heatmap, plot_io_cost
 
 darshan.enable_experimental()
 
@@ -352,6 +352,31 @@ class ReportData:
                 fig_description=temp_message,
             )
             self.figures.append(fig)
+
+        ################################
+        ## Cross-Module Comparisons
+        ################################
+
+        # add the I/O cost stacked bar graph
+        url = "https://www.mcs.anl.gov/research/projects/darshan/docs/darshan-util.html"
+
+        io_cost_description = (
+            f"Average runtime (across all processes) spent in I/O operations, "
+            f"broken down by process type (i.e. read, write, meta). Meant to "
+            f"illustrate roughly what percentage of the total runtime is spent "
+            f"in I/O operations. For module-specific details visit the "
+            f"<a href={url}>Darshan-util documentation</a>."
+        )
+        io_cost_params = {
+            "section_title": "Cross-Module Comparisons",
+            "fig_title": "I/O Cost",
+            "fig_func": plot_io_cost,
+            "fig_args": dict(report=self.report),
+            "fig_description": io_cost_description,
+            "fig_width": 350,
+        }
+        io_cost_fig = ReportFigure(**io_cost_params)
+        self.figures.append(io_cost_fig)
 
     def build_sections(self):
         """

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -135,4 +135,5 @@ def plot_io_cost(report: darshan.DarshanReport) -> Any:
     # adjust the figure to reduce white space
     io_cost_fig.subplots_adjust(right=0.59)
     io_cost_fig.tight_layout()
+    plt.close()
     return io_cost_fig

--- a/darshan-util/pydarshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/tests/test_summary.py
@@ -111,11 +111,7 @@ def test_main_without_args(tmpdir, argv, expected_img_count):
                         assert "Heat map is not available for this job" in report_str
 
                     # check that expected number of figures are found
-                    actual_img_count = 0
-                    for txt in report_str.split():
-                        if "img" in txt:
-                            actual_img_count += 1
-                    assert actual_img_count == expected_img_count
+                    assert report_str.count("img") == expected_img_count
 
                     # check if I/O cost figure is present
                     for mod in report.modules:

--- a/darshan-util/pydarshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/tests/test_summary.py
@@ -69,15 +69,15 @@ def test_main_with_args(tmpdir, argv):
 
 
 @pytest.mark.parametrize(
-    "argv", [
-        [os.path.abspath("./tests/input/noposix.darshan")],
-        [os.path.abspath("./tests/input/noposix.darshan"), "--output=test.html"],
-        [os.path.abspath("./tests/input/sample-dxt-simple.darshan")],
-        [os.path.abspath("./tests/input/sample-dxt-simple.darshan"), "--output=test.html"],
-        [None],
+    "argv, expected_img_count", [
+        ([os.path.abspath("./tests/input/noposix.darshan")], 1),
+        ([os.path.abspath("./tests/input/noposix.darshan"), "--output=test.html"], 1),
+        ([os.path.abspath("./tests/input/sample-dxt-simple.darshan")], 3),
+        ([os.path.abspath("./tests/input/sample-dxt-simple.darshan"), "--output=test.html"], 3),
+        ([None], 0),
     ]
 )
-def test_main_without_args(tmpdir, argv):
+def test_main_without_args(tmpdir, argv, expected_img_count):
     # test summary.main() by running it without a parser
 
     with mock.patch("sys.argv", [""] + argv):
@@ -110,6 +110,17 @@ def test_main_without_args(tmpdir, argv):
                         # check that help message is present
                         assert "Heat map is not available for this job" in report_str
 
+                    # check that expected number of figures are found
+                    actual_img_count = 0
+                    for txt in report_str.split():
+                        if "img" in txt:
+                            actual_img_count += 1
+                    assert actual_img_count == expected_img_count
+
+                    # check if I/O cost figure is present
+                    for mod in report.modules:
+                        if mod in ["POSIX", "MPI-IO", "STDIO"]:
+                            assert "I/O Cost" in report_str
         else:
             # if no log path is given expect a runtime error
             # due to a failure to open the file
@@ -150,6 +161,11 @@ def test_main_all_logs_repo_files(tmpdir, log_repo_files):
                     else:
                         # check that help message is present
                         assert "Heat map is not available for this job" in report_str
+
+                    # check if I/O cost figure is present
+                    for mod in report.modules:
+                        if mod in ["POSIX", "MPI-IO", "STDIO"]:
+                            assert "I/O Cost" in report_str
 
 class TestReportData:
 


### PR DESCRIPTION
* Add I/O cost figure into new report
section "Cross-Module Comparisons"

* Add `plt.close()` to `plot_io_cost()`
so figures are properly closed

* Add checks to tests `test_summary.test_main_without_args()`
and `test_summary.test_main_all_logs_repo_files()` to ensure
I/O cost figures are being generated when the relevant modules
are present in the report

* Add check to `test_summary.test_main_without_args()` which
counts the number of `img` tags in the HTML report to regression
guard the figure counts in the reports

* Contributes to #465