### PR TITLE
MAINT: Plot multiple modules in single IO cost plot

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -52,7 +52,7 @@ def get_by_avg_series(df: Any, mod_key: str, nprocs: int) -> Any:
     return by_avg_series
 
 
-def get_io_cost_df(report: darshan.DarshanReport, mod_key: str) -> Any:
+def get_io_cost_df(report: darshan.DarshanReport) -> Any:
     """
     Generates the I/O cost dataframe which contains the
     raw data to plot the I/O cost stacked bar graph.
@@ -61,32 +61,39 @@ def get_io_cost_df(report: darshan.DarshanReport, mod_key: str) -> Any:
     ----------
     report: a ``darshan.DarshanReport``.
 
-    mod_key: module to generate the I/O cost stacked
-    bar graph for (i.e. "POSIX", "MPI-IO", "STDIO").
-
     Returns
     -------
     io_cost_df: a ``pd.DataFrame`` containing the
     average read, write, and meta times.
 
     """
-    # collect the records in dataframe form
-    recs = report.records[mod_key].to_df(attach=["rank"])
-    # correct the MPI module key
-    if mod_key == "MPI-IO":
-        mod_key = "MPIIO"
-    nprocs = report.metadata["job"]["nprocs"]
-    # collect the data needed for the I/O cost dataframe
-    by_avg_series = get_by_avg_series(df=recs["fcounters"], mod_key=mod_key, nprocs=nprocs)
+    io_cost_dict = {}
+    # TODO: expand the scope of this function
+    # to include HDF5 module
+    supported_modules = ["POSIX", "MPI-IO", "STDIO"]
+    for mod_key in report.modules:
+        if mod_key in supported_modules:
+            # collect the records in dataframe form
+            recs = report.records[mod_key].to_df(attach=["rank"])
+            # correct the MPI module key
+            if mod_key == "MPI-IO":
+                mod_key = "MPIIO"
+            nprocs = report.metadata["job"]["nprocs"]
+            # collect the data needed for the I/O cost dataframe
+            io_cost_dict[mod_key] = get_by_avg_series(
+                df=recs["fcounters"],
+                mod_key=mod_key,
+                nprocs=nprocs,
+                )
 
     # construct the I/O cost dataframe with
     # appropriate labels for each series
     # TODO: add the "by-slowest" category
-    io_cost_df = pd.DataFrame({"by-average": by_avg_series}).T
+    io_cost_df = pd.DataFrame(io_cost_dict).T
     return io_cost_df
 
 
-def plot_io_cost(report: darshan.DarshanReport, mod_key: str) -> Any:
+def plot_io_cost(report: darshan.DarshanReport) -> Any:
     """
     Creates a stacked bar graph illustrating the percentage of
     runtime spent in read, write, and metadata operations.
@@ -95,24 +102,12 @@ def plot_io_cost(report: darshan.DarshanReport, mod_key: str) -> Any:
     ----------
     report: a ``darshan.DarshanReport``.
 
-    mod_key: module to generate the I/O cost stacked
-    bar graph for (i.e. "POSIX", "MPI-IO", "STDIO").
-
     Returns
     -------
     io_cost_fig: a ``matplotlib.pyplot.figure`` object containing a
     stacked bar graph of the average read, write, and metadata times.
 
-    Raises
-    ------
-    NotImplementedError: raised if the input module key is not "POSIX",
-    "MPI-IO", or "STDIO".
-
     """
-    if mod_key not in ["POSIX", "MPI-IO", "STDIO"]:
-        # TODO: expand the scope of this function
-        # to include HDF5 module
-        raise NotImplementedError(f"{mod_key} module is not supported.")
     # calculate the run time from the report metadata
     runtime = report.metadata["job"]["end_time"] - report.metadata["job"]["start_time"]
     if runtime == 0:
@@ -120,7 +115,7 @@ def plot_io_cost(report: darshan.DarshanReport, mod_key: str) -> Any:
         # to 1 like the original perl code
         runtime = 1
     # get the I/O cost dataframe
-    io_cost_df = get_io_cost_df(report=report, mod_key=mod_key)
+    io_cost_df = get_io_cost_df(report=report)
     # generate a figure with 2 y axes
     io_cost_fig = plt.figure(figsize=(4.5, 4))
     ax_raw = io_cost_fig.add_subplot(111)
@@ -142,7 +137,7 @@ def plot_io_cost(report: darshan.DarshanReport, mod_key: str) -> Any:
     # add the legend and appropriate labels
     ax_raw.set_ylabel("Runtime (s)")
     handles, labels = ax_raw.get_legend_handles_labels()
-    ax_norm.legend(handles[::-1], labels[::-1], loc="upper left", bbox_to_anchor=(1.3, 1.02))
+    ax_norm.legend(handles[::-1], labels[::-1], loc="upper left", bbox_to_anchor=(1.22, 1.02))
     # adjust the figure to reduce white space
     io_cost_fig.subplots_adjust(right=0.59)
     io_cost_fig.tight_layout()


### PR DESCRIPTION
* Change `plot_io_cost()` to iterate over all supported modules
and plot them in a single figure

* Correct `plot_io_cost()` call signatures and expected data
for `test_plot_io_cost.py` tests `test_get_io_cost_df`,
`test_plot_io_cost_ylims`, and `test_plot_io_cost_y_ticks_and_labels`

* Replace `by-average` x-axis label with module names

* Fixes #574