### PR TITLE
BUG: Correct I/O cost figure y limits

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -130,9 +130,8 @@ def plot_io_cost(report: darshan.DarshanReport) -> Any:
     ax_norm.yaxis.set_major_formatter(mtick.PercentFormatter())
     # align both axes tick labels so the grid matches
     # values on both sides of the bar graph
-    norm_yticks = ax_raw.get_yticks()
     n_ticks = len(ax_norm.get_yticks())
-    yticks = np.linspace(norm_yticks[0], norm_yticks[-1], n_ticks)
+    yticks = np.linspace(0, runtime, n_ticks)
     ax_raw.set_yticks(yticks)
     # add the legend and appropriate labels
     ax_raw.set_ylabel("Runtime (s)")

--- a/darshan-util/pydarshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/tests/test_plot_io_cost.py
@@ -53,7 +53,19 @@ def test_get_io_cost_df(report, expected_df):
         ),
         (
             darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
-            [0.0, 800.0],
+            [0.0, 779.0]
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/dxt.darshan"),
+            [0.0, 1468.0],
+        ),
+        (
+            darshan.DarshanReport("examples/example-logs/noposix.darshan"),
+            [0.0, 39212.0],
+        ),
+        (
+            darshan.DarshanReport("tests/input/noposixopens.darshan"),
+            [0.0, 1110.0],
         ),
     ],
 )
@@ -79,7 +91,7 @@ def test_plot_io_cost_ylims(report, expected_ylims):
         ),
         (
             darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
-            [0, 160, 320, 480, 640, 800],
+            [0.0, 155.8, 311.6, 467.4, 623.2, 779.0],
         ),
     ],
 )

--- a/darshan-util/pydarshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/tests/test_plot_io_cost.py
@@ -53,7 +53,7 @@ def test_get_io_cost_df(report, expected_df):
         ),
         (
             darshan.DarshanReport("examples/example-logs/sample-badost.darshan"),
-            [0.0, 779.0]
+            [0.0, 779.0],
         ),
         (
             darshan.DarshanReport("examples/example-logs/dxt.darshan"),


### PR DESCRIPTION
* Update y-axis ticks for I/O cost figure to have a maximum
value of the runtime calculated from the log metadata

* Correct and add new cases for test `test_plot_io_cost_ylims`
to regression guard against future y limit changes

* Correct test `test_plot_io_cost_y_ticks_and_labels`

* Fixes #591