### PR TITLE
TST: graceful HEATMAP xfails

### DIFF
--- a/darshan-util/pydarshan/darshan/log_utils.py
+++ b/darshan-util/pydarshan/darshan/log_utils.py
@@ -32,6 +32,12 @@ except ImportError:
     has_log_repo = False
 
 
+def _provide_logs_repo_filepaths():
+    if has_log_repo:
+        return _produce_log_dict("darshan_logs").values()
+    return []
+
+
 @functools.lru_cache(maxsize=4)
 def _produce_log_dict(project):
     p = importlib_resources.files(project) # type: Any

--- a/darshan-util/pydarshan/darshan/tests/conftest.py
+++ b/darshan-util/pydarshan/darshan/tests/conftest.py
@@ -20,22 +20,3 @@ except ImportError:
 
 def pytest_configure():
     pytest.has_log_repo = has_log_repo
-
-@pytest.fixture
-def log_repo_files():
-    # provide a convenient way to access the list
-    # of all *.darshan log files in the logs repo,
-    # returning a list of absolute file paths to
-    # the logs
-    if pytest.has_log_repo:
-        p = importlib_resources.files('darshan_logs')
-        return [str(p) for p in p.glob('**/*.darshan')]
-
-@pytest.fixture
-def select_log_repo_file(log_repo_files, filename):
-    # return the absolute path to a log repo
-    # file based on its filename
-    if pytest.has_log_repo:
-        for path in log_repo_files:
-            if filename in path:
-                return path

--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -15,7 +15,7 @@ from pandas.testing import assert_frame_equal
 import darshan
 import darshan.backend.cffi_backend as backend
 from darshan.report import DarshanRecordCollection
-from darshan.log_utils import get_log_path, _produce_log_dict
+from darshan.log_utils import get_log_path, _provide_logs_repo_filepaths
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def response():
 @pytest.mark.skipif(not pytest.has_log_repo,
                     reason="missing darshan_logs")
 @pytest.mark.parametrize("log_filepath",
-        _produce_log_dict("darshan_logs").values()
+        _provide_logs_repo_filepaths()
         )
 def test_jobid_type_all_logs_repo_files(log_filepath):
     # test for the expected jobid type in each of the

--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -15,7 +15,7 @@ from pandas.testing import assert_frame_equal
 import darshan
 import darshan.backend.cffi_backend as backend
 from darshan.report import DarshanRecordCollection
-from darshan.log_utils import get_log_path
+from darshan.log_utils import get_log_path, _produce_log_dict
 
 
 @pytest.fixture
@@ -29,16 +29,18 @@ def response():
 
 @pytest.mark.skipif(not pytest.has_log_repo,
                     reason="missing darshan_logs")
-def test_jobid_type_all_logs_repo_files(log_repo_files):
+@pytest.mark.parametrize("log_filepath",
+        _produce_log_dict("darshan_logs").values()
+        )
+def test_jobid_type_all_logs_repo_files(log_filepath):
     # test for the expected jobid type in each of the
     # log files in the darshan_logs package;
     # this is primarily intended as a demonstration of looping
     # through all logs repo files in a test
-    for log_filepath in log_repo_files:
-        if "heatmap" in log_filepath:
-            pytest.xfail(reason="HEATMAP module not yet supported")
-        report = darshan.DarshanReport(log_filepath)
-        assert isinstance(report.metadata['job']['jobid'], int)
+    if "heatmap" in log_filepath:
+        pytest.xfail(reason="no runtime HEATMAP support")
+    report = darshan.DarshanReport(log_filepath)
+    assert isinstance(report.metadata['job']['jobid'], int)
 
 def test_job():
     """Sample for expected job data."""

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -10,7 +10,7 @@ from pandas.testing import assert_frame_equal
 
 import darshan
 from darshan.cli import summary
-from darshan.log_utils import get_log_path, _produce_log_dict
+from darshan.log_utils import get_log_path, _provide_logs_repo_filepaths
 
 
 @pytest.mark.parametrize(
@@ -145,7 +145,7 @@ def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_coun
 @pytest.mark.skipif(not pytest.has_log_repo,
                     reason="missing darshan_logs")
 @pytest.mark.parametrize("log_filepath",
-        _produce_log_dict("darshan_logs").values()
+        _provide_logs_repo_filepaths()
         )
 def test_main_all_logs_repo_files(tmpdir, log_filepath):
     # similar to `test_main_without_args` but focused


### PR DESCRIPTION
* only test cases that require runtime `HEATMAP`
module support are `xfail`ed in the test suite now,
instead of skipping the cases that also come after
them in iterable tests

* while the original design was meant to be temporary (gh-671),
and was made intentionally on the assumption that HEATMAP
support would be added shortly, this introduces parametrization
into the two tests that are involved and does away with the
old fixtures to avoid debates like the one in https://github.com/darshan-hpc/darshan-logs/pull/27

* on `pydarshan-devel`:
`300 passed, 2 xfailed in 38.83s`

* on this branch:
`318 passed, 6 xfailed in 96.56s (0:01:36)`

* there are 3 runtime heatmap logs, and two tests that
need to avoid them, so the xfail arithmetic looks correct there,
along with the restoration of a bunch more logs cases...

* as always, others should feel free to help streamline the testing/devops infrastructure