### PR TITLE
ENH: Runtime heatmap multiple operation support

### DIFF
--- a/darshan-util/pydarshan/darshan/datatypes/heatmap.py
+++ b/darshan-util/pydarshan/darshan/datatypes/heatmap.py
@@ -1,3 +1,6 @@
+import functools
+from typing import Sequence
+
 import numpy as np
 import pandas as pd
 
@@ -53,7 +56,7 @@ class Heatmap():
             print()
             for op in ['read', 'write']:
                 print(op)
-                plt.pcolor(self.to_df(op=op))
+                plt.pcolor(self.to_df(ops=[op]))
                 plt.show()
 
     def add_record(self, rec: dict):  
@@ -88,23 +91,24 @@ class Heatmap():
             
         self._num_recs += 1
 
-    def to_df(self, op: str, interval_index: bool = True):
+    def to_df(self, ops: Sequence[str], interval_index: bool = True):
         """
         Return heatmap as pandas dataframe.
 
         Parameters
         ----------
 
-        op: which operation type to plot. Allowed values: ["read", "write"]
-        
+        ops: a sequence of keys designating which operations to use
+        for data aggregation. If multiple operations are given, their
+        dataframes will be summed. Allowed values: ["read", "write"].
+
         interval_index: bool to enable/disable interval indices for columns
 
         """
+        for op in ops:
+            if op not in self._data:
+                raise ValueError(f"{op} not in heatmap.")
 
-        if op not in self._data:
-            raise ValueError(f"{op} not in heatmap.")
-
-        data = self._data[op]
         nbins = self._nbins
         bin_width_seconds = self._bin_width_seconds
 
@@ -113,9 +117,15 @@ class Heatmap():
             columns = pd.IntervalIndex.from_breaks(breaks)
         else:
             columns = np.arange(nbins)
-            
-        df = pd.DataFrame.from_dict(data, orient='index', columns=columns)
-        df.index.name = "rank"
 
-        return df
+        df_list = []
+        for op in ops:
+            data = self._data[op]
+            df = pd.DataFrame.from_dict(data, orient='index', columns=columns)
+            df.index.name = "rank"
+            df_list.append(df)
+
+        # sum the dataframes
+        hmap_df = functools.reduce(lambda x, y: x.add(y), df_list)
+        return hmap_df
 

--- a/darshan-util/pydarshan/darshan/datatypes/heatmap.py
+++ b/darshan-util/pydarshan/darshan/datatypes/heatmap.py
@@ -1,4 +1,3 @@
-import functools
 from typing import Sequence
 
 import numpy as np
@@ -126,6 +125,5 @@ class Heatmap():
             df_list.append(df)
 
         # sum the dataframes
-        hmap_df = functools.reduce(lambda x, y: x.add(y), df_list)
-        return hmap_df
+        return sum(df_list)
 

--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -488,3 +488,12 @@ def test_heatmap_operations(mod, expected_counts):
         assert actual_count == expected_count
 
     assert_frame_equal(rd_df + wr_df, rd_wr_df)
+
+
+def test_heatmap_df_invalid_operation():
+    # check that when invalid operations (anything other than "read"
+    # or "write") are passed to `Heatmap.to_df()` a `ValueError` is raised
+    log_path = get_log_path("e3sm_io_heatmap_only.darshan")
+    report = darshan.DarshanReport(log_path)
+    with pytest.raises(ValueError, match="invalid_op not in heatmap"):
+        report.heatmaps["POSIX"].to_df(ops=["invalid_op"])


### PR DESCRIPTION
* Add multiple operation (i.e. read and write) data aggregation
in `Heatmap.to_df()` method. This more closely reflects the way
other heatmap-related functions operate which should allow for 
a more seamless integration of the runtime heatmap into 
`plot_heatmap()`.

* Correct call signatures for heatmap `to_df()` method

* Add test `test_heatmap_operations` for checking different
operation inputs and comparing their results

* Fix issue #697