### PR TITLE
TST: Close figures in `test_bar_heights`

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -291,4 +291,6 @@ def test_bar_heights(filename, mod, fig_func, expected_heights):
         for patch in ax.patches:
             actual_heights.append(patch.get_height())
 
+    plt.close(fig)
+
     assert_array_equal(actual_heights, expected_heights)


### PR DESCRIPTION
* Add appropriate close statement to ensure each figure
in `test_plot_exp_common.test_bar_heights` is closed.

* Fix issue darshan-hpc/darshan-logs#34

* Both CI commands pass after this change:
    - `pytest --pyargs darshan`
    - `pytest --import-mode=importlib`