### PR TITLE
MAINT: Add suffix to module data table entries

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -243,7 +243,7 @@ class ReportData:
             # retrieve the buffer size converted to KiB
             mod_buf_size = self.report.modules[mod]["len"] / 1024
             # create the key/value pairs for the dictionary
-            key = f"{mod} (ver={mod_version})"
+            key = f"{mod} (ver={mod_version}) Module Data"
             val = f"{mod_buf_size:.2f} KiB"
             flag = ""
             if self.report.modules[mod]["partial_flag"]:

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -418,6 +418,8 @@ class TestReportData:
         expected_module_count = len(R.report.modules.keys())
         assert actual_mod_df.shape[0] == expected_module_count
 
+        expected_df.index += " Module Data"
+
         # add new column for partial flags
         expected_df[1] = np.nan
         flag = "\u26A0 Module data incomplete due to runtime memory or record count limits"


### PR DESCRIPTION
* Suffix module descriptions in "Darshan Log Information"
table with "Module Data"

* Correct test `test_module_table` such that expected
dataframes contain the updated row names

* Contributes to gh-641