### PR TITLE
MAINT: Update partial flag message

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -247,7 +247,7 @@ class ReportData:
             val = f"{mod_buf_size:.2f} KiB"
             flag = ""
             if self.report.modules[mod]["partial_flag"]:
-                msg = "Ran out of memory or record limit reached!"
+                msg = "Module data incomplete due to runtime memory or record count limits"
                 flag = f"<p style='color:red'>&#x26A0; {msg}</p>"
             module_dict[key] = [val, flag]
 

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -420,7 +420,7 @@ class TestReportData:
 
         # add new column for partial flags
         expected_df[1] = np.nan
-        flag = "\u26A0 Ran out of memory or record limit reached!"
+        flag = "\u26A0 Module data incomplete due to runtime memory or record count limits"
         if "partial_data_stdio.darshan" in log_path:
             expected_df.iloc[2, 1] = flag
         if "partial_data_dxt.darshan" in log_path:


### PR DESCRIPTION
* Change partial flag message to "Module data incomplete
due to runtime memory or record count limits"

* Correct test `test_module_table` to reflect
updated partial data flag message

* Fixes task "Update partial flag message" in gh-641