### PR TITLE
WIP, ENH: HDF5 support for `plot_opcounts()` aggregators

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/aggregators/agg_ioops.py
+++ b/darshan-util/pydarshan/darshan/experimental/aggregators/agg_ioops.py
@@ -24,7 +24,7 @@ def agg_ioops(self, mode='append'):
     ctx = {}
 
     # aggragate
-    mods = ['MPI-IO', 'POSIX', 'STDIO']
+    mods = ['MPI-IO', 'POSIX', 'STDIO', "H5F", "H5D"]
     for mod in mods:
 
         # check records for module are present
@@ -70,6 +70,24 @@ def agg_ioops(self, mode='append'):
             ctx[mod] = agg
             ctx[mod + '_indep_simple'] = agg_indep
             ctx[mod + '_coll_simple'] = agg_coll
+
+        elif mod == "H5F":
+            tmp = {
+                'Open':  agg[mod + '_OPENS'],
+                'Flush': agg[mod + '_FLUSHES'],
+            }
+            ctx[mod] = agg
+            ctx[mod + '_simple'] = tmp
+
+        elif mod == "H5D":
+            tmp = {
+                'Read':  agg[mod + '_READS'],
+                'Write': agg[mod + '_WRITES'],
+                'Open':  agg[mod + '_OPENS'],
+                'Flush': agg[mod + '_FLUSHES'],
+            }
+            ctx[mod] = agg
+            ctx[mod + '_simple'] = tmp
 
         else:
             # POSIX and STDIO share most counter names and are handled 

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
@@ -82,12 +82,17 @@ def gather_count_data(report, mod):
         ]
 
     elif mod == 'H5D':
-        labels = ['Read', 'Write', 'Open', 'Flush']
+        labels = [
+            'Data Read', 'Data Write', 'Data Open',
+            'Data Flush', 'File Open', 'File Flush',
+        ]
         counts = [
-            mod_data['H5D_READS'],
-            mod_data['H5D_WRITES'],
-            mod_data['H5D_OPENS'],
-            mod_data['H5D_FLUSHES'],
+            report.summary['agg_ioops']['H5D']['H5D_READS'],
+            report.summary['agg_ioops']['H5D']['H5D_WRITES'],
+            report.summary['agg_ioops']['H5D']['H5D_OPENS'],
+            report.summary['agg_ioops']['H5D']['H5D_FLUSHES'],
+            report.summary['agg_ioops']['H5F']['H5F_OPENS'],
+            report.summary['agg_ioops']['H5F']['H5F_FLUSHES'],
         ]
 
     return labels, counts
@@ -96,8 +101,15 @@ def plot_opcounts(report, mod, ax=None):
     """
     Generates a bar chart summary for operation counts.
 
-	Args:
-        report (DarshanReport): darshan report object to plot
+    Parameters
+    ----------
+
+    report (DarshanReport): darshan report object to plot
+
+    mod: the module to plot operation counts for (i.e. "POSIX",
+    "MPI-IO", "STDIO", "H5F", "H5D"). If "H5D" is input the returned
+    figure will contain both "H5F" and "H5D" module data.
+
     """
 
     if ax is None:

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
@@ -74,6 +74,22 @@ def gather_count_data(report, mod):
             mod_data['STDIO_FLUSHES']
         ]
 
+    elif mod == 'H5F':
+        labels = ['Open', 'Flush']
+        counts = [
+            mod_data['H5F_OPENS'],
+            mod_data['H5F_FLUSHES'],
+        ]
+
+    elif mod == 'H5D':
+        labels = ['Read', 'Write', 'Open', 'Flush']
+        counts = [
+            mod_data['H5D_READS'],
+            mod_data['H5D_WRITES'],
+            mod_data['H5D_OPENS'],
+            mod_data['H5D_FLUSHES'],
+        ]
+
     return labels, counts
 
 def plot_opcounts(report, mod, ax=None):

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
@@ -83,8 +83,8 @@ def gather_count_data(report, mod):
 
     elif mod == 'H5D':
         labels = [
-            'Data Read', 'Data Write', 'Data Open',
-            'Data Flush', 'File Open', 'File Flush',
+            'H5D Read', 'H5D Write', 'H5D Open',
+            'H5D Flush', 'H5F Open', 'H5F Flush',
         ]
         counts = [
             report.summary['agg_ioops']['H5D']['H5D_READS'],

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -110,6 +110,18 @@ darshan.enable_experimental()
             ['Ind. Read', 'Ind. Write', 'Ind. Open',
             'Col. Read', 'Col. Write', 'Col. Open', 'Sync'],
         ),
