### PR TITLE
WIP, ENH: summary with data access cats

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -22,6 +22,7 @@ from darshan.experimental.plots import (
     plot_common_access_table,
     plot_access_histogram,
     plot_opcounts,
+    data_access_by_filesystem,
 )
 
 darshan.enable_experimental()
@@ -459,6 +460,20 @@ class ReportData:
                     fig_width=350,
                 )
                 self.figures.append(opcount_fig)
+
+        #########################
+        # Data Access by Category
+        if not {"POSIX", "STDIO"}.isdisjoint(set(self.report.modules)):
+            data_access_by_cat_fig = ReportFigure(
+                section_title="Data Access by Category",
+                fig_title="",
+                fig_func=data_access_by_filesystem.plot_with_report,
+                fig_args=dict(report=self.report, num_cats=8),
+                fig_description="",
+                fig_width=1,
+            )
+            self.figures.append(data_access_by_cat_fig)
+
 
 
     def build_sections(self):

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -469,8 +469,11 @@ class ReportData:
                 fig_title="",
                 fig_func=data_access_by_filesystem.plot_with_report,
                 fig_args=dict(report=self.report, num_cats=8),
-                fig_description="",
-                fig_width=1,
+                fig_description="Summary of data access volume "
+                                "categorized by storage "
+                                "target (e.g., file system "
+                                "mount point) and sorted by volume.",
+                fig_width=500,
             )
             self.figures.append(data_access_by_cat_fig)
 

--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -646,17 +646,25 @@ def plot_with_report(report: darshan.DarshanReport,
     file_id_dict = report.data["name_records"]
     filesystem_roots = identify_filesystems(file_id_dict=file_id_dict,
                                             verbose=verbose)
+    # NOTE: this is a bit ugly, STDIO and POSIX are both combined
+    # automatically later in the control flow, so an API redesign
+    # may be in order eventually
+    default_mod = "POSIX"
+    if "POSIX" not in report.modules:
+        # STDIO can also be used for this figure/analysis
+        default_mod = "STDIO"
+
     file_rd_series, file_wr_series = unique_fs_rw_counter(report=report,
                                                           filesystem_roots=filesystem_roots,
                                                           file_id_dict=file_id_dict,
                                                           processing_func=process_unique_files,
-                                                          mod='POSIX',
+                                                          mod=default_mod,
                                                           verbose=verbose)
     bytes_rd_series, bytes_wr_series = unique_fs_rw_counter(report=report,
                                                             filesystem_roots=filesystem_roots,
                                                             file_id_dict=file_id_dict,
                                                             processing_func=process_byte_counts,
-                                                            mod='POSIX', verbose=verbose)
+                                                            mod=default_mod, verbose=verbose)
     # reverse sort by total bytes IO per category
     sort_inds = (bytes_rd_series + bytes_wr_series).argsort()[::-1]
     if num_cats is None:

--- a/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
@@ -354,15 +354,6 @@ def test_empty_data_posix_text_position():
                     assert_allclose(child.get_position(), (0, 0.25))
 
 
-def test_posix_absent():
-    # check for an appropriate error when POSIX data
-    # is not even recorded in the darshan log
-    log_file_path = get_log_path('noposix.darshan')
-    report = darshan.DarshanReport(log_file_path)
-    with pytest.raises(ValueError, match="POSIX module data is required"):
-        actual_fig = data_access_by_filesystem.plot_with_report(report=report)
-
-
 @pytest.mark.parametrize("""file_rd_series,
                             file_wr_series,
                             bytes_rd_series,

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -74,12 +74,12 @@ def test_main_with_args(tmpdir, argv):
 
 @pytest.mark.parametrize(
     "argv, expected_img_count, expected_table_count", [
-        (["noposix.darshan"], 2, 2),
-        (["noposix.darshan", "--output=test.html"], 2, 2),
-        (["sample-dxt-simple.darshan"], 7, 4),
-        (["sample-dxt-simple.darshan", "--output=test.html"], 7, 4),
-        (["nonmpi_dxt_anonymized.darshan"], 5, 3),
-        (["ior_hdf5_example.darshan"], 10, 5),
+        (["noposix.darshan"], 3, 2),
+        (["noposix.darshan", "--output=test.html"], 3, 2),
+        (["sample-dxt-simple.darshan"], 8, 4),
+        (["sample-dxt-simple.darshan", "--output=test.html"], 8, 4),
+        (["nonmpi_dxt_anonymized.darshan"], 6, 3),
+        (["ior_hdf5_example.darshan"], 11, 5),
         ([None], 0, 0),
     ]
 )


### PR DESCRIPTION
Fixes #466 (eventually)

* add the "Data Access by Category" figure to the Python
summary report, and adjust tests to reflect the additional
figure, and support for both `POSIX` and `STDIO` with this fig

* some issues to think about
  - ~the new figure is ridicuously large compared to the previous
    figures in the report and the option to specify the width
    of the figure in the `ReportFigure` has no effect--see example in gh-717~
  - if we have a sample log that lacks both `POSIX` and `STDIO`,
    then `test_posix_absent` might be suitably replaced instead
    of deleted (may help if test coverage isn't 100 % anymore)
  - the code changes here contain comments about an eventual API redesign,
    the issue there should hopefully be clear from the diff
  - test suite ran in 3:34 on 6 cores locally--didn't quantify the
    slowdown relative to `pydarshan-devel` with new analysis/figs
  - there's some discussion from Shane in the matching issue about:
    - how to pick the top `N` categories vs. the magic number I've used here
    - something about ditching the plot entirely and using html table instead?
 