### PR TITLE
WIP, ENH: Update summary report styling

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -8,7 +8,7 @@
         ${report_data.stylesheet}
       </style>
     </head>
-    <body style="font-family: Gill Sans MT">
+    <body>
 
       <!-- Add the header  -->
       <div class="fixed-header">
@@ -31,7 +31,7 @@
       <!-- Add sections and their figures  -->
       % for sect_title in report_data.sections:
           <section>
-          <h2>${sect_title}</h2>
+          <h2 class="section_header">${sect_title}</h2>
 
           % if len(report_data.sections[sect_title]) > 1:
             <!-- if more than 1 figure in section, use grid wrapper class -->

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -24,6 +24,11 @@ th, td {
 table {
   border-collapse: collapse;
 }
+.section_header {
+  display: block;
+  background-color: #ddd;
+  padding: 5px;
+}
 .fixed-header, .fixed-footer{
     width: 100%;
     display: block;

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -16,7 +16,9 @@ html {
 }
 
 body {
-  margin: 0;
+  margin-top: 0px;
+  margin-left: 30px;
+  margin-right: 30px;
 }
 
 article,
@@ -270,6 +272,10 @@ th {
   padding: 0;
 }
 
+td:empty {
+  display: none;
+}
+
 table {
   border-collapse: collapse;
   border-spacing: 0;
@@ -292,10 +298,9 @@ table th {
 
 table tr {
   background-color: #fff;
-  border-top: 1px solid #ccc;
 }
 
-table tr:nth-child(2n) {
+table tr:nth-child(2n+1) {
   background-color: #f8f8f8;
 }
 
@@ -303,10 +308,10 @@ hr {
   box-sizing: content-box;
   overflow: visible;
   background: transparent;
-  height: 4px;
+  height: 1px;
   padding: 0;
   margin: 1em 0;
-  background-color: #e7e7e7;
+  background-color: #777;
   border: 0 none;
 }
 
@@ -337,7 +342,6 @@ figure {
 
 figure img {
   background: white;
-  border: 1px solid #c7c7c7;
   padding: 0.25em;
 }
 
@@ -507,4 +511,26 @@ template {
 
 [hidden] {
   display: none;
+}
+.section_header {
+  display: block;
+  background-color: #ddd;
+  padding: 5px;
+}
+.fixed-header, .fixed-footer{
+    width: 100%;
+    display: block;
+    text-align: right;
+}
+.fixed-header{
+    top: 0;
+}
+.fixed-footer{
+    bottom: 0;
+}
+.grid-wrapper {
+  display: grid;
+  /* set 2-column-wide grid with auto width scaling*/
+  grid-template-columns: repeat(2, auto);
+  gap: 5px;
 }

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -1,55 +1,510 @@
-p {
-  font-size: 12px;
+/*! style.css v1.0.0 | ISC License | https://github.com/ungoldman/style.css */
+html {
+  color: #303030;
+  background-color: white;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "fira sans", roboto, noto, "droid sans", "liberation sans", "lucida grande", "helvetica neue", helvetica, "franklin gothic medium", "century gothic", cantarell, oxygen, ubuntu, sans-serif;
+  font-size: calc(14px + 0.25vw);
+  line-height: 1.55;
+  -webkit-font-kerning: normal;
+          font-kerning: normal;
+  text-rendering: optimizeLegibility;
+  -webkit-font-feature-settings: "kern", "liga" 1, "calt" 0;
+          font-feature-settings: "kern", "liga" 1, "calt" 0;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
+
+body {
+  margin: 0;
+}
+
+article,
+aside,
+footer,
+header,
+nav,
+section,
+figcaption,
+figure,
+main {
+  display: block;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+p,
+blockquote,
+ul,
+ol,
+dl,
+table,
+pre {
+  margin-top: 0;
+  margin-bottom: 1.25em;
+}
+
+small {
+  font-size: 80%;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 500;
+  line-height: 1.25em;
+  margin-bottom: 1.25rem;
+  margin-top: 2rem;
+  position: relative;
+}
+
+h1 small,
+h2 small,
+h3 small,
+h4 small,
+h5 small,
+h6 small {
+  color: #777;
+  font-size: 0.7em;
+  font-weight: 300;
+}
+
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+  font-size: 0.9em;
+}
+
 h1 {
-  font-size: 24px;
+  font-size: 2.75em;
 }
+
 h2 {
-  font-size: 20px;
+  font-size: 2.25em;
 }
+
 h3 {
-  font-size: 16px;
+  font-size: 1.75em;
 }
-body{
-    margin: 50px;
-    padding: 15px;
+
+h4 {
+  font-size: 1.5em;
 }
-th, td {
-  font-size: 12px;
-  padding: 6px;
-  text-align: left;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+
+h5 {
+  font-size: 1.25em;
 }
+
+h6 {
+  font-size: 1.15em;
+  color: #575757;
+}
+
+p {
+  letter-spacing: -0.01em;
+}
+
+a {
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects;
+  color: #0074d9;
+  text-decoration: none;
+}
+
+a:active, a:hover {
+  outline-width: 0;
+  outline: 0;
+}
+
+a:active, a:focus, a:hover {
+  text-decoration: underline;
+}
+
+ul,
+ol {
+  padding: 0;
+  padding-left: 2em;
+}
+
+ul ol,
+ol ol {
+  list-style-type: lower-roman;
+}
+
+ul ul,
+ul ol,
+ol ul,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+ul ul ol,
+ul ol ol,
+ol ul ol,
+ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+li > p {
+  margin-top: 1em;
+}
+
+blockquote {
+  margin: 0 0 1rem;
+  padding: 0 1rem;
+  color: #7d7d7d;
+  border-left: 4px solid #d6d6d6;
+}
+
+blockquote > :first-child {
+  margin-top: 0;
+}
+
+blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+b,
+strong {
+  font-weight: inherit;
+  font-weight: 600;
+}
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: menlo, inconsolata, consolas, "fira mono", "noto mono", "droid sans mono", "liberation mono", "dejavu sans mono", "ubuntu mono", monaco, "courier new", monospace;
+  font-size: 90%;
+}
+
+pre, code {
+  background-color: #f7f7f7;
+  border-radius: 3px;
+}
+
+pre {
+  overflow: auto;
+  word-wrap: normal;
+  padding: 1em;
+  line-height: 1.45;
+}
+
+pre code {
+  background: transparent;
+  display: inline;
+  padding: 0;
+  line-height: inherit;
+  word-wrap: normal;
+}
+
+pre code::before, pre code::after {
+  content: normal;
+}
+
+pre > code {
+  border: 0;
+  font-size: 1em;
+  white-space: pre;
+  word-break: normal;
+}
+
+code {
+  padding: 0.2em 0;
+  margin: 0;
+}
+
+code::before, code::after {
+  letter-spacing: -0.2em;
+  content: '\00a0';
+}
+
+kbd {
+  background-color: #e6e6e6;
+  background-image: linear-gradient(#fafafa, #e6e6e6);
+  background-repeat: repeat-x;
+  border: 1px solid #d6d6d6;
+  border-radius: 2px;
+  box-shadow: 0 1px 0 #d6d6d6;
+  color: #303030;
+  display: inline-block;
+  line-height: 0.95em;
+  margin: 0 1px;
+  padding: 5px 5px 1px;
+}
+
+td,
+th {
+  padding: 0;
+}
+
 table {
   border-collapse: collapse;
-}
-.section_header {
+  border-spacing: 0;
   display: block;
-  background-color: #ddd;
-  padding: 5px;
+  width: 100%;
+  overflow: auto;
+  word-break: normal;
+  word-break: keep-all;
 }
-.fixed-header, .fixed-footer{
-    width: 100%;
-    display: block;
-    text-align: right;
+
+table th,
+table td {
+  padding: 6px 13px;
+  border: 1px solid #ddd;
 }
-.fixed-header{
-    top: 0;
+
+table th {
+  font-weight: bold;
 }
-.fixed-footer{
-    bottom: 0;
+
+table tr {
+  background-color: #fff;
+  border-top: 1px solid #ccc;
 }
+
+table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
+hr {
+  box-sizing: content-box;
+  overflow: visible;
+  background: transparent;
+  height: 4px;
+  padding: 0;
+  margin: 1em 0;
+  background-color: #e7e7e7;
+  border: 0 none;
+}
+
+hr::before {
+  display: table;
+  content: '';
+}
+
+hr::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+
+img {
+  border-style: none;
+  border: 0;
+  max-width: 100%;
+}
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
 figure {
-  text-align: center;
+  margin: 1em 0;
 }
-figure figcaption {
-  font-size: 12px;
-  text-align: center;
+
+figure img {
+  background: white;
+  border: 1px solid #c7c7c7;
+  padding: 0.25em;
 }
-.grid-wrapper {
-  display: grid;
-  /* set 2-column-wide grid with auto width scaling*/
-  grid-template-columns: repeat(2, auto);
-  gap: 5px;
+
+figcaption {
+  font-style: italic;
+  font-size: 0.75em;
+  font-weight: 200;
+  margin: 0;
+}
+
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  text-decoration: underline dotted;
+}
+
+dfn {
+  font-style: italic;
+}
+
+dd {
+  margin-left: 0;
+}
+
+dl {
+  padding: 0;
+}
+
+dl dt {
+  padding: 0;
+  margin-top: 1em;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: 600;
+}
+
+dl dd {
+  padding: 0 1em;
+  margin-bottom: 1.25em;
+}
+
+audio,
+video {
+  display: inline-block;
+}
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+input {
+  margin: 0;
+}
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: sans-serif;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+
+button,
+input {
+  overflow: visible;
+}
+
+button,
+select {
+  text-transform: none;
+}
+
+button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+legend {
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}
+
+progress {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+textarea {
+  overflow: auto;
+}
+
+[type="checkbox"],
+[type="radio"] {
+  padding: 0;
+}
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+[disabled] {
+  cursor: default;
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+details,
+menu {
+  display: block;
+}
+
+summary {
+  display: list-item;
+}
+
+canvas {
+  display: inline-block;
+}
+
+template {
+  display: none;
+}
+
+[hidden] {
+  display: none;
 }

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -231,7 +231,7 @@ class TestReportData:
         log_path = get_log_path(log_path)
         R = summary.ReportData(log_path=log_path)
         # verify the first line shows up correctly for each log
-        expected_str = "p {\n  font-size: 12px;\n}"
+        expected_str = "small {\n  font-size: 80%;\n}"
         assert expected_str in R.stylesheet
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Description
-------------
* Use stylesheet from the following location:
https://unpkg.com/style.css@1.0.0/style.css

* Misc adjustments to stylesheet:
  - Add margins to body so titles and figures
  do not touch window edge
  - Remove `figure` border
  - Add `td:empty` entry to prevent empty columns in
  "Darshan Log Information" table from being displayed
  - Change horizontal rule height to 1px, make color darker
  - Remove table tr `border-top`
  - Change table pattern to `2n+1` so tables
  start with darker color

* Correct expected string in `test_stylesheet`

* Add CSS class `section_header`, add to section
title tags to more clearly delineate sections

* Remove "Gill Sans" font family from body

Comments
------------
There has been a fair amount of discussion about adding a proper CSS style sheet to the report. This was the one that got the most positive feedback so I've basically just copy/pasted it into the `style.css` file. The details on the style sheet can be found on their [GitHub page](https://github.com/ungoldman/style.css). It as an ISC license (similar to MIT), so it should be okay to use this modified version of it. The updated style sheet is about 7 KB now. 

I'm opening this as a draft; if we want to keep the basic CSS we have now I can simply close this PR, but if we decide to keep the changes feedback on the current styling is also welcome. 

Examples
------------
Here is a set of example logs that I think is representative of the logs from the darshan-logs repo: [example_reports.tar.gz](https://github.com/darshan-hpc/darshan/files/8533221/example_reports.tar.gz)