### PR TITLE
clean up darshan-parser derived metric calculations and output

### DIFF
--- a/darshan-util/darshan-parser.c
+++ b/darshan-util/darshan-parser.c
@@ -91,7 +91,7 @@ typedef struct perf_data_s
     double slowest_rank_io_total_time;
     double slowest_rank_meta_only_time;
     int slowest_rank_rank;
-    double shared_time_by_slowest;
+    double shared_io_total_time_by_slowest;
     double agg_perf_by_slowest;
     double *rank_cumul_io_total_time;
     double *rank_cumul_md_only_time;
@@ -682,7 +682,7 @@ int main(int argc, char **argv)
             printf("# I/O timing for shared files (seconds):\n");
             printf("# (multiple estimates shown; time_by_slowest is generally the most accurate)\n");
             printf("# ...........................\n");
-            printf("# shared files: time_by_slowest: %lf\n", pdata.shared_time_by_slowest);
+            printf("# shared files: time_by_slowest: %lf\n", pdata.shared_io_total_time_by_slowest);
             printf("#\n");
             printf("# Aggregate performance, including both shared and unique files (MiB/s):\n");
             printf("# (multiple estimates shown; agg_perf_by_slowest is generally the most accurate)\n");
@@ -949,7 +949,7 @@ void stdio_accum_perf(struct darshan_stdio_file *pfile,
     if(pfile->base_rec.rank == -1)
     {
         /* by_slowest */
-        pdata->shared_time_by_slowest +=
+        pdata->shared_io_total_time_by_slowest +=
             pfile->fcounters[STDIO_F_SLOWEST_RANK_TIME];
     }
 
@@ -985,7 +985,7 @@ void posix_accum_perf(struct darshan_posix_file *pfile,
     if(pfile->base_rec.rank == -1)
     {
         /* by_slowest */
-        pdata->shared_time_by_slowest +=
+        pdata->shared_io_total_time_by_slowest +=
             pfile->fcounters[POSIX_F_SLOWEST_RANK_TIME];
     }
 
@@ -1020,7 +1020,7 @@ void mpiio_accum_perf(struct darshan_mpiio_file *mfile,
     if(mfile->base_rec.rank == -1)
     {
         /* by_slowest */
-        pdata->shared_time_by_slowest +=
+        pdata->shared_io_total_time_by_slowest +=
             mfile->fcounters[MPIIO_F_SLOWEST_RANK_TIME];
     }
 
@@ -1264,10 +1264,10 @@ void calc_perf(perf_data_t *pdata,
         }
     }
 
-    if (pdata->slowest_rank_io_total_time + pdata->shared_time_by_slowest)
+    if (pdata->slowest_rank_io_total_time + pdata->shared_io_total_time_by_slowest)
     pdata->agg_perf_by_slowest = ((double)pdata->total_bytes / 1048576.0) /
                                      (pdata->slowest_rank_io_total_time +
-                                      pdata->shared_time_by_slowest);
+                                      pdata->shared_io_total_time_by_slowest);
 
     return;
 }

--- a/darshan-util/darshan-parser.c
+++ b/darshan-util/darshan-parser.c
@@ -111,6 +111,7 @@ typedef struct perf_data_s
     int slowest_rank_rank;
     double shared_io_total_time_by_slowest;
     double agg_perf_by_slowest;
+    double agg_time_by_slowest;
     double *rank_cumul_io_total_time;
     double *rank_cumul_io_only_time;
     double *rank_cumul_md_only_time;
@@ -699,16 +700,16 @@ int main(int argc, char **argv)
             printf("# ...........................\n");
             printf("# unique files: slowest_rank_io_time: %lf\n", pdata.slowest_rank_io_total_time);
             printf("# unique files: slowest_rank_meta_only_time: %lf\n", pdata.slowest_rank_meta_only_time);
+            printf("# unique files: slowest_rank_io_only_time: %lf\n", pdata.slowest_rank_io_only_time);
             printf("# unique files: slowest_rank: %d\n", pdata.slowest_rank_rank);
             printf("#\n");
             printf("# I/O timing for shared files (seconds):\n");
-            printf("# (multiple estimates shown; time_by_slowest is generally the most accurate)\n");
             printf("# ...........................\n");
             printf("# shared files: time_by_slowest: %lf\n", pdata.shared_io_total_time_by_slowest);
             printf("#\n");
             printf("# Aggregate performance, including both shared and unique files (MiB/s):\n");
