### PR TITLE
TST: xfail HEATMAP tests

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -35,6 +35,8 @@ def test_jobid_type_all_logs_repo_files(log_repo_files):
     # this is primarily intended as a demonstration of looping
     # through all logs repo files in a test
     for log_filepath in log_repo_files:
+        if "heatmap" in log_filepath:
+            pytest.xfail(reason="HEATMAP module not yet supported")
         report = darshan.DarshanReport(log_filepath)
         assert isinstance(report.metadata['job']['jobid'], int)
 

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -150,6 +150,8 @@ def test_main_all_logs_repo_files(tmpdir, log_repo_files):
     # https://github.com/darshan-hpc/darshan-logs
 
     for log_filepath in log_repo_files:
+        if "heatmap" in log_filepath:
+            pytest.xfail(reason="HEATMAP module not yet supported")
         argv = [log_filepath]
         with mock.patch("sys.argv", [""] + argv):
             with tmpdir.as_cwd():


### PR DESCRIPTION
* mark the two test cases requiring `HEATMAP` module
support as known failures (`xfail`) for now, so that
PRs in the main and logs repos can pass CI until the
support is added in

* because the two tests are not parametrized, the
`xfail`s are imperative, which means that only
those inputs that precede the `xfail`ed logs
will run for now, so I wouldn't want to leave
these in for long, just long enough to avoid
rushing the HEATMAP support addition/review

* an alternative is to simply `pass`/`continue`
for these test cases, which would allow all
of the other cases for the two tests to run
as usual, though it would leave out the
convenient `pytest` reminder that the tests
have known failures in them