### PR TITLE
ENH: Add `H5D` module support to "Access Size Histogram"

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -396,7 +396,7 @@ class ReportData:
         ## Per-Module Statistics
         ################################
         for mod in self.report.modules:
-            if mod in ["POSIX", "MPI-IO"]:
+            if mod in ["POSIX", "MPI-IO", "H5D"]:
                 access_hist_description = (
                     "Read/write operations grouped by access size. Most frequent "
                     "access sizes are featured in the <i>Common Access Sizes</i> table."
@@ -410,7 +410,6 @@ class ReportData:
                     fig_width=350,
                 )
                 self.figures.append(access_hist_fig)
-            if mod in ["POSIX", "MPI-IO", "H5D"]:
                 if mod == "MPI-IO":
                     com_acc_tbl_description = (
                         "NOTE: MPI-IO accesses are given in "

--- a/darshan-util/pydarshan/darshan/experimental/aggregators/mod_agg_iohist.py
+++ b/darshan-util/pydarshan/darshan/experimental/aggregators/mod_agg_iohist.py
@@ -12,7 +12,7 @@ def mod_agg_iohist(self, mod, mode='append'):
     """
 
     # sanitation and guards
-    supported = ["POSIX", "MPI-IO"]
+    supported = ["POSIX", "MPI-IO", "H5D"]
     if mod not in supported:
         raise Exception("Unsupported mod_name for aggregated iohist.")
 

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -35,6 +35,13 @@ darshan.enable_experimental()
             "1M-4M", "4M-10M", "10M-100M", "100M-1G", "1G+"]
         ),
         (
+            "ior_hdf5_example.darshan",
+            "H5D",
+            plot_access_histogram,
+            ["0-100", "101-1K", "1K-10K", "10K-100K", "100K-1M",
+            "1M-4M", "4M-10M", "10M-100M", "100M-1G", "1G+"],
+        ),
+        (
             "sample-badost.darshan",
             "POSIX",
             plot_access_histogram,
@@ -146,6 +153,12 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             "MPI-IO",
             plot_access_histogram,
             [3, 17, 0, 0, 16, 0, 0, 0, 0, 0, 3, 4, 0, 0, 16, 0, 0, 0, 0, 0],
+        ),
+        (
+            "ior_hdf5_example.darshan",
+            "H5D",
+            plot_access_histogram,
+            [0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0],
         ),
         (
             "sample-badost.darshan",

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -78,6 +78,7 @@ def test_main_with_args(tmpdir, argv):
         (["sample-dxt-simple.darshan"], 5, 4),
         (["sample-dxt-simple.darshan", "--output=test.html"], 5, 4),
         (["nonmpi_dxt_anonymized.darshan"], 3, 3),
+        (["ior_hdf5_example.darshan"], 6, 5),
         ([None], 0, 0),
     ]
 )


### PR DESCRIPTION
* Add `H5D` to supported module list for `mod_agg_iohist`

* Add `H5D` access histogram to summary report

* Add test cases for `ior_hdf5_example.darshan`:
  - `test_main_without_args()` in `test_summary.py`
  - `test_xticks_and_labels()` and `test_bar_heights()`
  in `test_plot_exp_common.py`

* Fix issue #639