### PR TITLE
move bzip header include to .c file

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -19,6 +19,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef HAVE_LIBBZ2
+#include <bzlib.h>
+#endif
 
 #include "darshan-logutils.h"
 

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -9,9 +9,6 @@
 
 #include <limits.h>
 #include <zlib.h>
-#ifdef HAVE_LIBBZ2
-#include <bzlib.h>
-#endif
 
 #include "uthash-1.9.2/src/uthash.h"
 


### PR DESCRIPTION
This is a minor cleanup for clarity.  No bzip symbols are needed in public API, and ifdef guard likely doesn't work once header is installed.  This is only needed in the .c file.