### PR TITLE
Add dtype deprecations warnings to DarshanReport

### DIFF
--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -20,6 +20,8 @@ import pandas as pd
 
 import collections.abc
 
+import warnings
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -314,7 +316,11 @@ class DarshanReport(object):
         self.filename = filename
 
         # Behavioral Options
+        if dtype is not None:
+            warnings.warn('The use of dtype in reports is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
         self.dtype = dtype                                  # default dtype to return when viewing records
+
         self.automatic_summary = automatic_summary
         self.lookup_name_records = lookup_name_records
 
@@ -522,6 +528,9 @@ class DarshanReport(object):
             None
         """
 
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
         self.read_all_generic_records(dtype=dtype)
         self.read_all_dxt_records(dtype=dtype)
         if "LUSTRE" in self.data['modules']:
@@ -545,6 +554,9 @@ class DarshanReport(object):
             None
         """
 
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
         dtype = dtype if dtype else self.dtype
 
         for mod in self.data['modules']:
@@ -562,6 +574,9 @@ class DarshanReport(object):
         Return:
             None
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
 
         dtype = dtype if dtype else self.dtype
 
@@ -582,6 +597,10 @@ class DarshanReport(object):
             None
 
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
         unsupported =  ['DXT_POSIX', 'DXT_MPIIO', 'LUSTRE', 'APMPI', 'APXC']
 
         if mod in unsupported:
@@ -660,6 +679,10 @@ class DarshanReport(object):
             None
 
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
         if mod not in self.data['modules']:
             if warnings:
                 logger.warning(f" Skipping. Log does not contain data for mod: {mod}")
@@ -710,6 +733,11 @@ class DarshanReport(object):
             None
 
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
+
         if mod not in self.data['modules']:
             if warnings:
                 logger.warning(f" Skipping. Log does not contain data for mod: {mod}")
@@ -759,6 +787,11 @@ class DarshanReport(object):
             None
 
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
+
         if mod not in self.data['modules']:
             if warnings:
                 logger.warning(f" Skipping. Log does not contain data for mod: {mod}")
@@ -814,6 +847,11 @@ class DarshanReport(object):
             None
 
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
+
         if mod not in self.data['modules']:
             if warnings:
                 logger.warning(f" Skipping. Log does not contain data for mod: {mod}")
@@ -901,6 +939,11 @@ class DarshanReport(object):
             None
 
         """
+
+        if dtype is not None:
+            warnings.warn('The use dtype argument is deprecated in v3.3.2 and will be removed in v3.4.x', DeprecationWarning, stacklevel=2)
+
+
         cn = backend.counter_names(mod)
         fcn = backend.fcounter_names(mod)
 


### PR DESCRIPTION
As discussed in #540 this pull request only adds deprecation warnings to discourage the use of dtype as an argument to pydarshan DarshanReports. In a second pull request changes that actually deprecate the feature are 

- [ ] Check testing
- [ ] Discuss when this actually lands and deprecates dtype
- [ ] Consider adding alternative recommendation (to_df, to_x) to warning message