### PR TITLE
MAINT, CI: cibuildwheel support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - darshan-util/**
       - include/*
+  workflow_dispatch:
 
 jobs:
   get_commit_message:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,36 @@
+name: Build Wheels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - darshan-util/**
+      - include/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - darshan-util/**
+      - include/*
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.5.0
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -15,6 +15,26 @@ on:
       - include/*
 
 jobs:
+  get_commit_message:
+    name: Get commit message
+    runs-on: ubuntu-latest
+    if: github.repository == 'darshan-hpc/darshan'
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout darshan
+        uses: actions/checkout@v3
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_MSG=$(git log --no-merges -1 --oneline)
+          echo "::set-output name=message::$COMMIT_MSG"
+          echo github.ref ${{ github.ref }}
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     needs: get_commit_message

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
       github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,9 +27,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.5.0
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
+        with:
+          package-dir: ./darshan-util/pydarshan
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    if: >-
+      contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/darshan-util/pydarshan/RELEASE-CHECKLIST-PyDarshan.txt
+++ b/darshan-util/pydarshan/RELEASE-CHECKLIST-PyDarshan.txt
@@ -25,11 +25,15 @@ Notes on how to release a new version of PyDarshan
         (flake8 syntax warnings can be ignored)
     - TODO: CI?
 
- - Submit to PyPi using twine:
-    - make wheels       # requires docker, creates ./wheelhouse and builds architecture-specific *.whl that include libdarshan-util
-    - make dist         # gathers relevant wheels build earlier, adds non-binary wheel and a source distribution (zip/tgz)
-    - make release      # pushes contents of ./dist/* to PyPi
-        (be prompted for username/password)
+ - Submit to PyPI using cibuildwheel/twine:
+    - pipx run build --sdist
+        (in the pydarshan directory, creates a source distribution)
+    - download wheel artifacts from GitHub, copy to 'dist/' directory created above
+        (click on Actions in GitHub, find most recent "Build Wheels" workflow run with artifacts)
+        (download artifact zip, extract wheels to 'dist/' directory)
+    - pipx run twine upload dist/*
+        (requires PyPI credentials for darshan project)
+        (use '--repository testpypi' to test wheels using https://test.pypi.org/project/darshan/ before uploading to PyPI)
 
  - Add/update spack package: py-darshan
     - add version entry

--- a/darshan-util/pydarshan/devel/build-wheels.sh
+++ b/darshan-util/pydarshan/devel/build-wheels.sh
@@ -41,13 +41,15 @@ cd /
 
 ls /opt/python
 
+# Force setup.py to build the C extension
+export PYDARSHAN_BUILD_EXT=1
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     # JL: we do not really need any dependencies to build the wheel,
     #     but requirements install needs to be renabled when testing automatically
     #"${PYBIN}/pip" install -r /io/requirements_wheels.txt
-    "${PYBIN}/pip" wheel /io/ --build-option "--with-extension" --no-deps -w /io/wheelhouse/${PLAT}
+    "${PYBIN}/pip" wheel /io/ --no-deps -w /io/wheelhouse/${PLAT}
 done
 
 # Bundle external shared libraries into the wheels

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.cibuildwheel]
 environment = "PYDARSHAN_BUILD_EXT=1"
-build = "cp3*"
+build = "pp39*"
 skip = [
     "*musllinux*",
     "*i686*"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -22,6 +22,7 @@ skip = [
 test-requires = [
     "pytest",
     "lxml",
+    "matplotlib<3.5",
     "importlib_resources;python_version<'3.9'"
 ]
 test-command = "pytest {package}"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -12,6 +12,7 @@ before-all = [
     "make install"
 ]
 environment = "PYDARSHAN_BUILD_EXT=1"
+build = "cp3*"
 skip = [
     "*musllinux*",
     "*i686*"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -31,6 +31,7 @@ before-all = [
     "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
     "make install"
 ]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 before-all = [
@@ -41,4 +42,8 @@ before-all = [
     "./prepare.sh",
     "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
     "make install"
+]
+repair-wheel-command = [
+  "delocate-listdeps {wheel}",
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
 ]

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -9,6 +9,7 @@ before-all = [
     "yum install -y blas-devel lapack-devel",
     "yum install -y libxslt-devel libxml2-devel",
     "yum install -y libjpeg libjpeg-devel",
+    "git submodule update --init",
     "./prepare.sh",
     "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
     "make install"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -6,10 +6,12 @@ requires = [
 
 [tool.cibuildwheel]
 environment = "PYDARSHAN_BUILD_EXT=1"
-build = "pp39*"
 skip = [
+    "pp*",
     "*musllinux*",
-    "*i686*"
+    "*i686*",
+    "*_ppc64le",
+    "*_s390x"
 ]
 test-requires = [
     "pytest",

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -3,3 +3,24 @@ requires = [
     "wheel",
     "setuptools",
 ]
+
+[tool.cibuildwheel]
+before-all = [
+    "yum install -y blas-devel lapack-devel",
+    "yum install -y libxslt-devel libxml2-devel",
+    "yum install -y libjpeg libjpeg-devel",
+    "./prepare.sh",
+    "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
+    "make install"
+]
+environment = "PYDARSHAN_BUILD_EXT=1"
+skip = [
+    "*musllinux*",
+    "*i686*"
+]
+test-requires = [
+    "pytest",
+    "lxml",
+    "importlib_resources;python_version<'3.9'"
+]
+test-command = "pytest {package}"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -6,9 +6,6 @@ requires = [
 
 [tool.cibuildwheel]
 before-all = [
-    "yum install -y blas-devel lapack-devel",
-    "yum install -y libxslt-devel libxml2-devel",
-    "yum install -y libjpeg libjpeg-devel",
     "git submodule update --init",
     "./prepare.sh",
     "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
@@ -26,3 +23,10 @@ test-requires = [
     "importlib_resources;python_version<'3.9'"
 ]
 test-command = "pytest {package}"
+
+[tool.cibuildwheel.linux]
+before-all = [
+    "yum install -y blas-devel lapack-devel",
+    "yum install -y libxslt-devel libxml2-devel",
+    "yum install -y libjpeg libjpeg-devel"
+]

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -31,3 +31,8 @@ before-all = [
     "yum install -y libxslt-devel libxml2-devel",
     "yum install -y libjpeg libjpeg-devel"
 ]
+
+[tool.cibuildwheel.macos]
+before-all = [
+    "brew install automake"
+]

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -33,6 +33,8 @@ before-all = [
 [tool.cibuildwheel.macos]
 before-all = [
     "brew install automake",
+    "brew install openblas",
+    "brew install lapack",
     "git submodule update --init",
     "./prepare.sh",
     "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -5,12 +5,6 @@ requires = [
 ]
 
 [tool.cibuildwheel]
-before-all = [
-    "git submodule update --init",
-    "./prepare.sh",
-    "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
-    "make install"
-]
 environment = "PYDARSHAN_BUILD_EXT=1"
 build = "cp3*"
 skip = [
@@ -29,10 +23,18 @@ test-command = "pytest {package}"
 before-all = [
     "yum install -y blas-devel lapack-devel",
     "yum install -y libxslt-devel libxml2-devel",
-    "yum install -y libjpeg libjpeg-devel"
+    "yum install -y libjpeg libjpeg-devel",
+    "git submodule update --init",
+    "./prepare.sh",
+    "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
+    "make install"
 ]
 
 [tool.cibuildwheel.macos]
 before-all = [
-    "brew install automake"
+    "brew install automake",
+    "git submodule update --init",
+    "./prepare.sh",
+    "./configure --disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod",
+    "make install"
 ]

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -28,7 +28,7 @@ test_requirements = ["pytest"]
 # discoverable in the environment by means of LD_LIBRARY_PATH or
 # pkg-config there is no need to build the extension.
 ext_modules = []
-if "--with-extension" in sys.argv:
+if "PYDARSHAN_BUILD_EXT" in os.environ:
     ext_modules.append(
         Extension(
             "darshan.extension",
@@ -38,7 +38,6 @@ if "--with-extension" in sys.argv:
             libraries=["darshan-util"],
         )
     )
-    sys.argv.remove("--with-extension")
 
 #
 # Find backend python files in modules and copy them into lib


### PR DESCRIPTION
This PR includes updates for supporting `cibuildwheel`:

- `cibuildwheel` configuration in `pyproject.toml` which works for my local Linux builds over Docker
- first cut at GitHub workflow for automatically building wheels on updates to code that affects PyDarshan
- change `setup.py` argument `--with-extension` to env variable `PYDARSHAN_BUILD_EXT` 

The last change was needed because I couldn't find any other way to get user arguments to `setup.py` from `cibuildwheel`. There seems to be lack of general support in `cibuildwheel` for user-specified options to `setup.py`, as well as issues with `pip` supporting the `--build-option` flag we had been using -- see discussion at https://github.com/pypa/cibuildwheel/issues/268. The issue with `--build-option` is what I think was leading to recurring issues with our existing wheel building setup, with that option being silently ignored and the extension ultimately not being built.

WIP tag while I verify the GitHub actions are working as my local test have.