### PR TITLE
MAINT: Use runtime for DXT heatmap x-axis scaling

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -273,7 +273,7 @@ def get_aggregate_data(
     return agg_df
 
 
-def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFrame:
+def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int, tmax: float = None) -> pd.DataFrame:
     """
     Builds an array similar to a 2D-histogram, where the y data is the unique
     ranks and the x data is time. Each bin is populated with the data sum
@@ -289,6 +289,8 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     xbins: the number of x-axis bins to create.
 
     nprocs: the number of MPI ranks/processes used at runtime.
+
+    tmax: the maximum time for the heatmap interval bins.
 
     Returns
     -------
@@ -310,10 +312,12 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
         3                   1.048576e+06
 
     """
+    if not tmax:
+        # use final DXT segment end time
+        tmax = float(agg_df["end_time"].max())
     # generate the bin edges by generating an array of length n_bins+1, then
     # taking pairs of data points as the min/max bin value
-    max_time = agg_df["end_time"].max()
-    bin_edge_data = np.linspace(0.0, max_time, xbins + 1)
+    bin_edge_data = np.linspace(0.0, tmax, xbins + 1)
     # create dummy variables for start/end time data, where dataframe columns
     # are the x-axis bin ranges
     cats_start = pd.get_dummies(

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -273,7 +273,7 @@ def get_aggregate_data(
     return agg_df
 
 
-def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int, tmax: float = None) -> pd.DataFrame:
+def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFrame:
     """
     Builds an array similar to a 2D-histogram, where the y data is the unique
     ranks and the x data is time. Each bin is populated with the data sum
@@ -289,8 +289,6 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int, tmax: float = 
     xbins: the number of x-axis bins to create.
 
     nprocs: the number of MPI ranks/processes used at runtime.
-
-    tmax: the maximum time for the heatmap interval bins.
 
     Returns
     -------
@@ -312,12 +310,10 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int, tmax: float = 
         3                   1.048576e+06
 
     """
-    if not tmax:
-        # use final DXT segment end time
-        tmax = float(agg_df["end_time"].max())
     # generate the bin edges by generating an array of length n_bins+1, then
     # taking pairs of data points as the min/max bin value
-    bin_edge_data = np.linspace(0.0, tmax, xbins + 1)
+    max_time = agg_df["end_time"].max()
+    bin_edge_data = np.linspace(0.0, max_time, xbins + 1)
     # create dummy variables for start/end time data, where dataframe columns
     # are the x-axis bin ranges
     cats_start = pd.get_dummies(

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -20,35 +20,24 @@ def jointgrid():
 @pytest.mark.parametrize(
     "filepath, n_xlabels, expected_xticks, expected_xticklabels",
     [
-        ("ior_hdf5_example.darshan", 2, [0.0, 1.0], [0.0, 0.29]),
+        ("ior_hdf5_example.darshan", 2, [0.0, 1.0], [0.0, 1.0]),
         (
             "ior_hdf5_example.darshan",
             4,
             [0.0, 0.4, 0.6, 1.0],
-            [0.0, 0.1, 0.19, 0.29],
+            np.around(np.linspace(0, 1.0, 4), decimals=2),
         ),
         (
             "ior_hdf5_example.darshan",
             6,
             [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
-            [0.0, 0.06, 0.11, 0.17, 0.23, 0.29],
+            np.linspace(0, 1.0, 6),
         ),
         (
             "ior_hdf5_example.darshan",
             10,
             [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
-            [
-                0.0,
-                0.03,
-                0.06,
-                0.1,
-                0.13,
-                0.16,
-                0.19,
-                0.22,
-                0.25,
-                0.29,
-            ],
+            np.around(np.linspace(0, 1.0, 10), decimals=2),
         ),
         ("dxt.darshan", 2, [0.0, 1.0], [0, 1468]),
         (
@@ -69,35 +58,24 @@ def jointgrid():
             [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
             [0, 163, 326, 489, 652, 815, 978, 1141, 1304, 1468],
         ),
-        ("sample-dxt-simple.darshan", 2, [0.0, 1.0], [0.0, 0.1]),
+        ("sample-dxt-simple.darshan", 2, [0.0, 1.0], [0.0, 1.0]),
         (
             "sample-dxt-simple.darshan",
             4,
             [0.0, 0.4, 0.6, 1.0],
-            [0.0, 0.03, 0.07, 0.1],
+            np.around(np.linspace(0, 1.0, 4), decimals=2),
         ),
         (
             "sample-dxt-simple.darshan",
             6,
             [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
-            [0.0, 0.02, 0.04, 0.06, 0.08, 0.1],
+            np.linspace(0, 1.0, 6),
         ),
         (
             "sample-dxt-simple.darshan",
             10,
             [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
-            [
-                0.0,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.06,
-                0.07,
-                0.08,
-                0.09,
-                0.1,
-            ],
+            np.around(np.linspace(0, 1.0, 10), decimals=2),
         ),
         (None, 2, [0.0, 1.0], [0.0, 1.0]),
     ],
@@ -115,21 +93,19 @@ def test_set_x_axis_ticks_and_labels(
     if filepath is None:
         # don't have any data sets with a max time between 1 and 10, so
         # create a synthetic one here
-        data = [[4, 1.03378843, 1.03387713, 0], [4000, 1.04216653, 1.04231459, 0]]
-        cols = ["length", "start_time", "end_time", "rank"]
-        agg_df = pd.DataFrame(data=data, columns=cols)
+        runtime = 1
 
     else:
         filepath = get_log_path(filepath)
         # for all other data sets just load the data from the log file
+        # calculate the elapsed runtime
         report = darshan.DarshanReport(filepath)
-        agg_df = heatmap_handling.get_aggregate_data(
-            report=report, mod="DXT_POSIX", ops=["read", "write"]
-        )
+        runtime = report.metadata["job"]["end_time"] - report.metadata["job"]["start_time"]
+        runtime = max(runtime, 1)
 
     # set the x-axis ticks and tick labels
     plot_dxt_heatmap.set_x_axis_ticks_and_labels(
-        jointgrid=jointgrid, agg_df=agg_df, n_xlabels=n_xlabels
+        jointgrid=jointgrid, n_xlabels=n_xlabels, tmax=runtime,
     )
 
     # collect the actual x-axis tick labels

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -20,64 +20,64 @@ def jointgrid():
 @pytest.mark.parametrize(
     "filepath, n_xlabels, expected_xticks, expected_xticklabels",
     [
-        ("ior_hdf5_example.darshan", 2, [0.0, 1.0], [0.0, 1.0]),
+        ("ior_hdf5_example.darshan", 2, np.linspace(0.0, 348.956244, 2), [0.0, 1.0]),
         (
             "ior_hdf5_example.darshan",
             4,
-            [0.0, 0.4, 0.6, 1.0],
+            np.linspace(0.0, 348.956244, 4),
             np.around(np.linspace(0, 1.0, 4), decimals=2),
         ),
         (
             "ior_hdf5_example.darshan",
             6,
-            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            np.linspace(0.0, 348.956244, 6),
             np.linspace(0, 1.0, 6),
         ),
         (
             "ior_hdf5_example.darshan",
             10,
-            [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
+            np.linspace(0.0, 348.956244, 10),
             np.around(np.linspace(0, 1.0, 10), decimals=2),
         ),
-        ("dxt.darshan", 2, [0.0, 1.0], [0, 1468]),
+        ("dxt.darshan", 2, np.linspace(0.0, 100.023116, 2), [0, 1468]),
         (
             "dxt.darshan",
             4,
-            [0.0, 0.4, 0.6, 1.0],
+            np.linspace(0.0, 100.023116, 4),
             [0, 489, 978, 1468],
         ),
         (
             "dxt.darshan",
             6,
-            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            np.linspace(0.0, 100.023116, 6),
             [0, 293, 587, 880, 1174, 1468],
         ),
         (
             "dxt.darshan",
             10,
-            [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
+            np.linspace(0.0, 100.023116, 10),
             [0, 163, 326, 489, 652, 815, 978, 1141, 1304, 1468],
         ),
-        ("sample-dxt-simple.darshan", 2, [0.0, 1.0], [0.0, 1.0]),
+        ("sample-dxt-simple.darshan", 2, np.linspace(0.0, 959.403244, 2), [0.0, 1.0]),
         (
             "sample-dxt-simple.darshan",
             4,
-            [0.0, 0.4, 0.6, 1.0],
+            np.linspace(0.0, 959.403244, 4),
             np.around(np.linspace(0, 1.0, 4), decimals=2),
         ),
         (
             "sample-dxt-simple.darshan",
             6,
-            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            np.linspace(0.0, 959.403244, 6),
             np.linspace(0, 1.0, 6),
         ),
         (
             "sample-dxt-simple.darshan",
             10,
-            [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
+            np.linspace(0.0, 959.403244, 10),
             np.around(np.linspace(0, 1.0, 10), decimals=2),
         ),
-        (None, 2, [0.0, 1.0], [0.0, 2.0]),
+        (None, 2, [0.0, 191.880649], [0.0, 2.0]),
     ],
 )
 def test_set_x_axis_ticks_and_labels(
@@ -112,9 +112,17 @@ def test_set_x_axis_ticks_and_labels(
     if tmax_dxt > runtime:
         runtime += 1
 
-    # set the x-axis ticks and tick labels
+    # the jointgrid fixture has 100 xbins
+    xbins = 100
+    # add a heatmap to the jointgrid to simulate a normal use case
+    sns.heatmap(pd.DataFrame(np.ones((xbins, 4))), ax=jointgrid.ax_joint)
+    # calculate the scaled number of bins
+    bin_max = xbins * (runtime / tmax_dxt)
+    # set the new x limit based on the scaled bins
+    jointgrid.ax_joint.set_xlim(0.0, bin_max)
+    # set the x-axis ticks and tick labels using the runtime
     plot_dxt_heatmap.set_x_axis_ticks_and_labels(
-        jointgrid=jointgrid, n_xlabels=n_xlabels, tmax=runtime,
+        jointgrid=jointgrid, n_xlabels=n_xlabels, tmax=runtime, bin_max=bin_max,
     )
 
     # collect the actual x-axis tick labels
@@ -126,7 +134,7 @@ def test_set_x_axis_ticks_and_labels(
     plt.close()
 
     # verify the actual ticks/labels match the expected
-    assert_allclose(actual_xticks, expected_xticks, atol=1e-14, rtol=1e-17)
+    assert_allclose(actual_xticks, expected_xticks)
     assert_allclose(actual_xticklabels, expected_xticklabels, atol=1e-14, rtol=1e-17)
 
 

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -77,7 +77,7 @@ def jointgrid():
             [0.0, 1 / 9, 2 / 9, 3 / 9, 4 / 9, 5 / 9, 6 / 9, 7 / 9, 8 / 9, 1.0],
             np.around(np.linspace(0, 1.0, 10), decimals=2),
         ),
-        (None, 2, [0.0, 1.0], [0.0, 1.0]),
+        (None, 2, [0.0, 1.0], [0.0, 2.0]),
     ],
 )
 def test_set_x_axis_ticks_and_labels(
@@ -93,15 +93,24 @@ def test_set_x_axis_ticks_and_labels(
     if filepath is None:
         # don't have any data sets with a max time between 1 and 10, so
         # create a synthetic one here
+        data = [[4, 1.03378843, 1.03387713, 0], [4000, 1.04216653, 1.04231459, 0]]
+        cols = ["length", "start_time", "end_time", "rank"]
+        agg_df = pd.DataFrame(data=data, columns=cols)
         runtime = 1
 
     else:
         filepath = get_log_path(filepath)
         # for all other data sets just load the data from the log file
-        # calculate the elapsed runtime
         report = darshan.DarshanReport(filepath)
+        agg_df = heatmap_handling.get_aggregate_data(
+            report=report, mod="DXT_POSIX", ops=["read", "write"]
+        )
         runtime = report.metadata["job"]["end_time"] - report.metadata["job"]["start_time"]
-        runtime = max(runtime, 1)
+
+    runtime = max(runtime, 1)
+    tmax_dxt = float(agg_df["end_time"].max())
+    if tmax_dxt > runtime:
+        runtime += 1
 
     # set the x-axis ticks and tick labels
     plot_dxt_heatmap.set_x_axis_ticks_and_labels(


### PR DESCRIPTION
### Description

* Update `plot_heatmap()` to use the runtime for scaling x-axis

* Add `tmax` parameter to `get_heatmap_df` to allow for setting
the heatmap maximum time. Default behavior is to use the final
DXT segment end time.

* Add logic to `plot_heatmap` to prevent truncation of data
when using the job runtime for setting plotting boundaries

* Change `set_x_axis_ticks_and_labels()` and
`get_x_axis_tick_labels()` to use runtime for
x-axis labels

* Update `set_x_axis_ticks_and_labels()` parameters and expected
xticklabels in `test_set_x_axis_ticks_and_labels()`

* Contributes to x-axis rescaling portion of issue https://github.com/darshan-hpc/darshan/issues/575

### Comments
This gets us closer to resolving gh-652 because it removes the dependence on `get_aggregate_data()`, at least when it comes to the x-axis boundary setting. This should allow for an alternate code path that can generate the runtime heatmap without creating an aggregate dataframe.

There are a lot of changes to the values in some of the regression tests, but the heatmap dataframe sums remained the same, which gave me some confidence. We can probably clean up `test_runtime_dxt_heatmap_similarity()` further since the runtime/DXT heatmaps should align much closer now. I took a quick look and the resulting dataframes for that test are now nearly identical, with the exception of the column names having slightly different values (seems to be floating point related).

For the benchmarks, running `asv run --show-stderr` locally, the only errors I see are the (expected) `KeyError`s, so those look good. 