### PR TITLE
BENCH: asv benchmark for get_log_path()

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/log_utils.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/log_utils.py
@@ -1,0 +1,22 @@
+from darshan.log_utils import get_log_path
+
+
+class GetLogPath:
+    params = [[1, 10, 25], ["dxt.darshan"]]
+    param_names = ["num_calls", "filename"]
+    # TODO: when logs repo is available from
+    # asv, use an example file from there
+    
+    # Alternatively, could "mock" the presence of
+    # the logs repo and i.e., parametrize over
+    # an increasing number of "synthetic" dirs/log
+    # files
+
+
+    def time_get_log_path_repeat(self, num_calls, filename):
+        # it is important for get_log_path() to
+        # be fast on repeat calls because this mimics
+        # heavy usage of log file retrieval in pytest
+        # runs
+        for i in range(num_calls):
+            get_log_path(filename)


### PR DESCRIPTION
Related to some concerns in gh-606.

* add a benchmark for repeated calls to `get_log_path()`,
which is a situation likely to arise in the context of the
full `pytest` suite where many log files are retrieved

* benchmark runs in 42 seconds locally:

`time asv run -e -b "time_get_log_path_repeat"`

```
· Creating environments
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] · For pydarshan commit 6d0a48e0 <pydarshan-devel>:
[  0.00%] ·· Benchmarking virtualenv-py3.9-cffi-numpy-pytest
[ 50.00%] ··· Running (log_utils.GetLogPath.time_get_log_path_repeat--).
[100.00%] ··· log_utils.GetLogPath.time_get_log_path_repeat
ok
[100.00%] ··· =========== =============
              --             filename
              ----------- -------------
               num_calls   dxt.darshan
              =========== =============
                   1        97.5±0.8ms
                   10        972±8ms
                   25       2.43±0.02s
              =========== =============

asv run -e -b "time_get_log_path_repeat"  19.79s user 30.18s system 116%
cpu 42.835 total
```