-            printf("# (multiple estimates shown; agg_perf_by_slowest is generally the most accurate)\n");
             printf("# ...........................\n");
+            printf("# agg_time_by_slowest: %lf\n", pdata.agg_time_by_slowest);
             printf("# agg_perf_by_slowest: %lf\n", pdata.agg_perf_by_slowest);
         }
 
@@ -1304,6 +1305,8 @@ void calc_perf(perf_data_t *pdata,
     pdata->agg_perf_by_slowest = ((double)pdata->total_bytes / 1048576.0) /
                                      (pdata->slowest_rank_io_total_time +
                                       pdata->shared_io_total_time_by_slowest);
+    pdata->agg_time_by_slowest = pdata->slowest_rank_io_total_time +
+                                 pdata->shared_io_total_time_by_slowest;
 
     return;
 }

--- a/darshan-util/doc/darshan-util.txt
+++ b/darshan-util/doc/darshan-util.txt
@@ -284,10 +284,10 @@ value of 1 MiB for optimal file alignment.
 | POSIX_STRIDE[1-4]_COUNT | Count of 4 most common stride patterns
 | POSIX_ACCESS[1-4]_ACCESS | 4 most common POSIX access sizes
 | POSIX_ACCESS[1-4]_COUNT | Count of 4 most common POSIX access sizes
-| POSIX_FASTEST_RANK | The MPI rank with smallest time spent in POSIX I/O
-| POSIX_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with smallest time spent in POSIX I/O
-| POSIX_SLOWEST_RANK | The MPI rank with largest time spent in POSIX I/O
-| POSIX_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in POSIX I/O
+| POSIX_FASTEST_RANK | The MPI rank with smallest time spent in POSIX I/O (cumulative read, write, and meta times)
+| POSIX_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with smallest time spent in POSIX I/O (cumulative read, write, and meta times)
+| POSIX_SLOWEST_RANK | The MPI rank with largest time spent in POSIX I/O (cumulative read, write, and meta times)
+| POSIX_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in POSIX I/O (cumulative read, write, and meta times)
 | POSIX_F_*_START_TIMESTAMP | Timestamp that the first POSIX file open/read/write/close operation began
 | POSIX_F_*_END_TIMESTAMP | Timestamp that the last POSIX file open/read/write/close operation ended
 | POSIX_F_READ_TIME | Cumulative time spent reading at the POSIX level
@@ -296,7 +296,7 @@ value of 1 MiB for optimal file alignment.
 | POSIX_F_MAX_READ_TIME | Duration of the slowest individual POSIX read operation
 | POSIX_F_MAX_WRITE_TIME | Duration of the slowest individual POSIX write operation
 | POSIX_F_FASTEST_RANK_TIME | The time of the rank which had the smallest amount of time spent in POSIX I/O (cumulative read, write, and meta times)
-| POSIX_F_SLOWEST_RANK_TIME | The time of the rank which had the largest amount of time spent in POSIX I/O
+| POSIX_F_SLOWEST_RANK_TIME | The time of the rank which had the largest amount of time spent in POSIX I/O (cumulative read, write, and meta times)
 | POSIX_F_VARIANCE_RANK_TIME | The population variance for POSIX I/O time of all the ranks
 | POSIX_F_VARIANCE_RANK_BYTES | The population variance for bytes transferred of all the ranks
 |====
@@ -330,8 +330,8 @@ value of 1 MiB for optimal file alignment.
 | MPIIO_ACCESS[1-4]_COUNT | Count of 4 most common MPI aggregate access sizes
 | MPIIO_FASTEST_RANK | The MPI rank with smallest time spent in MPI I/O
 | MPIIO_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with smallest time spent in MPI I/O
-| MPIIO_SLOWEST_RANK | The MPI rank with largest time spent in MPI I/O
-| MPIIO_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in MPI I/O
+| MPIIO_SLOWEST_RANK | The MPI rank with largest time spent in MPI I/O (cumulative read, write, and meta times)
+| MPIIO_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in MPI I/O (cumulative read, write, and meta times)
 | MPIIO_F_*_START_TIMESTAMP | Timestamp that the first MPIIO file open/read/write/close operation began
 | MPIIO_F_*_END_TIMESTAMP | Timestamp that the last MPIIO file open/read/write/close operation ended
 | MPIIO_F_READ_TIME | Cumulative time spent reading at MPI level
