### PR TITLE
increase MAX_MODS to 64

### DIFF
--- a/darshan-runtime/lib/darshan-config.c
+++ b/darshan-runtime/lib/darshan-config.c
@@ -692,7 +692,7 @@ void darshan_parse_config_file(struct darshan_config *cfg)
                     if(mods)
                     {
                         tmp_mod_flags = darshan_module_csv_to_flags(mods);
-                        for(i = 0; i < DARSHAN_MAX_MODS; i++)
+                        for(i = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
                         {
                             if(DARSHAN_MOD_FLAG_ISSET(tmp_mod_flags, i))
                                 cfg->mod_max_records_override[i] = tmpmax;

--- a/darshan-runtime/lib/darshan-config.h
+++ b/darshan-runtime/lib/darshan-config.h
@@ -25,7 +25,7 @@ struct darshan_config
     uint64_t mod_disabled_flags;
     uint64_t mod_enabled_flags;
     uint64_t mod_disabled;
-    size_t mod_max_records_override[DARSHAN_MAX_MODS];
+    size_t mod_max_records_override[DARSHAN_KNOWN_MODULE_COUNT];
     char **exclude_dirs;
     char **user_exclude_dirs;
     char **include_dirs;

--- a/darshan-runtime/lib/darshan.h
+++ b/darshan-runtime/lib/darshan.h
@@ -138,7 +138,7 @@ struct darshan_core_runtime
     void *log_mod_p;
 
     /* darshan-core internal data structures */
-    struct darshan_core_module* mod_array[DARSHAN_MAX_MODS];
+    struct darshan_core_module* mod_array[DARSHAN_KNOWN_MODULE_COUNT];
     struct darshan_config config;
     size_t mod_mem_used;
     struct darshan_core_name_record_ref *name_hash;

--- a/darshan-util/darshan-dxt-parser.c
+++ b/darshan-util/darshan-dxt-parser.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
     printf("# record table: %zu bytes (compressed)\n", fd->name_map.len);
     for (i = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
     {
-        if (fd->mod_map[i].len)
+        if(fd->mod_map[i].len || DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i))
         {
             printf("# %s module: %zu bytes (compressed), ver=%d\n",
                 darshan_module_names[i], fd->mod_map[i].len, fd->mod_ver[i]);

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -1145,7 +1145,7 @@ static int darshan_log_get_header(darshan_fd fd)
         header.partial_flag = (uint64_t)header_3_00.partial_flag;
         memcpy(&header.name_map, &header_3_00.name_map,
             (1 + DARSHAN_MAX_MODS_3_00) * sizeof(header_3_00.name_map));
-        mempcpy(&header.mod_ver, &header_3_00.mod_ver,
+        memcpy(&header.mod_ver, &header_3_00.mod_ver,
             (DARSHAN_MAX_MODS_3_00) * sizeof(header_3_00.mod_ver[0]));
 
         fd->job_map.off = sizeof(header_3_00);

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -1025,7 +1025,8 @@ static int darshan_log_get_header(darshan_fd fd)
     }
     else if((strcmp(fd->version, "3.10") == 0) ||
             (strcmp(fd->version, "3.20") == 0) ||
-            (strcmp(fd->version, "3.21") == 0))
+            (strcmp(fd->version, "3.21") == 0) ||
+            (strcmp(fd->version, "3.40") == 0))
     {
         fd->state->get_namerecs = darshan_log_get_namerecs;
     }

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -80,7 +80,7 @@ struct darshan_fd_int_state
 
 /* each module's implementation of the darshan logutil functions */
 #define X(a, b, c, d) d,
-struct darshan_mod_logutil_funcs *mod_logutils[DARSHAN_MAX_MODS] =
+struct darshan_mod_logutil_funcs *mod_logutils[DARSHAN_KNOWN_MODULE_COUNT] =
 {
     DARSHAN_MODULE_IDS
 };
@@ -723,7 +723,7 @@ int darshan_log_get_mod(darshan_fd fd, darshan_module_id mod_id,
     state = fd->state;
     assert(state);
 
-    if(mod_id < 0 || mod_id >= DARSHAN_MAX_MODS)
+    if(mod_id < 0 || mod_id >= DARSHAN_KNOWN_MODULE_COUNT)
     {
         fprintf(stderr, "Error: invalid Darshan module id.\n");
         return(-1);
@@ -782,7 +782,7 @@ int darshan_log_put_mod(darshan_fd fd, darshan_module_id mod_id,
     state = fd->state;
     assert(state);
 
-    if(mod_id < 0 || mod_id >= DARSHAN_MAX_MODS)
+    if(mod_id < 0 || mod_id >= DARSHAN_KNOWN_MODULE_COUNT)
     {
         state->err = -1;
         fprintf(stderr, "Error: invalid Darshan module id.\n");
@@ -2007,7 +2007,7 @@ void darshan_log_get_modules(darshan_fd fd,
     *mods = malloc(sizeof(**mods) * DARSHAN_MAX_MODS);
     assert(*mods);
 
-    for (i = 0, j = 0; i < DARSHAN_MAX_MODS; i++)
+    for (i = 0, j = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
     {
         if (fd->mod_map[i].len)
         {
@@ -2016,6 +2016,18 @@ void darshan_log_get_modules(darshan_fd fd,
             (*mods)[j].ver           = fd->mod_ver[i];
             (*mods)[j].partial_flag  = DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i);
             (*mods)[j].idx           = i;
+            j += 1;
+        }
+    }
+    for (i = DARSHAN_KNOWN_MODULE_COUNT; i < DARSHAN_MAX_MODS; i++)
+    {
+        if (fd->mod_map[i].len)
+        {
+            /* we don't know the names of any modules in this region */
+            (*mods)[j].name = NULL;
+            (*mods)[j].len  = fd->mod_map[i].len;
+            (*mods)[j].ver  = fd->mod_ver[i];
+            (*mods)[j].idx  = i;
             j += 1;
         }
     }

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -91,6 +91,7 @@ static int darshan_mnt_info_cmp(const void *a, const void *b);
 static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
     int swap_flag, struct darshan_name_record_ref **hash,
     darshan_record_id *whitelist, int whitelist_count);
+static int darshan_log_get_format_version(char *ver_str, int *maj_num, int *min_num);
 static int darshan_log_get_header(darshan_fd fd);
 static int darshan_log_put_header(darshan_fd fd);
 static int darshan_log_seek(darshan_fd fd, off_t offset);
@@ -991,6 +992,51 @@ static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
     return(buf_processed);
 }
 
+
+/* extracts a major and minor format version from a log format version
+ *
+ * returns 0 on success, -1 on failure
+ */
+static int darshan_log_get_format_version(char *ver_str, int *maj_num, int *min_num)
+{
+    char *delim;
+    char *maj, *min;
+    float tmp_float_maj, tmp_float_min;
+    char *end_ptr;
+
+    if(!ver_str)
+        return(-1);
+
+    delim = strchr(ver_str, '.');
+    if(!delim)
+        return(-1);
+    *delim = '\0'; // temporarily create 2 strings
+    maj = ver_str;
+    min = delim + 1;
+
+    if((strlen(maj) < 1) || (strlen(min) < 1))
+        return(-1);
+
+    errno = 0;
+    tmp_float_maj = strtof(maj, &end_ptr);
+    if((tmp_float_maj == 0) && ((errno != 0) || (end_ptr == maj)))
+        return(-1);
+    if(*end_ptr != '\0')
+        return(-1);
+    errno = 0;
+    tmp_float_min = strtof(min, &end_ptr);
+    if((tmp_float_min == 0) && ((errno != 0) || (end_ptr == min)))
+        return(-1);
+    if(*end_ptr != '\0')
+        return(-1);
+
+    *delim = '.'; // fix version string
+    *maj_num = (int)tmp_float_maj;
+    *min_num = (int)tmp_float_min;
+
+    return(0);
+}
+
 /* read the header of the darshan log and set internal fd data structures
  * NOTE: this is the only portion of the darshan log that is uncompressed
  *
@@ -999,7 +1045,7 @@ static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
 static int darshan_log_get_header(darshan_fd fd)
 {
     struct darshan_header header;
-    double log_ver_val;
+    int log_ver_maj, log_ver_min;
     int i;
     int ret;
 
@@ -1018,15 +1064,24 @@ static int darshan_log_get_header(darshan_fd fd)
         return(-1);
     }
 
+    /* get major/minor version numbers */
+    ret = darshan_log_get_format_version(fd->version, &log_ver_maj, &log_ver_min);
+    if(ret < 0)
+    {
+        fprintf(stderr, "Error: unable to parse log file format version.\n");
+        return(-1);
+    }
+
     /* other log file versions can be detected and handled here */
-    if(strcmp(fd->version, "3.00") == 0)
+    if((log_ver_maj == 3) && (log_ver_min == 0))
     {
         fd->state->get_namerecs = darshan_log_get_namerecs_3_00;
     }
-    else if((strcmp(fd->version, "3.10") == 0) ||
-            (strcmp(fd->version, "3.20") == 0) ||
-            (strcmp(fd->version, "3.21") == 0) ||
-            (strcmp(fd->version, "3.40") == 0))
+    else if((log_ver_maj == 3) &&
+                ((log_ver_min == 10) ||
+                 (log_ver_min == 20) ||
+                 (log_ver_min == 21) ||
+                 (log_ver_min == 41)))
     {
         fd->state->get_namerecs = darshan_log_get_namerecs;
     }
@@ -1047,11 +1102,53 @@ static int darshan_log_get_header(darshan_fd fd)
     }
 
     /* read uncompressed header from log file */
-    ret = darshan_log_read(fd, &header, sizeof(header));
-    if(ret != (int)sizeof(header))
+    /* NOTE: header bumped from 16 to 64 modules at log ver 3.41 */
+    if(((log_ver_maj == 3) && (log_ver_min >= 41)) || (log_ver_maj > 3))
     {
-        fprintf(stderr, "Error: failed to read darshan log file header.\n");
-        return(-1);
+        ret = darshan_log_read(fd, &header, sizeof(header));
+        if(ret != (int)sizeof(header))
+        {
+            fprintf(stderr, "Error: failed to read darshan log file header.\n");
+            return(-1);
+        }
+
+        fd->job_map.off = sizeof(struct darshan_header);
+    }
+    else
+    {
+        /* backwards compatibility with 3.00 version of Darshan header */
+        #define DARSHAN_MAX_MODS_3_00 16
+        struct
+        {
+            char version_string[8];
+            int64_t magic_nr;
+            unsigned char comp_type;
+            uint32_t partial_flag;
+            struct darshan_log_map name_map;
+            struct darshan_log_map mod_map[DARSHAN_MAX_MODS_3_00];
+            uint32_t mod_ver[DARSHAN_MAX_MODS_3_00];
+        } header_3_00;
+
+        /* read old header structure */
+        ret = darshan_log_read(fd, &header_3_00, sizeof(header_3_00));
+        if(ret != sizeof(header_3_00))
+        {
+            fprintf(stderr, "Error: failed to read darshan log file header.\n");
+            return(-1);
+        }
+
+        /* set new header structure */
+        memset(&header, 0, sizeof(header));
+        strncpy(header.version_string, header_3_00.version_string, 8);
+        header.magic_nr = header_3_00.magic_nr;
+        header.comp_type = header_3_00.comp_type;
+        header.partial_flag = (uint64_t)header_3_00.partial_flag;
+        memcpy(&header.name_map, &header_3_00.name_map,
+            (1 + DARSHAN_MAX_MODS_3_00) * sizeof(header_3_00.name_map));
+        mempcpy(&header.mod_ver, &header_3_00.mod_ver,
+            (DARSHAN_MAX_MODS_3_00) * sizeof(header_3_00.mod_ver[0]));
+
+        fd->job_map.off = sizeof(header_3_00);
     }
 
     if(header.magic_nr == DARSHAN_MAGIC_NR)
@@ -1094,8 +1191,7 @@ static int darshan_log_get_header(darshan_fd fd)
     memcpy(&fd->name_map, &(header.name_map), sizeof(struct darshan_log_map));
     memcpy(&fd->mod_map, &(header.mod_map), DARSHAN_MAX_MODS * sizeof(struct darshan_log_map));
 
-    log_ver_val = atof(fd->version);
-    if(log_ver_val < 3.2)
+    if((log_ver_maj == 3) && (log_ver_min < 20))
     {
         /* perform module index shift to account for H5D module from 3.2.0 */
         memmove(&fd->mod_map[DARSHAN_H5D_MOD+1], &fd->mod_map[DARSHAN_H5D_MOD],
@@ -1107,7 +1203,6 @@ static int darshan_log_get_header(darshan_fd fd)
     }
 
     /* there may be nothing following the job data, so safety check map */
-    fd->job_map.off = sizeof(struct darshan_header);
     if(fd->name_map.off == 0)
     {
         for(i = 0; i < DARSHAN_MAX_MODS; i++)

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -992,47 +992,20 @@ static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
     return(buf_processed);
 }
 
-
 /* extracts a major and minor format version from a log format version
  *
  * returns 0 on success, -1 on failure
  */
 static int darshan_log_get_format_version(char *ver_str, int *maj_num, int *min_num)
 {
-    char *delim;
-    char *maj, *min;
-    float tmp_float_maj, tmp_float_min;
-    char *end_ptr;
+    int ret;
 
     if(!ver_str)
         return(-1);
 
-    delim = strchr(ver_str, '.');
-    if(!delim)
+    ret = sscanf(ver_str, "%d.%d", maj_num, min_num);
+    if(ret < 2)
         return(-1);
-    *delim = '\0'; // temporarily create 2 strings
-    maj = ver_str;
-    min = delim + 1;
-
-    if((strlen(maj) < 1) || (strlen(min) < 1))
-        return(-1);
-
-    errno = 0;
-    tmp_float_maj = strtof(maj, &end_ptr);
-    if((tmp_float_maj == 0) && ((errno != 0) || (end_ptr == maj)))
-        return(-1);
-    if(*end_ptr != '\0')
-        return(-1);
-    errno = 0;
-    tmp_float_min = strtof(min, &end_ptr);
-    if((tmp_float_min == 0) && ((errno != 0) || (end_ptr == min)))
-        return(-1);
-    if(*end_ptr != '\0')
-        return(-1);
-
-    *delim = '.'; // fix version string
-    *maj_num = (int)tmp_float_maj;
-    *min_num = (int)tmp_float_min;
 
     return(0);
 }

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -30,8 +30,8 @@ struct darshan_fd_s
      * performed on log file data
      */
     int swap_flag;
-    /* flag indicating whether a log file contains partial data */
-    int partial_flag;
+    /* bit-field indicating whether modules contain incomplete data */
+    uint64_t partial_flag;
     /* compression type used on log file */
     enum darshan_comp_type comp_type;
     /* log file offset/length maps for each log file region */

--- a/include/darshan-log-format.h
+++ b/include/darshan-log-format.h
@@ -24,7 +24,7 @@
  * log format version, NOT when a new version of a module record is
  * introduced -- we have module-specific versions to handle that
  */
-#define DARSHAN_LOG_VERSION "3.21"
+#define DARSHAN_LOG_VERSION "3.40"
 
 /* magic number for validating output files and checking byte order */
 #define DARSHAN_MAGIC_NR 6567223
@@ -36,7 +36,7 @@
 #define DARSHAN_EXE_LEN (DARSHAN_JOB_RECORD_SIZE - sizeof(struct darshan_job) - 1)
 
 /* max number of modules that can be used in a darshan log */
-#define DARSHAN_MAX_MODS 16
+#define DARSHAN_MAX_MODS 64
 
 /* simple macros for accessing module flag bitfields */
 #define DARSHAN_MOD_FLAG_SET(flags, id) flags = (flags | (1 << id))
@@ -72,7 +72,7 @@ struct darshan_header
     char version_string[8];
     int64_t magic_nr;
     unsigned char comp_type;
-    uint32_t partial_flag;
+    uint64_t partial_flag;
     struct darshan_log_map name_map;
     struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
     uint32_t mod_ver[DARSHAN_MAX_MODS];

--- a/include/darshan-log-format.h
+++ b/include/darshan-log-format.h
@@ -24,7 +24,7 @@
  * log format version, NOT when a new version of a module record is
  * introduced -- we have module-specific versions to handle that
  */
-#define DARSHAN_LOG_VERSION "3.40"
+#define DARSHAN_LOG_VERSION "3.41"
 
 /* magic number for validating output files and checking byte order */
 #define DARSHAN_MAGIC_NR 6567223
@@ -39,9 +39,9 @@
 #define DARSHAN_MAX_MODS 64
 
 /* simple macros for accessing module flag bitfields */
-#define DARSHAN_MOD_FLAG_SET(flags, id) flags = (flags | (1 << id))
-#define DARSHAN_MOD_FLAG_UNSET(flags, id) flags = (flags & ~(1 << id))
-#define DARSHAN_MOD_FLAG_ISSET(flags, id) (flags & (1 << id))
+#define DARSHAN_MOD_FLAG_SET(flags, id) flags = (flags | (1ULL << id))
+#define DARSHAN_MOD_FLAG_UNSET(flags, id) flags = (flags & ~(1ULL << id))
+#define DARSHAN_MOD_FLAG_ISSET(flags, id) (flags & (1ULL << id))
 
 /* compression method used on darshan log file */
 enum darshan_comp_type


### PR DESCRIPTION
This PR bumps Darshan's MAX_MODS value from 16 to 64. This is a small change to the header for the most part.

There are additional commits to address a couple of other issues:

- switched almost all references to `DARSHAN_MAX_MODS` to `DARSHAN_KNOWN_MODULE_COUNT` for safety purposes (fixes #712)
- small `darshan-dxt-parser` fix to align behavior with `darshan-parser` -- make sure to include info in the module summary section of parser output for modules that report partial data

This PR is marked WIP for a few reasons:

1. There is no backwards-compatibility support currently for previous log versions. I am still working on that.
2. No Python bindings support for this change yet.
3. I don't want to rush this in ahead of the upcoming pre-release, we can make sure we get this right and get it merged afterwards so it's part of the following release (pre-release or 3.4.0)

Fixes #667 