+        (
+            "ior_hdf5_example.darshan",
+            "H5F",
+            plot_opcounts,
+            ['Open', 'Flush'],
+        ),
+        (
+            "ior_hdf5_example.darshan",
+            "H5D",
+            plot_opcounts,
+            ['Read', 'Write', 'Open', 'Flush'],
+        ),
     ],
 )
 def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
@@ -250,7 +262,18 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             plot_opcounts,
             [0, 7695, 0, 0, 64, 16, 0],
         ),
-
+        (
+            "ior_hdf5_example.darshan",
+            "H5F",
+            plot_opcounts,
+            [6, 0],
+        ),
+        (
+            "ior_hdf5_example.darshan",
+            "H5D",
+            plot_opcounts,
+            [12, 12, 6, 0],
+        ),
     ],
 )
 def test_bar_heights(filename, mod, fig_func, expected_heights):

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -120,8 +120,8 @@ darshan.enable_experimental()
             "ior_hdf5_example.darshan",
             "H5D",
             plot_opcounts,
-            ['Data Read', 'Data Write', 'Data Open',
-            'Data Flush', 'File Open', 'File Flush'],
+            ['H5D Read', 'H5D Write', 'H5D Open',
+            'H5D Flush', 'H5F Open', 'H5F Flush'],
         ),
     ],
 )

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -120,7 +120,8 @@ darshan.enable_experimental()
             "ior_hdf5_example.darshan",
             "H5D",
             plot_opcounts,
-            ['Read', 'Write', 'Open', 'Flush'],
+            ['Data Read', 'Data Write', 'Data Open',
+            'Data Flush', 'File Open', 'File Flush'],
         ),
     ],
 )
@@ -272,7 +273,7 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             "ior_hdf5_example.darshan",
             "H5D",
             plot_opcounts,
-            [12, 12, 6, 0],
+            [12, 12, 6, 0, 6, 0],
         ),
     ],
 )


### PR DESCRIPTION
Description
------------
* Adds `H5F` and `H5D` specific sections to `plot_opcounts()`
aggregator functions `agg_ioops()` and `gather_count_data()`.
Current method does not combine `H5F` and `H5D` module
data together.

* Add `H5F` and `H5D` test cases to `test_plot_exp_common`
tests `test_xticks_and_labels` and `test_bar_heights`

* Contributes to issue #663

Considerations
----------------
I've played around with combining the `H5F` and `H5D` module data, and we can combine them fairly easily in `gather_count_data()` if we want to. The following diff shows one way of accomplishing this on this branch:

<details><summary>Diff</summary>

```diff
diff --git a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
index 97ac093..501268c 100644
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
@@ -83,11 +83,12 @@ def gather_count_data(report, mod):
 
     elif mod == 'H5D':
         labels = ['Read', 'Write', 'Open', 'Flush']
+        h5f_data = report.summary['agg_ioops']["H5F"]
         counts = [
             mod_data['H5D_READS'],
             mod_data['H5D_WRITES'],
-            mod_data['H5D_OPENS'],
-            mod_data['H5D_FLUSHES'],
+            mod_data['H5D_OPENS'] + h5f_data['H5F_OPENS'],
+            mod_data['H5D_FLUSHES'] + h5f_data['H5F_FLUSHES'],
         ]
 
     return labels, counts
```

</details>

With the above changes, `plot_opcounts(mod="H5F")` would return only the file data (for cases where only `H5F` is present), and `plot_opcounts(mod="H5D")` would return the combined HDF5 data. So it wouldn't be terribly difficult to add it to the report this way, but it is probably confusing to input a single module and get 2 modules' data. This does allow us to stick to the original module names  (which are documented), but there might be an argument for allowing "HDF5" as an input for plotting functions that support it. 

I'm not sure what is the best way to do this, so if reviewers have a better idea I'd be happy to implement it. Maybe @jakobluettgau has a better vision for this since he wrote the original aggregator functions. We could also just merge this and deal with the module combining in a separate PR, I just thought I would mention it since it can be done here.