@@ -340,7 +340,7 @@ value of 1 MiB for optimal file alignment.
 | MPIIO_F_MAX_READ_TIME | Duration of the slowest individual MPI read operation
 | MPIIO_F_MAX_WRITE_TIME | Duration of the slowest individual MPI write operation
 | MPIIO_F_FASTEST_RANK_TIME | The time of the rank which had the smallest amount of time spent in MPI I/O (cumulative read, write, and meta times)
-| MPIIO_F_SLOWEST_RANK_TIME | The time of the rank which had the largest amount of time spent in MPI I/O
+| MPIIO_F_SLOWEST_RANK_TIME | The time of the rank which had the largest amount of time spent in MPI I/O (cumulative read, write, and meta times)
 | MPIIO_F_VARIANCE_RANK_TIME | The population variance for MPI I/O time of all the ranks
 | MPIIO_F_VARIANCE_RANK_BYTES | The population variance for bytes transferred of all the ranks at MPI level
 |====
@@ -360,17 +360,17 @@ value of 1 MiB for optimal file alignment.
 | STDIO_BYTES_READ | Total number of bytes read from the file using stdio operations
 | STDIO_MAX_BYTE_READ | Highest offset in the file that was read
 | STDIO_MAX_BYTE_WRITTEN | Highest offset in the file that was written
-| STDIO_FASTEST_RANK | The MPI rank with the smallest time spent in stdio operations
-| STDIO_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with the smallest time spent in stdio operations
-| STDIO_SLOWEST_RANK | The MPI rank with the largest time spent in stdio operations
-| STDIO_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in stdio operations
+| STDIO_FASTEST_RANK | The MPI rank with the smallest time spent in stdio operations (cumulative read, write, and meta times)
+| STDIO_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with the smallest time spent in stdio operations (cumulative read, write, and meta times)
+| STDIO_SLOWEST_RANK | The MPI rank with the largest time spent in stdio operations (cumulative read, write, and meta times)
+| STDIO_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in stdio operations (cumulative read, write, and meta times)
 | STDIO_META_TIME | Cumulative time spent in stdio open/close/seek operations
 | STDIO_WRITE_TIME | Cumulative time spent in stdio write operations
 | STDIO_READ_TIME | Cumulative time spent in stdio read operations
 | STDIO_*_START_TIMESTAMP | Timestamp that the first stdio file open/read/write/close operation began
 | STDIO_*_END_TIMESTAMP | Timestamp that the last stdio file open/read/write/close operation ended
 | STDIO_F_FASTEST_RANK_TIME | The time of the rank which had the smallest time spent in stdio I/O (cumulative read, write, and meta times)
-| STDIO_F_SLOWEST_RANK_TIME | The time of the rank which had the largest time spent in stdio I/O
+| STDIO_F_SLOWEST_RANK_TIME | The time of the rank which had the largest time spent in stdio I/O (cumulative read, write, and meta times)
 | STDIO_F_VARIANCE_RANK_TIME | The population variance for stdio I/O time of all the ranks
 | STDIO_F_VARIANCE_RANK_BYTES | The population variance for bytes transferred of all the ranks
 |====
@@ -415,10 +415,10 @@ value of 1 MiB for optimal file alignment.
 | H5D_CHUNK_SIZE_D[1-5] | Chunk sizes in the last 5 dimensions of the dataset (D5 is the fastest changing dimension)
 | H5D_USE_MPIIO_COLLECTIVE | Flag indicating use of MPI-IO collectives
 | H5D_USE_DEPRECATED | Flag indicating whether deprecated create/open calls were used
-| H5D_FASTEST_RANK | The MPI rank with smallest time spent in H5D I/O
-| H5D_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with smallest time spent in H5D I/O
-| H5D_SLOWEST_RANK | The MPI rank with largest time spent in H5D I/O
-| H5D_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in H5D I/O
+| H5D_FASTEST_RANK | The MPI rank with smallest time spent in H5D I/O (cumulative read, write, and meta times)
+| H5D_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with smallest time spent in H5D I/O (cumulative read, write, and meta times)
+| H5D_SLOWEST_RANK | The MPI rank with largest time spent in H5D I/O (cumulative read, write, and meta times)
+| H5D_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in H5D I/O (cumulative read, write, and meta times)
 | H5D_F_*_START_TIMESTAMP | Timestamp that the first H5D open/read/write/close operation began
 | H5D_F_*_END_TIMESTAMP | Timestamp that the last H5D open/read/write/close operation ended
 | H5D_F_READ_TIME | Cumulative time spent reading at H5D level
