### PR TITLE
PyDarshan: Mitigate build errors from dependencies and speedup wheel building

### DIFF
--- a/darshan-util/pydarshan/Makefile
+++ b/darshan-util/pydarshan/Makefile
@@ -72,11 +72,13 @@ docs-show:
 
 # add AutoPef Python packages...
 add-modules:
+	git submodule init
+	git submodule update
 	for file in `find ../../modules/ -name "*-backend.py"` ; do \
 		cp $$file darshan/backend/`basename $$file | cut -d '-' -f 1`.py ; \
 	done
 
-wheels:
+wheels: add-modules
 	./devel/build-all-platforms.sh
 
 release: #dist # package and upload a release

--- a/darshan-util/pydarshan/devel/build-wheels.sh
+++ b/darshan-util/pydarshan/devel/build-wheels.sh
@@ -27,16 +27,26 @@ make distclean
 cd /
 
 
-# Do not build for end-of-life python versions
-rm -f /opt/python/cp27-cp27m
-rm -f /opt/python/cp27-cp27mu
-rm -f /opt/python/cp35-cp35m
+# Uncomment any of the following lines to exclude python variant from build process
+#rm -f /opt/python/cp36-cp36m
+#rm -f /opt/python/cp37-cp37m
+#rm -f /opt/python/cp38-cp38
+#rm -f /opt/python/cp39-cp39
+#rm -f /opt/python/cp310-cp310
+#
+#rm -f /opt/python/pp37-pypy37_pp73
+#rm -f /opt/python/pp38-pypy38_pp73
+#rm -f /opt/python/pp39-pypy39_pp73
+
+
 ls /opt/python
 
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
-    "${PYBIN}/pip" install -r /io/requirements_dev.txt
+    # JL: we do not really need any dependencies to build the wheel,
+    #     but requirements install needs to be renabled when testing automatically
+    #"${PYBIN}/pip" install -r /io/requirements_wheels.txt	                    
     "${PYBIN}/pip" wheel /io/ --build-option "--with-extension" --no-deps -w /io/wheelhouse/${PLAT}
 done
 


### PR DESCRIPTION
This pull request changes the wheel building procedure by not installing pydarshan dependencies to the manylinux docker container with the following effects:

* This aviods running into build error because of dependencies changing their build procedure (an alternative could be to pin to a working set of dependencies)
* The build is significantly faster as various dependencies would attempt to build from source
* But, we can not run tests directly after building (but we did not do this so far anyways)

I also made two small changes to the Makefile:
* `make wheels` now automatically issues add-modules
* the add-modules target performs `git submodule init `and `git submoudle update`