### PR TITLE
gracefully parse logs with unknown module ids

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 Darshan Release Change Log
 --------------------------
 
-Darshan-3.3.2
+Darshan-3.4
 =============
 * Add a new "heatmap" module that records histograms of I/O traffic over time
   on each process
@@ -12,6 +12,7 @@ Darshan-3.3.2
 * Add optional, limited support for RDTSCP-based timing, enabled via
   --enable-rdtscp at configure time
 * Remove unecessary explicit mpich binding libraries from link line when static linking
+* Graceful warnings when parsing log files with unknown module types
 
 Darshan-3.3.1
 =============

--- a/darshan-util/darshan-convert.c
+++ b/darshan-util/darshan-convert.c
@@ -386,9 +386,16 @@ int main(int argc, char **argv)
         /* check each module for any data */
         if(infile->mod_map[i].len == 0)
             continue;
+        /* skip modules that this version of Darshan can't parse */
+        else if(i >= DARSHAN_KNOWN_MODULE_COUNT)
+        {
+            fprintf(stderr, "# Warning: module id %d is unknown. You may need "
+                            "a newer version of the Darshan utilities to parse it.\n", i);
+            continue;
+        }
         else if(!mod_logutils[i])
         {
-            fprintf(stderr, "Warning: no log utility handlers defined "
+            fprintf(stderr, "# Warning: no log utility handlers defined "
                 "for module %s, SKIPPING.\n", darshan_module_names[i]);
             continue;
         }

--- a/darshan-util/darshan-diff.c
+++ b/darshan-util/darshan-diff.c
@@ -27,7 +27,7 @@ struct darshan_mod_record_ref
 struct darshan_file_record_ref
 {
     darshan_record_id rec_id;
-    struct darshan_mod_record_ref *mod_recs[DARSHAN_MAX_MODS];
+    struct darshan_mod_record_ref *mod_recs[DARSHAN_KNOWN_MODULE_COUNT];
     UT_hash_handle hlink;
 };
 
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
         /* search hash2 for this record */
         HASH_FIND(hlink, rec_hash2, &(rec_ref1->rec_id), sizeof(darshan_record_id), rec_ref2);
 
-        for(i = 0; i < DARSHAN_MAX_MODS; i++)
+        for(i = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
         {
             /* skip the DXT modules -- we won't be diff'ing traces */
             if(i == DXT_POSIX_MOD || i == DXT_MPIIO_MOD)
@@ -311,7 +311,7 @@ int main(int argc, char *argv[])
      */
     HASH_ITER(hlink, rec_hash2, rec_ref2, rec_tmp)
     {
-        for(i = 0; i < DARSHAN_MAX_MODS; i++)
+        for(i = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
         {
             while(rec_ref2->mod_recs[i])
             {
@@ -376,7 +376,7 @@ static int darshan_build_global_record_hash(
     /* iterate over all modules in each log file, adding records to the
      * appropriate hash table
      */
-    for(i = 0; i < DARSHAN_MAX_MODS; i++)
+    for(i = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
     {
         if(!mod_logutils[i]) continue;
 

--- a/darshan-util/darshan-merge.c
+++ b/darshan-util/darshan-merge.c
@@ -389,7 +389,7 @@ int main(int argc, char *argv[])
     /* iterate over active darshan modules and gather module data to write
      * to the merged output log
      */
-    for(i = 0; i < DARSHAN_MAX_MODS; i++)
+    for(i = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
     {
         if(!mod_logutils[i]) continue;
 

--- a/darshan-util/darshan-parser.c
+++ b/darshan-util/darshan-parser.c
@@ -333,12 +333,20 @@ int main(int argc, char **argv)
     printf("# header: %zu bytes (uncompressed)\n", sizeof(struct darshan_header));
     printf("# job data: %zu bytes (compressed)\n", fd->job_map.len);
     printf("# record table: %zu bytes (compressed)\n", fd->name_map.len);
-    for(i=0; i<DARSHAN_MAX_MODS; i++)
+    for(i=0; i<DARSHAN_KNOWN_MODULE_COUNT; i++)
     {
         if(fd->mod_map[i].len || DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i))
         {
             printf("# %s module: %zu bytes (compressed), ver=%d\n",
                 darshan_module_names[i], fd->mod_map[i].len, fd->mod_ver[i]);
+        }
+    }
+    for(i=DARSHAN_KNOWN_MODULE_COUNT; i<DARSHAN_MAX_MODS; i++)
+    {
+        if(fd->mod_map[i].len || DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i))
+        {
+            printf("# <UNKNOWN> module (id %d): %zu bytes (compressed), ver=%d\n",
+                i, fd->mod_map[i].len, fd->mod_ver[i]);
         }
     }
 
@@ -397,10 +405,17 @@ int main(int argc, char **argv)
             if(!DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i))
                 continue;
         }
+        /* skip modules that this version of Darshan can't parse */
+        else if(i >= DARSHAN_KNOWN_MODULE_COUNT)
+        {
+            fprintf(stderr, "# Warning: module id %d is unknown. You may need "
+                            "a newer version of the Darshan utilities to parse it.\n", i);
+            continue;
+        }
         /* skip modules with no logutil definitions */
         else if(!mod_logutils[i])
         {
-            fprintf(stderr, "Warning: no log utility handlers defined "
+            fprintf(stderr, "# Warning: no log utility handlers defined "
                 "for module %s, SKIPPING.\n", darshan_module_names[i]);
             continue;
         }

--- a/include/darshan-log-format.h
+++ b/include/darshan-log-format.h
@@ -178,12 +178,13 @@ struct darshan_base_record
 /* NOTES: - valid ids range from [0...DARSHAN_MAX_MODS-1]
  *        - order of ids control module shutdown order (and consequently, order in log file)
  */
-#define X(a, b, c, d) a,
 typedef enum
 {
+#define X(a, b, c, d) a,
     DARSHAN_MODULE_IDS
-} darshan_module_id;
 #undef X
+    DARSHAN_KNOWN_MODULE_COUNT
+} darshan_module_id;
 
 /* module name strings */
 #define X(a, b, c, d) b,


### PR DESCRIPTION
- bug reported by Jakob Luettgau
- prevents memory corruption when attempting to parse logs that have compatible log format but contain unknown log ids

Fixes #621