### PR TITLE
TST:  narrow heatmap xfail

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -38,8 +38,6 @@ def test_jobid_type_all_logs_repo_files(log_filepath):
     # log files in the darshan_logs package;
     # this is primarily intended as a demonstration of looping
     # through all logs repo files in a test
-    if "heatmap" in log_filepath:
-        pytest.xfail(reason="no runtime HEATMAP support")
     report = darshan.DarshanReport(log_filepath)
     assert isinstance(report.metadata['job']['jobid'], int)
 

--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -38,6 +38,8 @@ def test_jobid_type_all_logs_repo_files(log_filepath):
     # log files in the darshan_logs package;
     # this is primarily intended as a demonstration of looping
     # through all logs repo files in a test
+    if "e3sm_io_heatmap_and_dxt" in log_filepath:
+        pytest.xfail(reason="large memory requirements")
     report = darshan.DarshanReport(log_filepath)
     assert isinstance(report.metadata['job']['jobid'], int)
 

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -152,6 +152,8 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
     # on the Darshan logs from the logs repo:
     # https://github.com/darshan-hpc/darshan-logs
 
+    if "e3sm_io_heatmap_and_dxt" in log_filepath:
+        pytest.xfail(reason="large memory requirements")
     argv = [log_filepath]
     with mock.patch("sys.argv", [""] + argv):
         with tmpdir.as_cwd():

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -152,8 +152,6 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
     # on the Darshan logs from the logs repo:
     # https://github.com/darshan-hpc/darshan-logs
 
-    if "heatmap" in log_filepath:
-        pytest.xfail(reason="no runtime HEATMAP support")
     argv = [log_filepath]
     with mock.patch("sys.argv", [""] + argv):
         with tmpdir.as_cwd():


### PR DESCRIPTION
* ~we no longer need to mark runtime `HEATMAP` tests
as known failures, since the binding support has been
merged now~

* narrow the `HEATMAP` xfail to only exclude `e3sm_io_heatmap_and_dxt.darshan`, which still uses too much memory