### PR TITLE
MAINT: Correct `nonmpi_partial_modules.darshan` filename

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_log_utils.py
+++ b/darshan-util/pydarshan/darshan/tests/test_log_utils.py
@@ -25,7 +25,7 @@ import pytest
     "shane_macsio_id29959_5-22-32552-7035573431850780836_1590156158.darshan",
     "darshan-apmpi-2nodes-64mpi.darshan",
     "imbalanced-io.darshan",
-    "nonmpi_partial_modules.darshan",
+    "nonmpi_dxt_anonymized.darshan",
     "laytonjb_test1_id28730_6-7-43012-2131301613401632697_1.darshan",
     "snyder_acme.exe_id1253318_9-27-24239-1515303144625770178_2.darshan",
     "treddy_mpi-io-test_id4373053_6-2-60198-9815401321915095332_1.darshan",

--- a/darshan-util/pydarshan/darshan/tests/test_plot_common_access_table.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_common_access_table.py
@@ -28,7 +28,7 @@ from darshan.log_utils import get_log_path
             pd.DataFrame([[262144, 24]]),
         ),
         (
-            "nonmpi_partial_modules.darshan",
+            "nonmpi_dxt_anonymized.darshan",
             "POSIX",
             # values from the old report (Perl) code
             pd.DataFrame([[1024, 7692], [32, 276], [100, 269], [92, 265]]),

--- a/darshan-util/pydarshan/darshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_io_cost.py
@@ -196,7 +196,7 @@ def test_get_by_avg_series(mod_key, input_df, expected_series):
     "filename, expected_df",
     [
         (
-            "nonmpi_partial_modules.darshan",
+            "nonmpi_dxt_anonymized.darshan",
             pd.DataFrame(
                 np.array([
                     [0.281718, 0.504260, 0.170138],

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -77,7 +77,7 @@ def test_main_with_args(tmpdir, argv):
         (["noposix.darshan", "--output=test.html"], 1, 2),
         (["sample-dxt-simple.darshan"], 5, 4),
         (["sample-dxt-simple.darshan", "--output=test.html"], 5, 4),
-        (["nonmpi_partial_modules.darshan"], 3, 3),
+        (["nonmpi_dxt_anonymized.darshan"], 3, 3),
         ([None], 0, 0),
     ]
 )


### PR DESCRIPTION
* Correct all instances of `nonmpi_partial_modules.darshan` to
`nonmpi_dxt_anonymized.darshan` after the following darshan-logs
PR was merged:
https://github.com/darshan-hpc/darshan-logs/pull/19