### PR TITLE
MAINT: deal with pd deprecation

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -75,7 +75,7 @@ jobs:
           # to check HPC spack installs for example
           cd $RUNNER_TEMP
           site_packages=$(pip show darshan | grep Location | cut -d ' ' -f 2)
-          pytest --pyargs darshan --cov-report xml --cov=$site_packages/darshan
+          pytest -W error::FutureWarning --pyargs darshan --cov-report xml --cov=$site_packages/darshan
       # Python 3.6 doesn't have access to some
       # dependencies needed for our type hints
       - if: ${{matrix.python-version > 3.6}}

--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -209,13 +209,13 @@ def rec_to_rw_counter_dfs(report: Any,
     df_reads = pd.DataFrame()
     df_writes = pd.DataFrame()
     if "POSIX" in report.modules:
-        rec_counters = rec_counters.append(report.records["POSIX"].to_df()['counters'])
-        df_reads = df_reads.append(rec_counters.loc[rec_counters[f'POSIX_BYTES_READ'] >= 1])
-        df_writes = df_writes.append(rec_counters.loc[rec_counters[f'POSIX_BYTES_WRITTEN'] >= 1])
+        rec_counters = pd.concat(objs=(rec_counters, report.records["POSIX"].to_df()['counters']))
+        df_reads = pd.concat(objs=(df_reads, rec_counters.loc[rec_counters[f'POSIX_BYTES_READ'] >= 1]))
+        df_writes = pd.concat(objs=(df_writes, rec_counters.loc[rec_counters[f'POSIX_BYTES_WRITTEN'] >= 1]))
     if "STDIO" in report.modules:
-        rec_counters = rec_counters.append(report.records["STDIO"].to_df()['counters'])
-        df_reads = df_reads.append(rec_counters.loc[rec_counters[f'STDIO_BYTES_READ'] >= 1])
-        df_writes = df_writes.append(rec_counters.loc[rec_counters[f'STDIO_BYTES_WRITTEN'] >= 1])
+        rec_counters = pd.concat(objs=(rec_counters, report.records["STDIO"].to_df()['counters']))
+        df_reads = pd.concat(objs=(df_reads, rec_counters.loc[rec_counters[f'STDIO_BYTES_READ'] >= 1]))
+        df_writes = pd.concat(objs=(df_writes, rec_counters.loc[rec_counters[f'STDIO_BYTES_WRITTEN'] >= 1]))
     
     return df_reads, df_writes
 


### PR DESCRIPTION
* treat all `FutureWarning` as errors in the `pytest`
CI checks, and fixup the large number of `FutureWarning`s
coming from usage of `df.append()` by using the more modern
`pd.concat()` instead

* the full testsuite drops from 819 to 48 warnings for me
locally, as a result of this change