### PR TITLE
BUG: Change DXT heatmap to use `nprocs` for y-axis scale and correct bar graph anomalies

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
@@ -60,4 +60,4 @@ class GetHeatMapDf:
     def time_get_heatmap_df(self, unique_ranks, bin_count):
         # benchmark get_heatmap_df() handling of variable
         # numbers of unique ranks/bins
-        heatmap_handling.get_heatmap_df(self.agg_df, xbins=bin_count)
+        heatmap_handling.get_heatmap_df(self.agg_df, xbins=bin_count, nprocs=unique_ranks)

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -380,3 +380,32 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int) -> pd.DataFrame:
     cats.index = agg_df["rank"]
     hmap_df = cats.groupby("rank").sum()
     return hmap_df
+
+
+def get_filled_hmap_df(hmap_df: Any, nprocs: int) -> Any:
+    """
+    Takes a dataframe containing a subset of ranks and injects them into
+    a new dataframe with a row for each rank.
+
+    Parameters
+    ----------
+
+    hmap_df: dataframe with time intervals for columns and rank
+    index (0, 1, etc.) for rows, where each element contains the data
+    read/written by the corresponding rank in the given time interval.
+
+    nprocs: the number of MPI ranks/processes used at runtime.
+
+    Returns
+    -------
+
+    filled_df: dataframe of shape ``nprocs x xbins`` with same intervals as
+    `hmap_df`, all data from `hmap_df`, but rows that span from 0 to `nprocs-1`.
+
+    """
+    # make an empty dataframe of size `nprocs x xbins`
+    # and fill it with the data from above dataframe
+    filled_df = pd.DataFrame(np.zeros((nprocs, hmap_df.shape[1])), columns=hmap_df.columns)
+    filled_df.index.name = "rank"
+    filled_df.update(hmap_df)
+    return filled_df

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -374,7 +374,7 @@ def plot_heatmap(
     for _, spine in hmap.spines.items():
         spine.set_visible(True)
 
-    # if there is more than 1 processes,
+    # if there is more than 1 process,
     # create the horizontal bar graph
     if nprocs > 1:
         jgrid.ax_marg_y.barh(

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -334,14 +334,9 @@ def plot_heatmap(
     # aggregate the data according to the selected modules and operations
     agg_df = heatmap_handling.get_aggregate_data(report=report, mod=mod, ops=ops)
 
-    # get the heatmap data array
-    hmap_df = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)
-
     nprocs = report.metadata["job"]["nprocs"]
-    hmap_df = heatmap_handling.get_filled_hmap_df(hmap_df=hmap_df, nprocs=nprocs)
-
-    # reverse order of rows so the ranks are in ascending order when plotted
-    hmap_df = hmap_df.loc[::-1]
+    # get the heatmap data array
+    hmap_df = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins, nprocs=nprocs)
 
     # build the joint plot with marginal histograms
     jgrid = sns.jointplot(kind="hist", bins=[xbins, nprocs], space=0.05)
@@ -422,6 +417,9 @@ def plot_heatmap(
         # if there is only 1 unique rank there is no horizontal bar graph,
         # so set the subplot dimensions to fill the space
         adjust_for_colorbar(jointgrid=jgrid, fig_right=0.92, cbar_x0=0.82)
+
+    # invert the y-axis so rank values are increasing
+    jgrid.ax_joint.invert_yaxis()
 
     # set the axis labels
     jgrid.ax_joint.set_xlabel("Time (s)")

--- a/darshan-util/pydarshan/darshan/tests/test_heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/tests/test_heatmap_handling.py
@@ -332,19 +332,24 @@ def test_get_aggregate_data(log_file, expected_agg_data, mod, ops):
             "sample-dxt-simple.darshan",
             1,
             ["read", "write"],
-            np.array([[4040]]),
+            np.array([[4040, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0 , 0 ,0]]).reshape(16, 1),
         ),
         (
             "sample-dxt-simple.darshan",
             4,
             ["read", "write"],
+            np.vstack((
             np.array([[0, 0, 0, 4040]]),
+            np.zeros((15, 4)))),
         ),
         (
             "sample-dxt-simple.darshan",
             10,
             ["read", "write"],
+            np.vstack((
             np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 4040]]),
+            np.zeros((15, 10)))),
         ),
         # `dxt.darshan` is complex enough to warrant changing the
         # selected operations
@@ -558,14 +563,15 @@ def test_get_heatmap_df(
     agg_df = heatmap_handling.get_aggregate_data(
         report=report, mod="DXT_POSIX", ops=ops
     )
+    nprocs = report.metadata["job"]["nprocs"]
     # run the aggregated data through the heatmap data code
-    actual_hmap_data = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)
+    actual_hmap_data = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins, nprocs=nprocs)
 
     if "sample-dxt-simple.darshan" in filepath:
         # check the data is conserved
         assert actual_hmap_data.values.sum() == 4040
         # make sure the output array is the correct shape
-        assert actual_hmap_data.shape == (1, xbins)
+        assert actual_hmap_data.shape == (16, xbins)
         # make sure the output data contains identical values
         assert_allclose(actual_hmap_data.values, expected_hmap_data)
 

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -457,7 +457,7 @@ def test_plot_heatmap(filepath, mod, ops):
         assert jgrid.ax_joint.has_data()
         if "dxt.darshan" in filepath:
             # verify the horizontal bar graph does not contain data since there
-            # are is only 1 rank for this case
+            # is only 1 rank for this case
             assert not jgrid.ax_marg_y.has_data()
         else:
             # verify the horizontal bar graph contains data for multirank cases

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -269,8 +269,7 @@ def test_set_y_axis_ticks_and_labels(
     nprocs = report.metadata["job"]["nprocs"]
 
     # generate the heatmap data
-    data = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins)
-    data = heatmap_handling.get_filled_hmap_df(hmap_df=data, nprocs=nprocs)
+    data = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins, nprocs=nprocs)
 
     # generate a joint plot object, then add the heatmap to it
     jointgrid = sns.jointplot(kind="hist", bins=[xbins, nprocs])


### PR DESCRIPTION
* Use `nprocs` to scale y-axis for heatmap figure
instead of number of ranks with IO activity

* Add `nprocs` parameter to `get_heatmap_df`
and update documentation

* Update `get_heatmap_df` to return dense dataframe based on `nprocs`

* Correct tests in `test_plot_dxt_heatmap.py` for cases 
where not all ranks had non-zero bins

* Correct tests in `test_heatmap_handling.py` to reflect
dense heatmap dataframe output

* Fixes issue #576

* Contributes to issue #575