### PR TITLE
ENH: handle H5F absence

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_opcounts.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -91,6 +92,11 @@ def gather_count_data(report, mod):
             'H5D Read', 'H5D Write', 'H5D Open',
             'H5D Flush', 'H5F Open', 'H5F Flush',
         ]
+        # H5F is not necessarily available following
+        # gh-703
+        if not "H5F" in report.summary["agg_ioops"]:
+            report.summary['agg_ioops']['H5F'] = defaultdict(lambda: 0)
+
         counts = [
             report.summary['agg_ioops']['H5D']['H5D_READS'],
             report.summary['agg_ioops']['H5D']['H5D_WRITES'],

--- a/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_exp_common.py
@@ -341,6 +341,14 @@ def test_xticks_and_labels(log_path, func, expected_xticklabels, mod):
             plot_opcounts,
             [0, 5, 5, 0, 10, 0],
         ),
+        # "ground truth" log where H5F is disabled and 3
+        # datasets are opened and written to
+        (
+            "treddy_h5d_no_h5f.darshan",
+            "H5D",
+            plot_opcounts,
+            [0, 3, 3, 0, 0, 0],
+        ),
     ],
 )
 def test_bar_heights(filename, mod, fig_func, expected_heights):

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -222,7 +222,8 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                     (match and int(darshan_log_version[2]) >= 4)):
                     assert actual_runtime_heatmap_titles == 3
                 elif ("runtime_and_dxt_heatmaps_diagonal_write_only" in log_filepath or
-                      "treddy_runtime_heatmap_inactive_ranks" in log_filepath):
+                      "treddy_runtime_heatmap_inactive_ranks" in log_filepath or
+                      "h5d_no_h5f" in log_filepath):
                     assert actual_runtime_heatmap_titles == 1
                 else:
                     assert actual_runtime_heatmap_titles == 0


### PR DESCRIPTION
Fixes #709

* the new Python summary report can now gracefully
handle the case where `H5F` is intentionally disabled
via the new mechanism provided in gh-703

* add a new test using the log file from
https://github.com/darshan-hpc/darshan-logs/pull/38

* minor testing adjustments to account for the extra
log file in suite

* using zeros instead of "N/A" type fillers is convenient
here, but we could always decide to change that later if
the absence of the module from the module list above in the
report is not clear enough

Here's the `HDF5` section of the new summary report for this log,
which should reflect the 3 ranks writing 5 H5D bytes each (the log
would error out with current `main`):

![image](https://user-images.githubusercontent.com/7903078/168941216-8bb183b0-f723-4704-8229-90e7b5561136.png)
