### PR TITLE
ENH: Add access size histogram to summary report

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -20,6 +20,7 @@ from darshan.experimental.plots import (
     plot_dxt_heatmap,
     plot_io_cost,
     plot_common_access_table,
+    plot_access_histogram,
 )
 
 darshan.enable_experimental()
@@ -393,6 +394,20 @@ class ReportData:
         ## Per-Module Statistics
         ################################
         for mod in self.report.modules:
+            if mod in ["POSIX", "MPI-IO"]:
+                access_hist_description = (
+                    "Read/write operations grouped by access size. Most frequent "
+                    "access sizes are featured in the <i>Common Access Sizes</i> table."
+                )
+                access_hist_fig = ReportFigure(
+                    section_title=f"Per-Module Stats: {mod}",
+                    fig_title="Access Sizes",
+                    fig_func=plot_access_histogram,
+                    fig_args=dict(report=self.report, mod=mod),
+                    fig_description=access_hist_description,
+                    fig_width=350,
+                )
+                self.figures.append(access_hist_fig)
             if mod in ["POSIX", "MPI-IO", "H5D"]:
                 if mod == "MPI-IO":
                     com_acc_tbl_description = (

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -74,9 +74,9 @@ def test_main_with_args(tmpdir, argv):
     "argv, expected_img_count, expected_table_count", [
         (["noposix.darshan"], 1, 2),
         (["noposix.darshan", "--output=test.html"], 1, 2),
-        (["sample-dxt-simple.darshan"], 3, 4),
-        (["sample-dxt-simple.darshan", "--output=test.html"], 3, 4),
-        (["nonmpi_partial_modules.darshan"], 2, 3),
+        (["sample-dxt-simple.darshan"], 5, 4),
+        (["sample-dxt-simple.darshan", "--output=test.html"], 5, 4),
+        (["nonmpi_partial_modules.darshan"], 3, 3),
         ([None], 0, 0),
     ]
 )
@@ -119,11 +119,12 @@ def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_coun
                     assert report_str.count("img") == expected_img_count
 
                     # check that the expected number of tables are found
-                    # NOTE: there are 2 "table" tags per table, and 2 other
-                    # instances of the word in each report (1 comment, 1 from CSS)
-                    expected_table_count = 2 * expected_table_count + 2
-
-                    assert report_str.count("table") == expected_table_count
+                    # NOTE: since there are extraneous instances of "table"
+                    # in each report, the actual table count is half the
+                    # sum of the opening and closing tags
+                    actual_table_count = (report_str.count("<table")
+                                          + report_str.count("</table>")) / 2
+                    assert actual_table_count == expected_table_count
                     # check the number of opening section tags
                     # matches the number of closing section tags
                     assert report_str.count("<section>") == report_str.count("</section>")


### PR DESCRIPTION
* Add access size histogram figure from
`plot_access_histogram` to summary report

* Update expected `img` tag counts in `test_main_without_args`
to account for new access size histogram figures

* Rework table counting in `test_main_without_args` to ignore
extraneous instances of the word "table", such as the instance
in the figure caption for the access size histogram

* Contributes to issue #465