### PR TITLE
MAINT: Close dxt heatmap matplotlib figures, add `pytest.ini`

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -428,4 +428,6 @@ def plot_heatmap(
     jgrid.ax_joint.set_xlabel("Time (s)")
     jgrid.ax_joint.set_ylabel("Rank")
 
+    plt.close()
+
     return jgrid

--- a/darshan-util/pydarshan/pytest.ini
+++ b/darshan-util/pydarshan/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+
+filterwarnings =
+    error:More than 20 figures have been opened.:RuntimeWarning


### PR DESCRIPTION
* Fixes issue when running tests where many figures are opened and
not explicitly closed, generating a pytest warning

* Add `pytest.ini` to upgrade `matplotlib`-generated
RuntimeWarnings into errors