### PR TITLE
ENH: faster get_log_path()

### DIFF
--- a/darshan-util/pydarshan/darshan/log_utils.py
+++ b/darshan-util/pydarshan/darshan/log_utils.py
@@ -12,6 +12,7 @@ else:
     # see: https://github.com/python/mypy/issues/1153
     import importlib.resources as importlib_resources # type: ignore
 
+import functools
 import sys
 import os
 import glob
@@ -31,8 +32,8 @@ except ImportError:
     has_log_repo = False
 
 
-def _locate_log(filename: str, project: str) -> Optional[str]:
-    """Locates a log in a project."""
+@functools.lru_cache(maxsize=4)
+def _produce_log_dict(project):
     p = importlib_resources.files(project) # type: Any
     if project == "darshan":
         # move up 1 directory for now
@@ -40,12 +41,17 @@ def _locate_log(filename: str, project: str) -> Optional[str]:
         # the pydarshan package and/or start shifting
         # more files to the logs repo
         p = p.parent
-    darshan_logs_paths = [str(p) for p in p.glob('**/*.darshan')]
-    for log_path in darshan_logs_paths:
-        if filename in log_path:
-            return log_path
-    # if log is not found
-    return None
+    darshan_log_dict = {p.name:str(p) for p in p.glob('**/*.darshan')}
+    return darshan_log_dict
+
+
+def _locate_log(filename: str, project: str) -> Optional[str]:
+    """Locates a log in a project."""
+    try:
+        path =  _produce_log_dict(project)[filename]
+        return path
+    except KeyError:
+        return None
 
 def get_log_path(filename: str) -> str:
     """

--- a/darshan-util/pydarshan/darshan/log_utils.py
+++ b/darshan-util/pydarshan/darshan/log_utils.py
@@ -48,7 +48,7 @@ def _produce_log_dict(project):
 def _locate_log(filename: str, project: str) -> Optional[str]:
     """Locates a log in a project."""
     try:
-        path =  _produce_log_dict(project)[filename]
+        path = _produce_log_dict(project)[filename]
         return path
     except KeyError:
         return None


### PR DESCRIPTION
Related to gh-606.

* this is a precursor to using `get_log_path()` ubiquitously
in the test suite, which itself is a precursor to being
able to run the test suite from any directory (including
a user/developer with a `spack` install of `py-darshan`, which
is our primary planned vehicle for initial delivery of the new
report capability)

* achieve nearly constant-time log filepath retrieval
using a dictionary/hash table

* the speedups on repeated calls, the most important scenario
for running in `pytest`, are several orders of magnitude faster using
the new benchmark in gh-610:

`asv continuous pydarshan-devel treddy_get_log_path_dict -e -b
"time_get_log_path_repeat`

```
       before           after         ratio
     [6d0a48e0]       [47e9a462]
     <pydarshan-devel>       <treddy_get_log_path_dict>
-        97.6±2ms        962±100ns     0.00
         log_utils.GetLogPath.time_get_log_path_repeat(1, 'dxt.darshan')
-         974±7ms       3.14±0.1μs     0.00
          log_utils.GetLogPath.time_get_log_path_repeat(10,
'dxt.darshan')
-         2.43±0s       7.31±0.3μs     0.00
          log_utils.GetLogPath.time_get_log_path_repeat(25,
'dxt.darshan')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

* the new tests from gh-609 also seem to pass with this branch,
though it would probably be prudent to review/fix/merge that
first..