### PR TITLE
BUG, BENCH: fix time_plot_heatmap_builtin_logs

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
@@ -3,6 +3,7 @@ import importlib
 
 import pandas as pd
 
+import darshan
 from darshan.experimental.plots import plot_dxt_heatmap, heatmap_handling
 # TODO: no good reason pydarshan should have hyphenated module
 # names... for now I hack around it...
@@ -29,6 +30,7 @@ class PlotDXTHeatMapSmall:
             self.logfile = example_logs.example_data_files_dxt[filename]
         else:
             self.logfile = test_data_files_dxt[filename]
+        self.report = darshan.DarshanReport(self.logfile)
 
     def time_plot_heatmap_builtin_logs(self, darshan_logfile, xbins):
         # benchmark DXT heatmap plotting for
@@ -36,8 +38,8 @@ class PlotDXTHeatMapSmall:
         # repo proper--these are likely to be quite
         # small for the most part
         plot_dxt_heatmap.plot_heatmap(
-            log_path=self.logfile,
-            mods=["DXT_POSIX"],
+            report=self.report,
+            mod="DXT_POSIX",
             ops=["read", "write"],
             xbins=xbins)
 


### PR DESCRIPTION
Fixes #586 

* fix the call signature of `plot_heatmap()` in
`time_plot_heatmap_builtin_logs()` so that the
benchmark no longer fails

* locally, ` asv run -e -b "time_plot_heatmap_builtin_logs"`:

```
· Creating environments
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] · For pydarshan commit 6d0a48e0 <pydarshan-devel>:
[  0.00%] ·· Benchmarking virtualenv-py3.9-cffi-numpy-pytest
[ 50.00%] ··· Running (dxt_heatmap.PlotDXTHeatMapSmall.time_plot_heatmap_builtin_logs--).
[100.00%] ··· dxt_heatmap.PlotDXTHeatMapSmall.time_plot_heatmap_builtin_logs                                                                                                                                                                                                                                              ok
[100.00%] ··· ================================================ ========= ========== ============
              --                                                             xbins              
              ------------------------------------------------ ---------------------------------
                              darshan_logfile                      10       100         1000    
              ================================================ ========= ========== ============
               examples/example-logs/ior_hdf5_example.darshan   354±2ms   510±30ms   1.20±0.03s 
                     examples/example-logs/dxt.darshan          352±6ms   471±3ms    1.19±0.01s 
                   tests/input/sample-dxt-simple.darshan        307±4ms   416±6ms    1.10±0.03s 
              ================================================ ========= ========== ============
```