### PR TITLE
BENCH: peakmem benchmarks for heatmap

### DIFF
--- a/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
+++ b/darshan-util/pydarshan/benchmarks/benchmarks/dxt_heatmap.py
@@ -44,20 +44,33 @@ class PlotDXTHeatMapSmall:
             xbins=xbins)
 
 
+    def peakmem_plot_heatmap_builtin_logs(self, darshan_logfile, xbins):
+        plot_dxt_heatmap.plot_heatmap(
+            report=self.report,
+            mod="DXT_POSIX",
+            ops=["read", "write"],
+            xbins=xbins)
+
+
 class GetHeatMapDf:
-    params = [[50, 1000, 10000], [10, 50, 250]]
-    param_names = ['unique_ranks', 'bin_count']
+    params = [[50, 1000, 10000], [10, 50, 250], [0.001, 0.01, 1.0]]
+    param_names = ['unique_ranks', 'bin_count', 'density']
 
 
-    def setup(self, unique_ranks, bin_count):
-        self.agg_df = pd.DataFrame({'length': [10] * unique_ranks,
-                                    'start_time': [0.1] * unique_ranks,
-                                    'end_time': [0.9] * unique_ranks,
-                                    'rank': range(unique_ranks),
+    def setup(self, unique_ranks, bin_count, density):
+        active_ranks = max(int(density * unique_ranks), 1)
+        self.agg_df = pd.DataFrame({'length': [10] * active_ranks,
+                                    'start_time': [0.1] * active_ranks,
+                                    'end_time': [0.9] * active_ranks,
+                                    'rank': range(active_ranks),
                                    })
 
 
-    def time_get_heatmap_df(self, unique_ranks, bin_count):
+    def time_get_heatmap_df(self, unique_ranks, bin_count, density):
         # benchmark get_heatmap_df() handling of variable
         # numbers of unique ranks/bins
+        heatmap_handling.get_heatmap_df(self.agg_df, xbins=bin_count, nprocs=unique_ranks)
+
+
+    def peakmem_get_heatmap_df(self, unique_ranks, bin_count, density):
         heatmap_handling.get_heatmap_df(self.agg_df, xbins=bin_count, nprocs=unique_ranks)


### PR DESCRIPTION
* add some peak memory tracking `asv` benchmarks
for the DXT heatmap code, because the decision
between sparse and dense data structures requires
statistically robust measurements of both performance
and memory impact

* the `GetHeatMapDf` benchmarks on synthetic data
now include a spread of data densities to better
reflect the reality that many MPI applications
only have a subset of IO-active ranks

* benchmarks were previously completely insensitive to memory footprint; comparison of running
the heatmat benchmarks on this feature branch vs. `pydarshan-devel` for a comparison
against a feature branch (`treddy_sparse_df`) that does not reindex the heatmap data (remains sparse) demonstrates
the sensitivity to memory footprint along with the time cost of doing this extra bechmarking
work

- on my new branch here:
`time asv continuous -e -b ".\*heatmap.\*" pydarshan-devel treddy_sparse_df`
```
       before           after         ratio
     [cd2d7c68]       [6e0e9fc1]
     <pydarshan-devel>       <treddy_sparse_df>
-            201M             183M     0.91  dxt_heatmap.GetHeatMapDf.peakmem_get_heatmap_df(10000, 50, 1.0)
-        27.1±3ms       24.2±0.5ms     0.89  dxt_heatmap.GetHeatMapDf.time_get_heatmap_df(10000, 50, 0.01)
-            145M             127M     0.88  dxt_heatmap.GetHeatMapDf.peakmem_get_heatmap_df(10000, 250, 0.01)
-            145M             124M     0.85  dxt_heatmap.GetHeatMapDf.peakmem_get_heatmap_df(10000, 250, 0.001)
-        385±20ms          326±5ms     0.85  dxt_heatmap.PlotDXTHeatMapSmall.time_plot_heatmap_builtin_logs('tests/input/sample-dxt-simple.darshan', 10)
-        24.4±3ms       19.1±0.3ms     0.78  dxt_heatmap.GetHeatMapDf.time_get_heatmap_df(10000, 50, 0.001)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```
- it took: `12:28.00 total`

- on `pydarshan-devel`:
`time asv continuous -e -b ".\*heatmap.\*" pydarshan-devel treddy_sparse_df`
```
       before           after         ratio
     [cd2d7c68]       [6e0e9fc1]
     <pydarshan-devel>       <treddy_sparse_df>
-         361±4ms          320±6ms     0.89  dxt_heatmap.PlotDXTHeatMapSmall.time_plot_heatmap_builtin_logs('tests/input/sample-dxt-simple.darshan', 10)
-         493±7ms         429±10ms     0.87  dxt_heatmap.PlotDXTHeatMapSmall.time_plot_heatmap_builtin_logs('tests/input/sample-dxt-simple.darshan', 100)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```
- it took: `7:13.95 total`