### PR TITLE
ENH: Add HDF5 operation counts figures to summary report

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -398,6 +398,15 @@ class ReportData:
         ################################
         ## Per-Module Statistics
         ################################
+
+        # for the operation counts, since the `H5D` variant contains
+        # both modules' data, we either want `H5F` or `H5D`, not both
+        opcounts_mods = ["POSIX", "MPI-IO", "STDIO"]
+        if "H5D" in self.report.modules:
+            opcounts_mods.append("H5D")
+        elif "H5F" in self.report.modules:
+            opcounts_mods.append("H5F")
+
         for mod in self.report.modules:
             if mod in ["POSIX", "MPI-IO", "H5D"]:
                 access_hist_description = (
@@ -432,7 +441,7 @@ class ReportData:
                 self.figures.append(com_acc_tbl_fig)
 
             # add the operation counts figure
-            if mod in ["POSIX", "MPI-IO", "STDIO"]:
+            if mod in opcounts_mods:
                 opcount_fig = ReportFigure(
                     section_title=f"Per-Module Statistics: {mod}",
                     fig_title="Operation Counts",

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -78,7 +78,7 @@ def test_main_with_args(tmpdir, argv):
         (["sample-dxt-simple.darshan"], 7, 4),
         (["sample-dxt-simple.darshan", "--output=test.html"], 7, 4),
         (["nonmpi_dxt_anonymized.darshan"], 5, 3),
-        (["ior_hdf5_example.darshan"], 9, 5),
+        (["ior_hdf5_example.darshan"], 10, 5),
         ([None], 0, 0),
     ]
 )


### PR DESCRIPTION
* Add `H5D` or `H5F` to operation count figure modules.
Only 1 module is added since `H5D` figure encompasses
both HDF5 modules' data.

* Correct expected figure count in `test_main_without_args`
for `ior_hdf5_example.darshan` case since `H5D` section
now contains an operation counts figure.

* Contribute to issue #663