### PR TITLE
BUG: correct section closing tag in `base.html`

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -45,8 +45,8 @@
               </figcaption>
             % endif
           </figure>
-          </section>
           % endfor
+        </section>
       % endfor
 
       <!-- Add the footer -->

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -178,6 +178,10 @@ def test_main_all_logs_repo_files(tmpdir, log_repo_files):
                         if mod in ["POSIX", "MPI-IO", "STDIO"]:
                             assert "I/O Cost" in report_str
 
+                    # check the number of opening section tags
+                    # matches the number of closing section tags
+                    assert report_str.count("<section>") == report_str.count("</section>")
+
 class TestReportData:
 
     @pytest.mark.parametrize(

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -122,7 +122,11 @@ def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_coun
                     # NOTE: there are 2 "table" tags per table, and 2 other
                     # instances of the word in each report (1 comment, 1 from CSS)
                     expected_table_count = 2 * expected_table_count + 2
+
                     assert report_str.count("table") == expected_table_count
+                    # check the number of opening section tags
+                    # matches the number of closing section tags
+                    assert report_str.count("<section>") == report_str.count("</section>")
 
                     # check if I/O cost figure is present
                     for mod in report.modules:


### PR DESCRIPTION
* Relocate section closing tag to outside of figure loop

* Add check to tests `test_main_without_args` and `test_main_all_logs_repo_files` to verify the number of close/open section tags match