### PR TITLE
ENH: HDF5 Support for I/O Cost Figure 

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -48,6 +48,38 @@ def get_by_avg_series(df: Any, mod_key: str, nprocs: int) -> Any:
     return by_avg_series
 
 
+def combine_hdf5_modules(df: Any) -> Any:
+    """
+    Combines the "H5F" and "H5D" rows in the input dataframe into
+    a single entry under the "HDF5" title.
+
+    Parameters
+    ----------
+    df: a ``pd.DataFrame`` containing the average read, write, and meta
+    times for various pydarshan modules (i.e. "POSIX", "MPI-IO", "STDIO").
+
+    Returns
+    -------
+    Modified version of the input dataframe, where
+    if either or both "H5F" and "H5D" modules are
+    present, they have been renamed and/or summed
+    under a new index "HDF5", if available.
+
+    Notes
+    -----
+    If a single HDF5-related module is present it will
+    be renamed as "HDF5". If no HDF5-related modules
+    are present the dataframe will be unchanged.
+
+    """
+    # replace the H5D/H5F indexes with HDF5 and sum them
+    df = df.reset_index().replace(to_replace=r"H5\D", value="HDF5", regex=True)
+    df = df.groupby('index', sort=False).sum()
+    # clean up the index name
+    df.index.name = None
+    return df
+
+
 def get_io_cost_df(report: darshan.DarshanReport) -> Any:
     """
     Generates the I/O cost dataframe which contains the
@@ -64,9 +96,7 @@ def get_io_cost_df(report: darshan.DarshanReport) -> Any:
 
     """
     io_cost_dict = {}
-    # TODO: expand the scope of this function
-    # to include HDF5 module
-    supported_modules = ["POSIX", "MPI-IO", "STDIO"]
+    supported_modules = ["POSIX", "MPI-IO", "STDIO", "H5F", "H5D"]
     for mod_key in report.modules:
         if mod_key in supported_modules:
             # collect the records in dataframe form
@@ -86,6 +116,10 @@ def get_io_cost_df(report: darshan.DarshanReport) -> Any:
     # appropriate labels for each series
     # TODO: add the "by-slowest" category
     io_cost_df = pd.DataFrame(io_cost_dict).T
+
+    # combine `H5F` and `H5D` modules
+    io_cost_df = combine_hdf5_modules(df=io_cost_df)
+
     return io_cost_df
 
 

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -39,11 +39,12 @@ def get_by_avg_series(df: Any, mod_key: str, nprocs: int) -> Any:
         f"{mod_key}_F_WRITE_TIME",
         f"{mod_key}_F_META_TIME",
     ]
-    df = df.filter(cols, axis=1)
+    by_avg_series = df.filter(cols, axis=1).sum(axis=0) / nprocs
+    # reindex to ensure 3 rows are always created
+    by_avg_series = by_avg_series.reindex(cols, fill_value=0.0)
     # rename the columns so the labels are automatically generated when plotting
     name_dict = {cols[0]: "Read", cols[1]: "Write", cols[2]: "Meta"}
-    df.rename(columns=name_dict, inplace=True)
-    by_avg_series = df.sum(axis=0) / nprocs
+    by_avg_series.rename(index=name_dict, inplace=True)
     return by_avg_series
 
 


### PR DESCRIPTION
* Refactor `get_by_avg_series()` such that all modules output
`pd.Series` objects of the same shape. This is specifically
targeted at the `H5F` module, which previously produced a data
array of length 1 since it contains only "Meta" data.

* Update list of supported modules in `get_io_cost_df()`
to include `H5F` and `H5D` modules

* Add function `combine_hdf5_modules()` to aggregate the HDF5
modules (`H5F` and `H5D`) together for the I/O cost figure

* Fix test case for `test_get_io_cost_df()` as it now includes
the HDF5 module

* Add test `test_combine_hdf5_data()` to verify the HDF5
module data is being combined appropriately

* Contributes to gh-663

Description
------------
The way the HDF5 label is implemented here, if any HDF5-related modules are present in a log they will be relabeled as `HDF5` in the I/O cost figure. If both `H5F` and `H5D` are present, their `nprocs`-averaged `Meta` times will be summed (`H5F` only has `Meta` data). 

Examples
----------
Here are some example reports I generated on this branch: [example_reports.tar.gz](https://github.com/darshan-hpc/darshan/files/8345819/example_reports.tar.gz)