### PR TITLE
MAINT: Update darshan summary report metadata table runtime datatype

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -174,11 +174,11 @@ class ReportData:
 
         """
         # calculate the run time
-        runtime_val = float(
+        runtime_val = int(
             report.metadata["job"]["end_time"] - report.metadata["job"]["start_time"]
         )
-        if runtime_val < 1.0:
-            # to prevent the displayed run time from being 0.0 seconds
+        if runtime_val < 1:
+            # to prevent the displayed run time from being 0 seconds
             # label anything under 1 second as less than 1
             runtime = "< 1"
         else:

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -238,7 +238,7 @@ class TestReportData:
                         "4478544",
                         "69615",
                         "2048",
-                        "116.0",
+                        "116",
                         str(datetime.fromtimestamp(1490000867)),
                         str(datetime.fromtimestamp(1490000983)),
                         (
@@ -265,7 +265,7 @@ class TestReportData:
                         "83017637",
                         "996599276",
                         "512",
-                        "39212.0",
+                        "39212",
                         str(datetime.fromtimestamp(1514923055)),
                         str(datetime.fromtimestamp(1514962267)),
                         "Anonymized",
@@ -476,11 +476,11 @@ class TestReportData:
     @pytest.mark.parametrize(
         "logname, expected_runtime",
         [
-            ("sample.darshan", "116.0",),
-            ("noposix.darshan", "39212.0"),
-            ("noposixopens.darshan", "1110.0"),
-            ("sample-badost.darshan", "779.0",),
-            ("sample-goodost.darshan", "4.0",),
+            ("sample.darshan", "116",),
+            ("noposix.darshan", "39212"),
+            ("noposixopens.darshan", "1110"),
+            ("sample-badost.darshan", "779",),
+            ("sample-goodost.darshan", "4",),
             # special case where the calculated run time is 0
             ("sample-dxt-simple.darshan", "< 1",),
         ],


### PR DESCRIPTION
* Change method `ReportData.get_runtime()`
to use integers instead of floats

* Correct tests `test_metadata_table` and
`test_get_runtime` to use integer values

* Fixes task "Change runtime data type to integer" in gh-641