### PR TITLE
Ensure files are closed when destructing report objects.

### DIFF
--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -1073,7 +1073,7 @@ class DarshanReport(object):
         self._cleanup()
 
 
-    def __enter(self):
+    def __enter__(self):
         """ Satisfy API for use with context manager (e.g., with-statement) """
         pass
 

--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -1058,6 +1058,25 @@ class DarshanReport(object):
         return json.dumps(data, cls=DarshanReportJSONEncoder)
 
 
+    def _cleanup(self):
+        """
+        Cleanup when deleting object.
+        """
+        # CFFI/C backend needs to be notified that it can close the log file.
+        if self.log is not None:
+            rec = backend.log_close(self.log)
+            self.log = None
 
 
+    def __del__(self):
+        """ Clean up when deleted or garbage collected (e.g., del-statement) """
+        self._cleanup()
 
+
+    def __enter(self):
+        """ Satisfy API for use with context manager (e.g., with-statement) """
+        pass
+
+    def __exit__(self):
+        """ Cleanup when used by context manager (e.g., with-statement) """
+        self._cleanup()

--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -312,6 +312,7 @@ class DarshanReport(object):
 
         """
         self.filename = filename
+        self.log = None
 
         # Behavioral Options
         self.dtype = dtype                                  # default dtype to return when viewing records
@@ -1063,9 +1064,14 @@ class DarshanReport(object):
         Cleanup when deleting object.
         """
         # CFFI/C backend needs to be notified that it can close the log file.
-        if self.log is not None:
-            rec = backend.log_close(self.log)
-            self.log = None
+        try:
+            if self.log is not None:
+                rec = backend.log_close(self.log)
+                self.log = None
+        except AttributeError:
+            # we sometimes observe that i.e., pytest has problems
+            # calling _cleanup() because self.log does not exist
+            pass
 
 
     def __del__(self):

--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -1075,8 +1075,8 @@ class DarshanReport(object):
 
     def __enter__(self):
         """ Satisfy API for use with context manager (e.g., with-statement) """
-        pass
+        return self
 
-    def __exit__(self):
+    def __exit__(self, type, value, traceback):
         """ Cleanup when used by context manager (e.g., with-statement) """
         self._cleanup()

--- a/darshan-util/pydarshan/tests/test_report.py
+++ b/darshan-util/pydarshan/tests/test_report.py
@@ -4,6 +4,7 @@
 """Tests for `pydarshan` package."""
 
 import copy
+import pickle
 
 import pytest
 import numpy as np
@@ -357,3 +358,17 @@ class TestDarshanRecordCollection:
             actual_fct_df = actual_records["fcounters"]
             assert_frame_equal(actual_ct_df, expected_ct_df)
             assert_frame_equal(actual_fct_df, expected_fct_df)
+
+def test_file_closure():
+    # regression test for gh-578
+    with darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan") as report:
+        # you cannot serialize a report object
+        # until after you close its associated
+        # file handle; check that __del__ cleans up
+        # poperly
+        report.__del__()
+        pickle.dumps(report)
+        # let's also check that we can properly exit
+        # context when report.log has been removed
+        # (happens with pytest sometimes)
+        del(report.log)


### PR DESCRIPTION
This might provide some more desirable behavior when working with many logs in a single process such as raised by #578.

This pull requests adds hooks for `__del__`, `__enter__`,`__exit__` to call a cleanup routine to ensure opened log files are also closed when the object is destroyed.