### PR TITLE
BUG: Fix `plot_io_cost()` calculation

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -35,20 +35,15 @@ def get_by_avg_series(df: Any, mod_key: str, nprocs: int) -> Any:
     """
     # filter out all except the following columns
     cols = [
-        "rank",
         f"{mod_key}_F_READ_TIME",
         f"{mod_key}_F_WRITE_TIME",
         f"{mod_key}_F_META_TIME",
     ]
     df = df.filter(cols, axis=1)
-    # locate any rows where "rank" == -1 and divide them by nprocs
-    df.loc[df["rank"] == -1] /= nprocs
-    # drop the "rank" column since it's no longer needed
-    df.drop("rank", axis=1, inplace=True)
     # rename the columns so the labels are automatically generated when plotting
-    name_dict = {cols[1]: "Read", cols[2]: "Write", cols[3]: "Meta"}
+    name_dict = {cols[0]: "Read", cols[1]: "Write", cols[2]: "Meta"}
     df.rename(columns=name_dict, inplace=True)
-    by_avg_series = df.mean(axis=0)
+    by_avg_series = df.sum(axis=0) / nprocs
     return by_avg_series
 
 
@@ -74,7 +69,7 @@ def get_io_cost_df(report: darshan.DarshanReport) -> Any:
     for mod_key in report.modules:
         if mod_key in supported_modules:
             # collect the records in dataframe form
-            recs = report.records[mod_key].to_df(attach=["rank"])
+            recs = report.records[mod_key].to_df(attach=None)
             # correct the MPI module key
             if mod_key == "MPI-IO":
                 mod_key = "MPIIO"

--- a/darshan-util/pydarshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/tests/test_plot_io_cost.py
@@ -18,9 +18,9 @@ from darshan.experimental.plots.plot_io_cost import (
             darshan.DarshanReport("examples/example-logs/ior_hdf5_example.darshan"),
             pd.DataFrame(
                 np.array([
-                    [0.0196126699, 0.134203, 0.0074423551],
-                    [0.0196372866, 0.134251, 0.0475],
-                    [0.0, 0.0001022815, 0.0],
+                    [0.0196126699, 0.1342029571533203, 0.0074423551],
+                    [0.0196372866, 0.13425052165985107, 0.0475],
+                    [0.0, 2.5570392608642578e-05, 0.0],
                 ]),
                 ["POSIX", "MPIIO", "STDIO"],
                 ["Read", "Write", "Meta"],
@@ -31,7 +31,7 @@ from darshan.experimental.plots.plot_io_cost import (
             pd.DataFrame(
                 np.array([
                     [0.0, 33.48587587394286, 0.5547398688504472],
-                    [0.0037345244005943337, 1.544055218497912e-07, 0.045062407424362995],
+                    [0.011203573201783001, 4.632166e-07, 0.135187],
                 ]),
                 ["POSIX", "STDIO"],
                 ["Read", "Write", "Meta"],
@@ -128,16 +128,16 @@ def test_plot_io_cost_y_ticks_and_labels(report, expected_yticks):
         "POSIX",
         pd.DataFrame(
             data=[
-                [0, 0, 1, 10, 3],
-                [1, 12, 5, 20, 3]
+                [0, 1, 10, 3],
+                [12, 5, 20, 3]
             ],
             columns=[
-                "rank", "POSIX_F_READ_TIME", "POSIX_F_WRITE_TIME",
+                "POSIX_F_READ_TIME", "POSIX_F_WRITE_TIME",
                 "POSIX_F_META_TIME", "TEST"
             ],
         ),
         pd.Series(
-            data=[6.0, 3.0, 15.0],
+            data=[1.2, .6, 3.0],
             index=["Read", "Write", "Meta"],
         ),
     ),
@@ -148,10 +148,10 @@ def test_plot_io_cost_y_ticks_and_labels(report, expected_yticks):
         "STDIO",
         pd.DataFrame(
             data=[
-                [-1, 30000, 3000, 300, 10],
+                [30000, 3000, 300, 10],
             ],
             columns=[
-                "rank", "STDIO_F_READ_TIME", "STDIO_F_WRITE_TIME",
+                "STDIO_F_READ_TIME", "STDIO_F_WRITE_TIME",
                 "STDIO_F_META_TIME", "TEST"
             ],
         ),
@@ -166,17 +166,17 @@ def test_plot_io_cost_y_ticks_and_labels(report, expected_yticks):
         "MPIIO",
         pd.DataFrame(
             data=[
-                [0, 0, 1, 10, 3],
-                [1, 12, 5, 20, 3],
-                [-1, 30000, 3000, 300, 10],
+                [0, 1, 10, 3],
+                [12, 5, 20, 3],
+                [30000, 3000, 300, 10],
             ],
             columns=[
-                "rank", "MPIIO_F_READ_TIME", "MPIIO_F_WRITE_TIME",
+                "MPIIO_F_READ_TIME", "MPIIO_F_WRITE_TIME",
                 "MPIIO_F_META_TIME", "TEST"
             ],
         ),
         pd.Series(
-            data=[1004.0, 102.0, 20.0],
+            data=[3001.2, 300.6, 33.0],
             index=["Read", "Write", "Meta"],
         ),
     )

--- a/darshan-util/pydarshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/tests/test_plot_io_cost.py
@@ -185,3 +185,29 @@ def test_get_by_avg_series(mod_key, input_df, expected_series):
     # unit test for `plot_io_cost.get_by_avg_series`
     actual_series = get_by_avg_series(df=input_df, mod_key=mod_key, nprocs=10)
     assert_series_equal(actual_series, expected_series)
+
+
+@pytest.mark.skipif(not pytest.has_log_repo, # type: ignore
+                    reason="missing darshan_logs")
+@pytest.mark.parametrize(
+    "filename, expected_df",
+    [
+        (
+            "nonmpi_partial_modules.darshan",
+            pd.DataFrame(
+                np.array([
+                    [0.281718, 0.504260, 0.170138],
+                    [0.232386, 0.165982, 0.072751],
+                ]),
+                ["POSIX", "STDIO"],
+                ["Read", "Write", "Meta"],
+            ),
+        ),
+    ])
+def test_issue_590(select_log_repo_file, expected_df):
+    # regression test for issue #590
+    # see: https://github.com/darshan-hpc/darshan/issues/590
+    log_path = select_log_repo_file
+    report = darshan.DarshanReport(log_path)
+    actual_df = get_io_cost_df(report=report)
+    assert_frame_equal(actual_df, expected_df)


### PR DESCRIPTION
* Correct the calculation in `plot_io_cost.get_by_avg_series()`
to remove the division by number of records

* Remove "ranks" column attachment and downstream
code since it is no longer necessary

* Fix tests `test_get_io_cost_df` and `test_get_by_avg_series`
to reflect changes in I/O cost calculations

* Close #590