### PR TITLE
BUG: pydarshan HEATMAP inactive handle

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -381,6 +381,9 @@ def plot_heatmap(
         hmap_df = heatmap_handling.get_heatmap_df(agg_df=agg_df, xbins=xbins, nprocs=nprocs)
     elif mod == "HEATMAP":
         hmap_df = report.heatmaps[submodule].to_df(ops=ops)
+        # mirror the DXT approach to heatmaps by
+        # adding all-zero rows for inactive ranks
+        hmap_df = hmap_df.reindex(index=range(nprocs), fill_value=0.0)
         xbins = hmap_df.shape[1]
 
     # build the joint plot with marginal histograms

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -189,7 +189,12 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                     mpiio_position = report_str.find("Heat Map: HEATMAP MPIIO")
                     posix_position = report_str.find("Heat Map: HEATMAP POSIX")
                     stdio_position = report_str.find("Heat Map: HEATMAP STDIO")
-                    assert mpiio_position < posix_position < stdio_position
+                    # the 3-way check is only valid if all heatmap modules
+                    # are present:
+                    if (mpiio_position > -1 and
+                        posix_position > -1 and
+                        stdio_position > -1):
+                        assert mpiio_position < posix_position < stdio_position
                 else:
                     # check that help message is present
                     assert "Heatmap data is not available for this job" in report_str
@@ -208,7 +213,8 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                 actual_runtime_heatmap_titles = report_str.count("<h3>Heat Map: HEATMAP")
                 if "e3sm_io_heatmap_only" in log_filepath:
                     assert actual_runtime_heatmap_titles == 3
-                elif "runtime_and_dxt_heatmaps_diagonal_write_only" in log_filepath:
+                elif ("runtime_and_dxt_heatmaps_diagonal_write_only" in log_filepath or
+                      "treddy_runtime_heatmap_inactive_ranks" in log_filepath):
                     assert actual_runtime_heatmap_titles == 1
                 else:
                     assert actual_runtime_heatmap_titles == 0


### PR DESCRIPTION
* deal with 1/2 of the issue described in gh-730

* allow `plot_heatmap()` to gracefully handle
the scenario where a log file has some inactive
ranks and the new runtime `HEATMAP` tracking

* this branch is meant to accompany the new logs
repo PR: https://github.com/darshan-hpc/darshan-logs/pull/37

* minor testing changes to accomodate that new
log file; the test suite will fail with that new
log file without the patch provided here

If you're curious, this is what the new HEATMAP looks like for that log file we couldn't previously process, with the "darker" ranks printing one extra character because the `printf` includes i.e., `rank 10` instead of `rank 9` (so the heatmap scale is super sensitive here).

![image](https://user-images.githubusercontent.com/7903078/167273004-d3048734-ad50-4ae6-b8b9-97b059067f94.png)
