### PR TITLE
ENH: summary with runtime heatmaps

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -4,6 +4,7 @@ import io
 import base64
 import argparse
 import datetime
+from collections import OrderedDict
 if sys.version_info >= (3, 7):
     import importlib.resources as importlib_resources
 else:
@@ -341,21 +342,26 @@ class ReportData:
         )
         modules_avail = set(self.report.modules)
         hmap_modules = ["HEATMAP", "DXT_POSIX", "DXT_MPIIO"]
+        hmap_grid = OrderedDict([["HEATMAP_MPIIO", None],
+                                 ["DXT_MPIIO", None],
+                                 ["HEATMAP_POSIX", None],
+                                 ["DXT_POSIX", None],
+                                 ["HEATMAP_STDIO", None],
+                                ])
         if not set(hmap_modules).isdisjoint(modules_avail):
             for mod in hmap_modules:
                 if mod in self.report.modules:
                     if mod == "HEATMAP":
-                        for possible_submodule in ["POSIX", "MPI-IO", "STDIO"]:
-                            if possible_submodule in self.report.modules:
-                                possible_submodule = possible_submodule.replace("-", "")
-                                heatmap_fig = ReportFigure(
-                                    section_title="I/O Summary",
-                                    fig_title=f"Heat Map: {mod} {possible_submodule}",
-                                    fig_func=plot_dxt_heatmap.plot_heatmap,
-                                    fig_args=dict(report=self.report, mod=mod, submodule=possible_submodule),
-                                    fig_description=hmap_description,
-                                )
-                                self.figures.append(heatmap_fig)
+                        for possible_submodule in self.report.heatmaps:
+                            possible_submodule = possible_submodule.replace("-", "")
+                            heatmap_fig = ReportFigure(
+                                section_title="I/O Summary",
+                                fig_title=f"Heat Map: {mod} {possible_submodule}",
+                                fig_func=plot_dxt_heatmap.plot_heatmap,
+                                fig_args=dict(report=self.report, mod=mod, submodule=possible_submodule),
+                                fig_description=hmap_description,
+                            )
+                            hmap_grid[f"HEATMAP_{possible_submodule}"] = heatmap_fig
                     else:
                         heatmap_fig = ReportFigure(
                             section_title="I/O Summary",
@@ -364,18 +370,24 @@ class ReportData:
                             fig_args=dict(report=self.report, mod=mod),
                             fig_description=hmap_description,
                         )
-                        self.figures.append(heatmap_fig)
+                        hmap_grid[mod] = heatmap_fig
+            for heatmap_fig in hmap_grid.values():
+                if heatmap_fig:
+                    self.figures.append(heatmap_fig)
         else:
