### PR TITLE
ENH: Add common access size table to darshan summary report

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -389,6 +389,28 @@ class ReportData:
         io_cost_fig = ReportFigure(**io_cost_params)
         self.figures.append(io_cost_fig)
 
+        ################################
+        ## Per-Module Statistics
+        ################################
+        for mod in self.report.modules:
+            if mod in ["POSIX", "MPI-IO", "H5D"]:
+                if mod == "MPI-IO":
+                    com_acc_tbl_description = (
+                        "NOTE: MPI-IO accesses are given in "
+                        "terms of aggregate datatype size."
+                    )
+                else:
+                    com_acc_tbl_description = ""
+                com_acc_tbl_fig = ReportFigure(
+                    section_title=f"Per-Module Stats: {mod}",
+                    fig_title="Common Access Sizes",
+                    fig_func=plot_common_access_table.plot_common_access_table,
+                    fig_args=dict(report=self.report, mod=mod),
+                    fig_description=com_acc_tbl_description,
+                    fig_width=350,
+                )
+                self.figures.append(com_acc_tbl_fig)
+
     def build_sections(self):
         """
         Uses figure info to generate the unique sections

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -71,16 +71,16 @@ def test_main_with_args(tmpdir, argv):
 
 
 @pytest.mark.parametrize(
-    "argv, expected_img_count", [
-        (["noposix.darshan"], 1),
-        (["noposix.darshan", "--output=test.html"], 1),
-        (["sample-dxt-simple.darshan"], 3),
-        (["sample-dxt-simple.darshan", "--output=test.html"], 3),
-        (["nonmpi_partial_modules.darshan"], 2),
-        ([None], 0),
+    "argv, expected_img_count, expected_table_count", [
+        (["noposix.darshan"], 1, 2),
+        (["noposix.darshan", "--output=test.html"], 1, 2),
+        (["sample-dxt-simple.darshan"], 3, 4),
+        (["sample-dxt-simple.darshan", "--output=test.html"], 3, 4),
+        (["nonmpi_partial_modules.darshan"], 2, 3),
+        ([None], 0, 0),
     ]
 )
-def test_main_without_args(tmpdir, argv, expected_img_count):
+def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_count):
     # test summary.main() by running it without a parser
     if argv[0] is not None:
         argv[0] = get_log_path(argv[0])
@@ -117,6 +117,12 @@ def test_main_without_args(tmpdir, argv, expected_img_count):
 
                     # check that expected number of figures are found
                     assert report_str.count("img") == expected_img_count
+
+                    # check that the expected number of tables are found
+                    # NOTE: there are 2 "table" tags per table, and 2 other
+                    # instances of the word in each report (1 comment, 1 from CSS)
+                    expected_table_count = 2 * expected_table_count + 2
+                    assert report_str.count("table") == expected_table_count
 
                     # check if I/O cost figure is present
                     for mod in report.modules:


### PR DESCRIPTION
* Add "Per-Module Stats" section to report
containing the common access size table (to start)

* Extend `test_main_without_args` to check for number of tables
generated as a regression guard