### PR TITLE
eliminate use of PATH_MAX constant

### DIFF
--- a/darshan-runtime/lib/darshan-common.c
+++ b/darshan-runtime/lib/darshan-common.c
@@ -127,10 +127,10 @@ char* darshan_clean_file_path(const char* path)
     else
     {
         /* handle relative path */
-        cwd = malloc(PATH_MAX);
+        cwd = malloc(__DARSHAN_PATH_MAX);
         if(cwd)
         {
-            if(getcwd(cwd, PATH_MAX))
+            if(getcwd(cwd, __DARSHAN_PATH_MAX))
             {
                 newpath = malloc(strlen(path) + strlen(cwd) + 2);
                 if(newpath)

--- a/darshan-runtime/lib/darshan-posix.c
+++ b/darshan-runtime/lib/darshan-posix.c
@@ -522,7 +522,7 @@ int DARSHAN_DECL(openat)(int dirfd, const char *pathname, int flags, ...)
     int ret;
     double tm1, tm2;
     struct posix_file_record_ref *rec_ref;
-    char tmp_path[PATH_MAX] = {0};
+    char tmp_path[__DARSHAN_PATH_MAX] = {0};
     char *dirpath = NULL;
 
     MAP_OR_FAIL(openat);
@@ -562,13 +562,19 @@ int DARSHAN_DECL(openat)(int dirfd, const char *pathname, int flags, ...)
         if(rec_ref)
         {
             dirpath = darshan_core_lookup_record_name(rec_ref->file_rec->base_rec.id);
-            if(dirpath)
+            /* Safety check path length against temporary buffer.  If the
+             * combined path is too long, then we set dirpath to NULL to fall
+             * through to using relative path below.
+             */
+            if(dirpath && (strlen(dirpath) + strlen(pathname) + 2) < __DARSHAN_PATH_MAX)
             {
                 strcat(tmp_path, dirpath);
                 if(dirpath[strlen(dirpath)-1] != '/')
                     strcat(tmp_path, "/");
                 strcat(tmp_path, pathname);
             }
+            else
+                dirpath = NULL;
         }
 
         if(dirpath)
@@ -593,7 +599,7 @@ int DARSHAN_DECL(openat64)(int dirfd, const char *pathname, int flags, ...)
     int ret;
     double tm1, tm2;
     struct posix_file_record_ref *rec_ref;
-    char tmp_path[PATH_MAX] = {0};
+    char tmp_path[__DARSHAN_PATH_MAX] = {0};
     char *dirpath = NULL;
 
     MAP_OR_FAIL(openat64);
@@ -633,13 +639,19 @@ int DARSHAN_DECL(openat64)(int dirfd, const char *pathname, int flags, ...)
         if(rec_ref)
         {
             dirpath = darshan_core_lookup_record_name(rec_ref->file_rec->base_rec.id);
-            if(dirpath)
+            /* Safety check path length against temporary buffer.  If the
+             * combined path is too long then, we set dirpath to NULL to fall
+             * through to using relative path below.
+             */
+            if(dirpath && (strlen(dirpath) + strlen(pathname) + 2) < __DARSHAN_PATH_MAX)
             {
                 strcat(tmp_path, dirpath);
                 if(dirpath[strlen(dirpath)-1] != '/')
                     strcat(tmp_path, "/");
                 strcat(tmp_path, pathname);
             }
+            else
+                dirpath = NULL;
         }
 
         if(dirpath)

--- a/darshan-runtime/lib/darshan.h
+++ b/darshan-runtime/lib/darshan.h
@@ -46,7 +46,7 @@
 #define DARSHAN_MOD_MEM_OVERRIDE "DARSHAN_MODMEM"
 
 /* Environment variable to enable profiling without MPI */
-#define DARSHAN_ENABLE_NONMPI "DARSHAN_ENABLE_NONMPI" 
+#define DARSHAN_ENABLE_NONMPI "DARSHAN_ENABLE_NONMPI"
 
 #ifdef __DARSHAN_ENABLE_MMAP_LOGS
 /* Environment variable to override default mmap log path */
@@ -67,6 +67,9 @@
 
 /* default name record buf can store 2048 records of size 100 bytes */
 #define DARSHAN_NAME_RECORD_BUF_SIZE (2048 * 100)
+
+/* maximum buffer size for full paths, for internal use only */
+#define __DARSHAN_PATH_MAX 4096
 
 typedef union
 {
@@ -122,7 +125,7 @@ struct darshan_core_runtime
     size_t name_mem_used;
     char *comp_buf;
 #ifdef __DARSHAN_ENABLE_MMAP_LOGS
-    char mmap_log_name[PATH_MAX];
+    char mmap_log_name[__DARSHAN_PATH_MAX];
 #endif
 #ifdef HAVE_MPI
     MPI_Comm mpi_comm;

--- a/darshan-util/darshan-convert.c
+++ b/darshan-util/darshan-convert.c
@@ -141,11 +141,13 @@ void obfuscate_exe(int key, char *exe)
     return;
 }
 
+#define __TMP_OBF_SIZE 4096
+
 void obfuscate_filenames(int key, struct darshan_name_record_ref *name_hash, struct darshan_mnt_info *mnt_data_array, int mount_count )
 {
     struct darshan_name_record_ref *ref, *tmp;
     uint32_t hashed;
-    char tmp_string[PATH_MAX+128] = {0};
+    char tmp_string[__TMP_OBF_SIZE] = {0};
     darshan_record_id tmp_id;
 
     HASH_ITER(hlink, name_hash, ref, tmp)
@@ -168,13 +170,13 @@ void obfuscate_filenames(int key, struct darshan_name_record_ref *name_hash, str
         tmp_id = ref->name_record->id;
         hashed = darshan_hashlittle(ref->name_record->name,
             strlen(ref->name_record->name), key);
-        if ( mnt_pt != NULL ) 
+        if ( mnt_pt != NULL )
         {
-            sprintf(tmp_string, "%s/%u", mnt_pt, hashed);
+            snprintf(tmp_string, __TMP_OBF_SIZE, "%s/%u", mnt_pt, hashed);
         }
-        else 
+        else
         {
-            sprintf(tmp_string, "%u", hashed);
+            snprintf(tmp_string, __TMP_OBF_SIZE, "%u", hashed);
         }
         free(ref->name_record);
         ref->name_record = malloc(sizeof(struct darshan_name_record) +

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -24,6 +24,7 @@
 
 /* default input buffer size for decompression algorithm */
 #define DARSHAN_DEF_COMP_BUF_SZ (1024*1024) /* 1 MiB */
+#define __DARSHAN_PATH_MAX 4096
 
 /* special identifers for referring to header, job, and
  * record map regions of the darshan log file
@@ -59,7 +60,7 @@ struct darshan_fd_int_state
     /* flag indicating whether log file was created (and written) */
     int creat_flag;
     /* log file path name */
-    char logfile_path[PATH_MAX];
+    char logfile_path[__DARSHAN_PATH_MAX];
     /* pointer to exe & mount data in darshan job data structure */
     char *exe_mnt_data;
     /* whether previous file operations have failed */
@@ -160,7 +161,7 @@ darshan_fd darshan_log_open(const char *name)
         free(tmp_fd);
         return(NULL);
     }
-    strncpy(tmp_fd->state->logfile_path, name, PATH_MAX);
+    strncpy(tmp_fd->state->logfile_path, name, __DARSHAN_PATH_MAX);
 
     /* read the header from the log file to init fd data structures */
     ret = darshan_log_get_header(tmp_fd);
@@ -226,7 +227,7 @@ darshan_fd darshan_log_create(const char *name, enum darshan_comp_type comp_type
     }
     tmp_fd->state->creat_flag = 1;
     tmp_fd->partial_flag = partial_flag;
-    strncpy(tmp_fd->state->logfile_path, name, PATH_MAX);
+    strncpy(tmp_fd->state->logfile_path, name, __DARSHAN_PATH_MAX);
 
     /* position file pointer to prealloc space for the log file header
      * NOTE: the header is written at close time, after all internal data
@@ -744,10 +745,10 @@ int darshan_log_put_namehash(darshan_fd fd, struct darshan_name_record_ref *hash
     assert(state);
 
     /* allocate memory for largest possible hash record */
-    name_rec = malloc(sizeof(darshan_record_id) + PATH_MAX + 1);
+    name_rec = malloc(sizeof(darshan_record_id) + __DARSHAN_PATH_MAX + 1);
     if(!name_rec)
         return(-1);
-    memset(name_rec, 0, sizeof(darshan_record_id) + PATH_MAX + 1);
+    memset(name_rec, 0, sizeof(darshan_record_id) + __DARSHAN_PATH_MAX + 1);
 
     /* individually serialize each hash record and write to log file */
     HASH_ITER(hlink, hash, ref, tmp)


### PR DESCRIPTION
Use internal __DARSHAN_PATH_MAX define instead.   Also add additional buffer length safety checks and comments to existing checks.

Fixes #623