@@ -427,7 +427,7 @@ value of 1 MiB for optimal file alignment.
 | H5D_F_MAX_READ_TIME | Duration of the slowest individual H5D read operation
 | H5D_F_MAX_WRITE_TIME | Duration of the slowest individual H5D write operation
 | H5D_F_FASTEST_RANK_TIME | The time of the rank which had the smallest amount of time spent in H5D I/O (cumulative read, write, and meta times)
-| H5D_F_SLOWEST_RANK_TIME | The time of the rank which had the largest amount of time spent in H5D I/O
+| H5D_F_SLOWEST_RANK_TIME | The time of the rank which had the largest amount of time spent in H5D I/O (cumulative read, write, and meta times)
 | H5D_F_VARIANCE_RANK_TIME | The population variance for H5D I/O time of all the ranks
 | H5D_F_VARIANCE_RANK_BYTES | The population variance for bytes transferred of all the ranks at H5D level
 | H5D_FILE_REC_ID | Darshan file record ID of the file the dataset belongs to


### PR DESCRIPTION
Fixes #245 

This PR does three things to darshan-parser at a high level:
- completely eliminates the 3 deprecated performance estimates (leaving only the _by_slowest method)
- renames variables and adds comments in the source code to clarify a few calculations
- adds two new --perf output fields for completeness (previously these could only be derived by working backwards from other fields):
  - agg_time_by_slowest
  - slowest_rank_io_only_time

Example of new --perf output for a module:
```
# *******************************************************
# STDIO module data
# *******************************************************

# performance
# -----------
# total_bytes: 100663618
#
# I/O timing for unique files (seconds):
# ...........................
# unique files: slowest_rank_io_time: 0.014875
# unique files: slowest_rank_meta_only_time: 0.000178
# unique files: slowest_rank_io_only_time: 0.014697
# unique files: slowest_rank: 1
#
# I/O timing for shared files (seconds):
# ...........................
# shared files: time_by_slowest: 0.026610
#
# Aggregate performance, including both shared and unique files (MiB/s):
# ...........................
# agg_time_by_slowest: 0.041485
# agg_perf_by_slowest: 2314.119460
```

Here is a diff showing all changes from a complete darshan-parser --perf run on a given log:
```
86a87
> # unique files: slowest_rank_io_only_time: 0.000000
90d90
< # (multiple estimates shown; time_by_slowest is generally the most accurate)
92,95d91
< # shared files: time_by_cumul_io_only: 0.028280
< # shared files: time_by_cumul_meta_only: 0.000044
< # shared files: time_by_open: 0.079830
< # shared files: time_by_open_lastio: 0.079636
99d94
< # (multiple estimates shown; agg_perf_by_slowest is generally the most accurate)
101,103c96
< # agg_perf_by_cumul: 4526.125582
< # agg_perf_by_open: 1603.408621
< # agg_perf_by_open_lastio: 1607.320943
---
> # agg_time_by_slowest: 0.040990
117a111
> # unique files: slowest_rank_io_only_time: 0.000000
121d114
< # (multiple estimates shown; time_by_slowest is generally the most accurate)
123,126d115
< # shared files: time_by_cumul_io_only: 0.034118
< # shared files: time_by_cumul_meta_only: 0.005193
< # shared files: time_by_open: 0.083205
< # shared files: time_by_open_lastio: 0.082503
130d118
< # (multiple estimates shown; agg_perf_by_slowest is generally the most accurate)
132,134c120
< # agg_perf_by_cumul: 3751.666028
< # agg_perf_by_open: 1538.373780
< # agg_perf_by_open_lastio: 1551.461707
---
> # agg_time_by_slowest: 0.046796
148a135
> # unique files: slowest_rank_io_only_time: 0.014697
152d138
< # (multiple estimates shown; time_by_slowest is generally the most accurate)
154,157d139
< # shared files: time_by_cumul_io_only: 0.016924
< # shared files: time_by_cumul_meta_only: 0.003774
< # shared files: time_by_open: 0.028915
< # shared files: time_by_open_lastio: 0.118086
161d142
< # (multiple estimates shown; agg_perf_by_slowest is generally the most accurate)
163,165c144
< # agg_perf_by_cumul: 3018.999067
< # agg_perf_by_open: 2192.295185
< # agg_perf_by_open_lastio: 722.018351
---
> # agg_time_by_slowest: 0.041485
```