### PR TITLE
MAINT: Include `H5D` columns in `H5F`-only operation counts figure

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
@@ -75,8 +75,13 @@ def gather_count_data(report, mod):
         ]
 
     elif mod == 'H5F':
-        labels = ['Open', 'Flush']
+        labels = [
+            'H5D Read', 'H5D Write', 'H5D Open',
+            'H5D Flush', 'H5F Open', 'H5F Flush',
+        ]
         counts = [
+            # set H5D counters to zero
+            0, 0, 0, 0,
             mod_data['H5F_OPENS'],
             mod_data['H5F_FLUSHES'],
         ]

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -114,7 +114,8 @@ darshan.enable_experimental()
             "ior_hdf5_example.darshan",
             "H5F",
             plot_opcounts,
-            ['Open', 'Flush'],
+            ['H5D Read', 'H5D Write', 'H5D Open',
+            'H5D Flush', 'H5F Open', 'H5F Flush'],
         ),
         (
             "ior_hdf5_example.darshan",
@@ -267,7 +268,7 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             "ior_hdf5_example.darshan",
             "H5F",
             plot_opcounts,
-            [6, 0],
+            [0, 0, 0, 0, 6, 0],
         ),
         (
             "ior_hdf5_example.darshan",


### PR DESCRIPTION
Description
--------------

* Change operation counts figure to always list columns for
both `H5F` and `H5D` modules. When `H5D` module data is not
present the values are set to zero.

* Contribute to issue #706

Example
----------
Here is the updated operation counts figure for `hdf5_file_opens_only.darshan`:
![image](https://user-images.githubusercontent.com/46797896/162284989-8f2636b5-8ac0-45bd-b3eb-4351e4212a63.png)
