### PR TITLE
ENH: Add dataframe/table figure support

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -35,8 +35,8 @@
           % for fig_title, fig in report_data.sections[sect_title].items():
             <h3>${fig_title}</h3>
             <figure style="width: ${fig.fig_width}px;">
-            % if fig.img_str:
-              ${fig.img_str}
+            % if fig.fig_html:
+              ${fig.fig_html}
               <figcaption>${fig.fig_description}</figcaption>
             % else:
               <!-- temporary handling for DXT-disabled cases -->

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -13,12 +13,14 @@ from typing import Any, Union, Callable
 
 import pandas as pd
 from mako.template import Template
-import matplotlib
-import seaborn
 
 import darshan
 import darshan.cli
-from darshan.experimental.plots import plot_dxt_heatmap, plot_io_cost
+from darshan.experimental.plots import (
+    plot_dxt_heatmap,
+    plot_io_cost,
+    plot_common_access_table,
+)
 
 darshan.enable_experimental()
 
@@ -90,20 +92,16 @@ class ReportFigure:
         # generate the figure using the figure's
         # function and function arguments
         fig = self.fig_func(**self.fig_args)
-        supported_mpl_fig_types = [matplotlib.figure.Figure, seaborn.axisgrid.JointGrid]
-        if type(fig) in supported_mpl_fig_types:
+        if hasattr(fig, "savefig"):
             # encode the matplotlib figure
             encoded = self.get_encoded_fig(mpl_fig=fig)
             # create the img string
             self.fig_html = f"<img src=data:image/png;base64,{encoded} alt={self.fig_title} width={self.fig_width}>"
-        elif isinstance(fig, pd.DataFrame):
-            # use built-in pandas utility to convert table to html
-            self.fig_html = fig.to_html(index=False, border=0)
+        elif isinstance(fig, plot_common_access_table.DarshanReportTable):
+            # retrieve html table from `DarshanReportTable`
+            self.fig_html = fig.html
         else:
-            err_msg = (
-                f"Figure of type {type(fig)} not supported. \n"
-                f"Supported figure types: {supported_mpl_fig_types}"
-            )
+            err_msg = f"Figure of type {type(fig)} not supported."
             raise NotImplementedError(err_msg)
 
 class ReportData:

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -98,7 +98,7 @@ class ReportFigure:
             self.fig_html = f"<img src=data:image/png;base64,{encoded} alt={self.fig_title} width={self.fig_width}>"
         elif isinstance(fig, pd.DataFrame):
             # use built-in pandas utility to convert table to html
-            self.fig_html = fig.to_html(header=False, border=0)
+            self.fig_html = fig.to_html(index=False, border=0)
         else:
             err_msg = (
                 f"Figure of type {type(fig)} not supported. \n"

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_common_access_table.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_common_access_table.py
@@ -106,9 +106,25 @@ def get_access_count_df(mod_df: Any, mod: str) -> Any:
     return pd.concat(df_list, axis=1)
 
 
+class DarshanReportTable:
+    """
+    Stores table figures in dataframe and html formats.
+
+    Parameters
+    ----------
+    df: a ``pd.DataFrame``.
+
+    kwargs: keyword arguments passed to ``pd.DataFrame.to_html()``.
+
+    """
+    def __init__(self, df: Any, **kwargs):
+        self.df = df
+        self.html = self.df.to_html(**kwargs)
+
+
 def plot_common_access_table(report: darshan.DarshanReport, mod: str, n_rows: int = 4) -> Any:
     """
-    Creates a dataframe containing the most
+    Creates a table containing the most
     common access sizes and their counts.
 
     Parameters
@@ -122,9 +138,11 @@ def plot_common_access_table(report: darshan.DarshanReport, mod: str, n_rows: in
 
     Returns
     -------
-    common_access_df: a ``pd.DataFrame`` containing the `n_rows` most common
-    access sizes and their counts for the specified module. Table is
-    sorted in descending order based on the access size count.
+    common_access_table: a ``DarshanReportTable`` containing the `n_rows`
+    most common access sizes and their counts for the specified module.
+    The table is sorted in descending order based on the access size count
+    and can be retrieved as either a ``pd.DataFrame`` or html table via
+    the `df` or `html` attributes, respectively.
 
     """
     mod_df = report.records[mod].to_df(attach=None)["counters"]
@@ -135,5 +153,9 @@ def plot_common_access_table(report: darshan.DarshanReport, mod: str, n_rows: in
     df = get_access_count_df(mod_df=mod_df, mod=mod)
     df = remove_nonzero_rows(df=df)
     df = combine_access_sizes(df=df)
-    common_access_df = get_most_common_access_sizes(df=df, n_rows=n_rows)
-    return common_access_df
+    df = get_most_common_access_sizes(df=df, n_rows=n_rows)
+    common_access_table = DarshanReportTable(
+        # remove index labels and remove border
+        df=df, index=False, border=0,
+    )
+    return common_access_table

--- a/darshan-util/pydarshan/darshan/tests/test_plot_common_access_table.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_common_access_table.py
@@ -51,7 +51,7 @@ def test_common_access_table(filename, mod, expected_df):
     log_path = get_log_path(filename=filename)
     expected_df.columns = ["Access Size", "Count"]
     report = darshan.DarshanReport(log_path)
-    actual_df = plot_common_access_table.plot_common_access_table(report=report, mod=mod)
+    actual_df = plot_common_access_table.plot_common_access_table(report=report, mod=mod).df
     assert_frame_equal(actual_df, expected_df)
 
 

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -432,3 +432,23 @@ class TestReportData:
         report = darshan.DarshanReport(get_log_path(logname))
         actual_runtime = summary.ReportData.get_runtime(report=report)
         assert actual_runtime == expected_runtime
+
+
+class TestReportFigure:
+
+    def test_generate_fig_unsupported_fig_type(self):
+        # input figure function that outputs an unsupported figure type
+        # to check an error is raised
+
+        with pytest.raises(NotImplementedError) as err:
+            # initializing a `ReportFigure` automatically calls `generate_fig()`
+            summary.ReportFigure(
+                # create a simple function
+                fig_func=lambda x:x,
+                fig_args=dict(x=1),
+                section_title="Test Section Title",
+                fig_title="Test Figure Title",
+            )
+
+        # verify correct error is being raised
+        assert "Figure of type <class 'int'> not supported." in str(err)


### PR DESCRIPTION
* Update method `generate_img` name to more general `generate_fig`
and update documentation to reflect the changes

* Generalize `generate_fig` to support figure
functions that generate pandas dataframes

* Add test `test_generate_fig_unsupported_fig_type` to
check appropriate error is raised when input function
does not generate the supported figure types

* Add object `DarshanReportTable` to `plot_common_access_table.py`
for storing tables in dataframe and html format. Should set a
standard that allows access for testing but also puts the burden
on the figure function to generate a `DarshanReportTable` that
contains the desired html table for the report.

* Change `plot_common_access_table` to return
`DarshanReportTable` and update documentation

* Fix `test_common_access_table` due to above change

* Fix issue #550