### PR TITLE
run pytest on each built wheel

### DIFF
--- a/darshan-util/pydarshan/devel/build-wheels.sh
+++ b/darshan-util/pydarshan/devel/build-wheels.sh
@@ -44,9 +44,6 @@ ls /opt/python
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
-    # JL: we do not really need any dependencies to build the wheel,
-    #     but requirements install needs to be renabled when testing automatically
-    #"${PYBIN}/pip" install -r /io/requirements_wheels.txt	                    
     "${PYBIN}/pip" wheel /io/ --build-option "--with-extension" --no-deps -w /io/wheelhouse/${PLAT}
 done
 
@@ -55,8 +52,13 @@ for whl in /io/wheelhouse/${PLAT}/*.whl; do
     repair_wheel "$whl"
 done
 
-## Install packages and test
-#for PYBIN in /opt/python/*/bin/; do
-#    "${PYBIN}/pip" install darshan --no-index -f /io/wheelhouse/${PLAT}
-#    (cd "$HOME"; "${PYBIN}/nosetests" darshan)
-#done
+# Install packages and test
+cd /io/
+for PYBIN in /opt/python/*/bin/; do
+    # JL: we do not really need any dependencies to build the wheel,
+    #     but requirements install needs to be renabled when testing automatically
+    "${PYBIN}/pip" install -r /io/requirements.txt
+    "${PYBIN}/pip" install pytest
+    "${PYBIN}/pip" install darshan --no-index -f /io/wheelhouse/${PLAT}
+    "${PYBIN}/pytest" --pyargs darshan ./
+done


### PR DESCRIPTION
Originally discussed in #705, but these changes add some `pytest` testing that is exercised for each wheel/python version that we currently support. This slows down wheel building considerably, but that's probably fine as we only do this as part of a release process where we want to double check we aren't hitting weird errors for specific versions.

This is far from sophisticated, but is useful to sanity check there are no errors until we get a more comprehensive wheel building and CI setup using `cibuildwheels`.