### PR TITLE
add missing stdatomic autoconf test

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -484,7 +484,7 @@ if test "x$enable_darshan_runtime" = xyes ; then
    AC_CHECK_TYPES([off64_t])
    CFLAGS="$old_cflags"
 
-   AC_CHECK_HEADERS(mntent.h sys/mount.h)
+   AC_CHECK_HEADERS(mntent.h sys/mount.h stdatomic.h)
 
    # check for availablity of rdtscp intrinsic on this platform
    # NOTE: we only care about finding the gnu compiler intrinsic for use in

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -171,9 +171,6 @@ static void darshan_core_cleanup(
     struct darshan_core_runtime* core);
 static void darshan_core_fork_child_cb(void);
 
-#define DARSHAN_CORE_LOCK() pthread_mutex_lock(&darshan_core_mutex)
-#define DARSHAN_CORE_UNLOCK() pthread_mutex_unlock(&darshan_core_mutex)
-
 #define DARSHAN_WARN(__err_str, ...) do { \
     darshan_core_fprintf(stderr, "darshan_library_warning: " \
         __err_str ".\n", ## __VA_ARGS__); \


### PR DESCRIPTION
- also remove unused (deprecated) DARSHAN_CORE_LOCK() macros that have
  been replaced with __DARSHAN_CORE_LOCK() in the code

Fixes #604 