### PR TITLE
BUG: cats only allow POSIX/STDIO

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade mypy pyflakes asv codecov lxml
-          python -m pip install pytest-cov "pytest<7.1.2"
+          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml
           # matplotlib is pinned because of
           # gh-479
           python -m pip install 'matplotlib<3.5'

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade mypy pyflakes asv codecov lxml
-          python -m pip install pytest-cov "pytest==7.0.1"
+          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml
           # matplotlib is pinned because of
           # gh-479
           python -m pip install 'matplotlib<3.5'

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml
+          python -m pip install --upgrade mypy pyflakes asv codecov lxml
+          python -m pip install pytest-cov "pytest==7.0.1"
           # matplotlib is pinned because of
           # gh-479
           python -m pip install 'matplotlib<3.5'

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml
+          python -m pip install --upgrade mypy pyflakes asv codecov lxml
+          python -m pip install pytest-cov "pytest<7.1.2"
           # matplotlib is pinned because of
           # gh-479
           python -m pip install 'matplotlib<3.5'

--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -644,17 +644,29 @@ def plot_with_report(report: darshan.DarshanReport,
     """
     fig = plt.figure()
     file_id_dict = report.data["name_records"]
-    filesystem_roots = identify_filesystems(file_id_dict=file_id_dict,
+    allowed_file_id_dict = {}
+
+    # only POSIX/STDIO entries allowed
+    for module in ["POSIX", "STDIO"]:
+        for key in ["counters", "fcounters"]:
+            try:
+                allowed_ids = report.records[module].to_df()[key]["id"]
+            except KeyError:
+                allowed_ids = []
+            for ident in allowed_ids:
+                allowed_file_id_dict[ident] = file_id_dict[ident]
+
+    filesystem_roots = identify_filesystems(file_id_dict=allowed_file_id_dict,
                                             verbose=verbose)
     file_rd_series, file_wr_series = unique_fs_rw_counter(report=report,
                                                           filesystem_roots=filesystem_roots,
-                                                          file_id_dict=file_id_dict,
+                                                          file_id_dict=allowed_file_id_dict,
                                                           processing_func=process_unique_files,
                                                           mod='POSIX',
                                                           verbose=verbose)
     bytes_rd_series, bytes_wr_series = unique_fs_rw_counter(report=report,
                                                             filesystem_roots=filesystem_roots,
-                                                            file_id_dict=file_id_dict,
+                                                            file_id_dict=allowed_file_id_dict,
                                                             processing_func=process_byte_counts,
                                                             mod='POSIX', verbose=verbose)
     # reverse sort by total bytes IO per category

--- a/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
@@ -309,8 +309,10 @@ def test_empty_data_posix_y_axis_annot_position():
                     assert actual_fontsize == 12
 
 @pytest.mark.parametrize("log_file_path, expected_text_labels", [
-    (get_log_path('noposixopens.darshan'), ['/global', 'anonymized', 'anonymized', 'anonymized']),
-    (get_log_path('sample.darshan'), ['/scratch2', '<STDERR>', '<STDOUT>', '<STDIN>']),
+    (get_log_path('noposixopens.darshan'), ['/global', 'anonymized']),
+    (get_log_path('sample.darshan'), ['/scratch2', '<STDERR>', '<STDOUT>']),
+    # test case for gh-678
+    (get_log_path('mpi-io-test.darshan'), ['/global', '<STDOUT>']),
     ])
 def test_cat_labels_std_streams(log_file_path, expected_text_labels):
     # for an anonymized log file that operates on STDIO, STDERR

--- a/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
@@ -308,17 +308,18 @@ def test_empty_data_posix_y_axis_annot_position():
                 else:
                     assert actual_fontsize == 12
 
-@pytest.mark.parametrize("log_file_path, expected_text_labels", [
-    (get_log_path('noposixopens.darshan'), ['/global', 'anonymized']),
-    (get_log_path('sample.darshan'), ['/scratch2', '<STDERR>', '<STDOUT>']),
+@pytest.mark.parametrize("log_file_name, expected_text_labels", [
+    ('noposixopens.darshan', ['/global', 'anonymized']),
+    ('sample.darshan', ['/scratch2', '<STDERR>', '<STDOUT>']),
     # test case for gh-678
-    (get_log_path('mpi-io-test.darshan'), ['/global', '<STDOUT>']),
+    ('mpi-io-test.darshan', ['/global', '<STDOUT>']),
     ])
-def test_cat_labels_std_streams(log_file_path, expected_text_labels):
+def test_cat_labels_std_streams(log_file_name, expected_text_labels):
     # for an anonymized log file that operates on STDIO, STDERR
     # and STDIN, we want appropriate labels to be used instead of confusing
     # integers on y axis; for the same scenario without anonymization,
     # the STD.. stream label seem appropriate
+    log_file_path = get_log_path(log_file_name)
     actual_text_labels = []
     report = darshan.DarshanReport(log_file_path)
     actual_fig = data_access_by_filesystem.plot_with_report(report=report)


### PR DESCRIPTION
Fixes #678

* only allow `POSIX` and `STDIO` records
to get passed through the control flow
that produces the "Data Access by Category"
plots

* add one new test case and adjust old cases
to reflect the more selective plotting of
categories

Below the fold I'll place the updated examples for the problematic cases
cited in the matching issue. It is trivial to add new test cases so if reviewers
have others they know pretty well and want to see tested that should be easy
enough to do.

<details>

<summary>
For mpi-io-test that had spurious autoperf entries and inactive std streams
</summary>

![mpi-io-test](https://user-images.githubusercontent.com/7903078/165351139-ca8450fc-e6d6-4fcf-8aa6-32d3f17894a4.png)

</details>

<details>
<summary>
For the Tensorflow monitoring log that had spurious heatmap entries and inactive std streams
</summary>

![tf_fail](https://user-images.githubusercontent.com/7903078/165351518-31acbf45-fab6-41e8-91c0-e43a851e5c92.png)


</details>

I have to admit that because this makes the number of categories much smaller in general, the "width" of the bars is a bit excessive sometimes, but that is perhaps to be dealt with separately.