### PR TITLE
TST: Add HDF5 test cases using "ground truth" logs 

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_plot_common_access_table.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_common_access_table.py
@@ -45,13 +45,45 @@ from darshan.log_utils import get_log_path
             # values from the old report (Perl) code
             pd.DataFrame([[241664, 71400], [294912, 18806], [483328, 4862], [512, 1003]]),
         ),
+        (
+            # "ground truth" log where 10 ranks wrote 1 byte each
+            "hdf5_diagonal_write_1_byte_dxt.darshan",
+            "H5D",
+            pd.DataFrame([[1, 10]]),
+        ),
+        (
+            # "ground truth" log where 10 ranks wrote `10 * (1 + rank)` bytes
+            # each (e.g. 10 bytes for rank 0, 20 bytes for rank 1, etc.)
+            "hdf5_diagonal_write_bytes_range_dxt.darshan",
+            "H5D",
+            pd.DataFrame(
+                [[10, 1], [20, 1], [30, 1], [40, 1], [50, 1],
+                [60, 1], [70, 1], [80, 1], [90, 1], [100, 1]],
+            ),
+        ),
+        (
+            # "ground truth" log where 10 ranks wrote 1 byte each and
+            # 5 of the ranks called the `flush` operation. Results
+            # should be the same as `hdf5_diagonal_write_1_byte_dxt.darshan`
+            "hdf5_diagonal_write_half_flush_dxt.darshan",
+            "H5D",
+            pd.DataFrame([[1, 10]]),
+        ),
+        (
+            # "ground truth" log where 5 ranks wrote 1 byte each
+            "hdf5_diagonal_write_half_ranks_dxt.darshan",
+            "H5D",
+            pd.DataFrame([[1, 5]]),
+        ),
     ],
 )
 def test_common_access_table(filename, mod, expected_df):
     log_path = get_log_path(filename=filename)
     expected_df.columns = ["Access Size", "Count"]
     report = darshan.DarshanReport(log_path)
-    actual_df = plot_common_access_table.plot_common_access_table(report=report, mod=mod).df
+    # collect the number of rows from the expected dataframe
+    n_rows = expected_df.shape[0]
+    actual_df = plot_common_access_table.plot_common_access_table(report=report, mod=mod, n_rows=n_rows).df
     assert_frame_equal(actual_df, expected_df)
 
 

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -210,6 +210,29 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             [11, 2492, 2, 0, 0, 0, 0, 410, 86, 0, 2526,
             303, 2, 0, 97812, 396, 0, 410, 86, 0],
         ),
+        # "ground truth" log where 10 ranks wrote 1 byte each
+        (
+            "hdf5_diagonal_write_1_byte_dxt.darshan",
+            "H5D",
+            plot_access_histogram,
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ),
+        # "ground truth" log where 10 ranks wrote 10-100 bytes each.
+        # Should be the same as `hdf5_diagonal_write_1_byte_dxt.darshan`
+        # since the first bin includes 0-100
+        (
+            "hdf5_diagonal_write_bytes_range_dxt.darshan",
+            "H5D",
+            plot_access_histogram,
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ),
+        # "ground truth" log where 5 ranks wrote 1 byte each
+        (
+            "hdf5_diagonal_write_half_ranks_dxt.darshan",
+            "H5D",
+            plot_access_histogram,
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ),
         (
             "dxt.darshan",
             "POSIX",
@@ -275,6 +298,48 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             "H5D",
             plot_opcounts,
             [12, 12, 6, 0, 6, 0],
+        ),
+        # "ground truth" log with only 3 `H5F` opens
+        (
+            "hdf5_file_opens_only.darshan",
+            "H5F",
+            plot_opcounts,
+            [0, 0, 0, 0, 3, 0],
+        ),
+        # "ground truth" log where 10 files and datasets are opened
+        # and each dataset is written to once
+        (
+            "hdf5_diagonal_write_1_byte_dxt.darshan",
+            "H5D",
+            plot_opcounts,
+            [0, 10, 10, 0, 10, 0],
+        ),
+        # "ground truth" log where 10 files and datasets are opened
+        # and each dataset is written to once. Should match
+        # `hdf5_diagonal_write_1_byte_dxt.darshan` since they only
+        # differ in the number of bytes written to each dataset
+        (
+            "hdf5_diagonal_write_bytes_range_dxt.darshan",
+            "H5D",
+            plot_opcounts,
+            [0, 10, 10, 0, 10, 0],
+        ),
+        # "ground truth" log where 10 files and datasets are opened,
+        # each dataset is written to once, and half of the files
+        # call the flush operation
+        (
+            "hdf5_diagonal_write_half_flush_dxt.darshan",
+            "H5D",
+            plot_opcounts,
+            [0, 10, 10, 0, 10, 5],
+        ),
+        # "ground truth" log where 10 files are opened and 5
+        # datasets are opened and written to
+        (
+            "hdf5_diagonal_write_half_ranks_dxt.darshan",
+            "H5D",
+            plot_opcounts,
+            [0, 5, 5, 0, 10, 0],
         ),
     ],
 )


### PR DESCRIPTION
Description
-------------
* Add "ground truth" testing log cases to `test_common_access_table`
and change the number of rows to be configurable based on the
number of rows in the input `expected_df`

* Add "ground truth" testing log cases to `test_plot_exp_common.py`
tests `test_xticks_and_labels` and `test_bar_heights` to check
results for `plot_opcounts` and `plot_access_histogram`

* Fix issue https://github.com/darshan-hpc/darshan/issues/706

Considerations
-----------------
This branch is based off of the feature branch in gh-711, so it should be reviewed/merged last. 