-            # temporary message to direct users to DXT tracing
-            # documentation until DXT tracing is enabled by default
             url = (
                 "https://www.mcs.anl.gov/research/projects/darshan/docs/darshan"
                 "-runtime.html#_using_the_darshan_extended_tracing_dxt_module"
             )
             temp_message = (
-                f"Heat map is not available for this job as DXT was not "
-                f"enabled at run time. For details on how to enable DXT visit "
-                f"the <a href={url}>Darshan-runtime documentation</a>."
+                    "Heatmap data is not available for this job. Consider "
+                    "enabling the runtime heatmap module (available and "
+                    "enabled by default in Darshan 3.4 or newer) or the "
+                    "DXT tracing module (available and optionally enabled "
+                    "in Darshan 3.1.3 or newer) if you would like to analyze "
+                    "I/O intensity using a heatmap visualization. "
+                    "For details, see "
+                    f"the <a href={url}>Darshan-runtime documentation</a>."
             )
             fig = ReportFigure(
                 section_title="I/O Summary",

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -358,7 +358,12 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     # for each row (IO event) fill in any empty (NaN) bins
     # between filled bins because those are time spans b/w start
     # and stop events
-    cats.interpolate(method="linear", limit_area="inside", axis=1, inplace=True)
+    # interpolation is pointless when there is
+    # a single non-null value in a row
+    null_mask = cats.notna().sum(axis=1) > 1
+    cats_vals_to_interp = pd.DataFrame(cats[null_mask].values)
+    cats_vals_to_interp.interpolate(method="nearest", axis=1, inplace=True)
+    cats.iloc[null_mask] = cats_vals_to_interp
     # each time bin containing an event has a 1 in it, otherwise NaN
     # store mask for restoring fully occupied bins
     mask_occ = cats == 2

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -360,11 +360,14 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     # and stop events
     # interpolation is pointless when there is
     # a single non-null value in a row
-    null_mask = cats.notna().sum(axis=1) > 1
-    null_mask = null_mask.loc[null_mask == True].index
-    cats_vals_to_interp = pd.DataFrame(cats.iloc[null_mask].values)
-    cats_vals_to_interp.interpolate(method="nearest", axis=1, inplace=True)
-    cats.iloc[null_mask] = cats_vals_to_interp
+    if sys.version_info.minor < 7:
+        cats.interpolate(method="linear", limit_area="inside", axis=1, inplace=True)
+    else:
+        null_mask = cats.notna().sum(axis=1) > 1
+        null_mask = null_mask.loc[null_mask == True].index
+        cats_vals_to_interp = pd.DataFrame(cats.iloc[null_mask].values)
+        cats_vals_to_interp.interpolate(method="nearest", axis=1, inplace=True)
+        cats.iloc[null_mask] = cats_vals_to_interp
     # each time bin containing an event has a 1 in it, otherwise NaN
     # store mask for restoring fully occupied bins
     mask_occ = cats == 2

--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -361,7 +361,8 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     # interpolation is pointless when there is
     # a single non-null value in a row
     null_mask = cats.notna().sum(axis=1) > 1
-    cats_vals_to_interp = pd.DataFrame(cats[null_mask].values)
+    null_mask = null_mask.loc[null_mask == True].index
+    cats_vals_to_interp = pd.DataFrame(cats.iloc[null_mask].values)
     cats_vals_to_interp.interpolate(method="nearest", axis=1, inplace=True)
     cats.iloc[null_mask] = cats_vals_to_interp
     # each time bin containing an event has a 1 in it, otherwise NaN

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -3,6 +3,7 @@ Module for creating the ranks vs. time IO intensity
 heatmap figure for the Darshan job summary.
 """
 
+import functools
 from typing import (Any, List, Sequence, Union,
                     TYPE_CHECKING, Tuple, Optional)
 
@@ -29,6 +30,7 @@ import darshan
 from darshan.experimental.plots import heatmap_handling
 
 
+@functools.lru_cache(maxsize=10)
 def determine_hmap_runtime(report: darshan.DarshanReport) -> Tuple[float, float]:
     """
     Determine the effective heatmap runtime to be used

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -411,7 +411,7 @@ def test_plot_heatmap(filepath, mod, ops):
     report = darshan.DarshanReport(filepath)
 
     if mod == "POSIX":
-        with pytest.raises(NotImplementedError, match="Only DXT modules are supported."):
+        with pytest.raises(NotImplementedError, match="Only DXT and HEATMAP modules are supported."):
             plot_dxt_heatmap.plot_heatmap(report=report, mod=mod)
     elif ("dxt.darshan" in filepath) & (mod == "DXT_MPIIO"):
         # if the input module is not "DXT_POSIX" check

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -176,6 +176,8 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                     for dxt_mod in ["DXT_POSIX", "DXT_MPIIO"]:
                         if dxt_mod in report.modules:
                             assert f"Heat Map: {dxt_mod}" in report_str
+                elif "HEATMAP" in "\t".join(report.modules):
+                    assert "Heat Map: HEATMAP" in report_str
                 else:
                     # check that help message is present
                     assert "Heat map is not available for this job" in report_str
@@ -188,6 +190,16 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                 # check the number of opening section tags
                 # matches the number of closing section tags
                 assert report_str.count("<section>") == report_str.count("</section>")
+
+                # check for presence of expected runtime HEATMAPs
+                actual_runtime_heatmap_titles = report_str.count("<h3>Heat Map: HEATMAP")
+                if "e3sm_io_heatmap_only" in log_filepath:
+                    assert actual_runtime_heatmap_titles == 3
+                elif "runtime_and_dxt_heatmaps_diagonal_write_only" in log_filepath:
+                    assert actual_runtime_heatmap_titles == 1
+                else:
+                    assert actual_runtime_heatmap_titles == 0
+
 
 class TestReportData:
 

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -115,7 +115,8 @@ def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_coun
                                 assert f"Heat Map: {dxt_mod}" in report_str
                     else:
                         # check that help message is present
-                        assert "Heat map is not available for this job" in report_str
+                        assert "Heatmap data is not available for this job" in report_str
+                        assert "Consider enabling the runtime heatmap module" in report_str
 
                     # check that expected number of figures are found
                     assert report_str.count("<img") == expected_img_count
@@ -176,11 +177,22 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                     for dxt_mod in ["DXT_POSIX", "DXT_MPIIO"]:
                         if dxt_mod in report.modules:
                             assert f"Heat Map: {dxt_mod}" in report_str
+                        # MPIIO should come first
+                        mpiio_position = report_str.find("Heat Map: DXT_MPIIO")
+                        posix_position = report_str.find("Heat Map: DXT_POSIX")
+                        if mpiio_position != -1 and posix_position != -1:
+                            assert mpiio_position < posix_position
                 elif "HEATMAP" in "\t".join(report.modules):
                     assert "Heat Map: HEATMAP" in report_str
+                    # enforce the desired order
+                    mpiio_position = report_str.find("Heat Map: HEATMAP MPIIO")
+                    posix_position = report_str.find("Heat Map: HEATMAP POSIX")
+                    stdio_position = report_str.find("Heat Map: HEATMAP STDIO")
+                    assert mpiio_position < posix_position < stdio_position
                 else:
                     # check that help message is present
-                    assert "Heat map is not available for this job" in report_str
+                    assert "Heatmap data is not available for this job" in report_str
+                    assert "Consider enabling the runtime heatmap module" in report_str
 
                 # check if I/O cost figure is present
                 for mod in report.modules:


### PR DESCRIPTION
Fixes #652

* add the runtime (`HEATMAP` module) heatmaps to
the pydarshan/Python summary reports

* adjust some tests to reflect the new runtime `HEATMAP`
  support and to test some components of it in a bit
  more detail

* design considerations:
  - at the moment, the runtime heatmaps are placed first, but it may
    be helpful to grid i.e., POSIX versions of DXT and runtime maps
    side-by-side to make the comparisons less jarring
  - it is a bit awkward that `DXT` data is directly associated with the
    module data source like `DXT_POSIX`, while for `HEATMAP` we index
    into a "submodule" dictionary--this awkwardness should be clear in
    the diff--not sure if we want to do anything about that
  - the new `determine_hmap_runtime()` function was added to provide
    a common abstraction when plotting heatmap data (i.e., this gives
    you access to DXT time resolution if available, even when only
    calling `plot_heatmap()` for `HEATMAP` module); this should be "ok"
    even if in the future we disable plotting the `DXT` data for large
    cases because it is mostly the plotting-related expansion of the
    data that causes the memory explosion rather than raw `DXT` access
  - it is a bit awkward that some of this machinery now resides in
    `plot_dxt_heatmap.py`, but now supports modes of operation
     that don't require DXT data at all--since this is mostly a naming
     issue it might be deferred for a while

<details>

<summary> Below the fold is an example for `e3sm_io_heatmap_and_dxt.darshan`, which might be more conveniently organized in the grid layout described above. (whitespace also pretty wild on widescreen monitor, but that's another matter) </summary>

![image](https://user-images.githubusercontent.com/7903078/163627625-f8eb7b22-4215-4f2f-b82d-e5674d9ecae1.png)


</details>