### PR TITLE
CI, TST: early draft of functional testing

### DIFF
--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -23,8 +23,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          apt-get update -y
-          apt-get install -y hdf5-tools libhdf5-openmpi-dev openmpi-bin
+          sudo apt-get update -y
+          sudo apt-get install -y hdf5-tools libhdf5-openmpi-dev openmpi-bin
           python -m pip install --upgrade pip
           python -m pip install --upgrade pytest mpi4py
           # the organization of HDF5 files from apt isn't

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -48,6 +48,7 @@ jobs:
           make install
       - name: Install darshan-util
         run: |
+          export DARSHAN_INSTALL_PATH=$PWD/darshan_install
           cd darshan-util
           mkdir build
           cd build
@@ -60,6 +61,7 @@ jobs:
           python -m pip install .
       - name: Test with pytest
         run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/darshan_install/lib
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install
           export DARSHAN_ROOT_PATH=$PWD
           export HDF5_LIB=/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -1,0 +1,66 @@
+name: Runtime Testing
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test_runtime:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: ["3.10"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          apt-get update -y
+          apt-get install -y hdf5-tools libhdf5-openmpi-dev openmpi-bin
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pytest mpi4py
+          # the organization of HDF5 files from apt isn't
+          # ideal for usage with darshan, but we can cheat
+          # a little
+          cp /usr/include/hdf5/openmpi/*.h /usr/include
+          # we need to build h5py with the system HDF5 lib backend
+          export HDF5_MPI="ON"
+          CC=mpicc python -m pip install --no-binary=h5py h5py
+      - name: Install darshan-runtime
+        run: |
+          mkdir darshan_install
+          export DARSHAN_INSTALL_PATH=$PWD/darshan_install
+          git submodule update --init
+          ./prepare.sh
+          cd darshan-runtime
+          mkdir build
+          cd build
+          CC=mpicc ../configure --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=SLURM_JOBID --enable-hdf5-mod
+          make
+          make install
+      - name: Install darshan-util
+        run: |
+          cd darshan-util
+          mkdir build
+          cd build
+          ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-apxc-mod --enable-apmpi-mod
+          make
+          make install
+      - name: Install pydarshan
+        run: |
+          cd darshan-util/pydarshan
+          python -m pip install .
+      - name: Test with pytest
+        run: |
+          export DARSHAN_INSTALL_PATH=$PWD/darshan_install
+          export DARSHAN_ROOT_PATH=$PWD
+          export HDF5_LIB=/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so
+          python -m pytest darshan-test/python_runtime_tests.py

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -30,7 +30,7 @@ jobs:
           # the organization of HDF5 files from apt isn't
           # ideal for usage with darshan, but we can cheat
           # a little
-          cp /usr/include/hdf5/openmpi/*.h /usr/include
+          sudo cp /usr/include/hdf5/openmpi/*.h /usr/include
           # we need to build h5py with the system HDF5 lib backend
           export HDF5_MPI="ON"
           CC=mpicc python -m pip install --no-binary=h5py h5py

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -27,15 +27,12 @@ jobs:
           sudo apt-get install -y hdf5-tools libhdf5-openmpi-dev openmpi-bin
           python -m pip install --upgrade pip
           python -m pip install --upgrade pytest mpi4py
-          # the organization of HDF5 files from apt isn't
-          # ideal for usage with darshan, but we can cheat
-          # a little
-          sudo cp /usr/include/hdf5/openmpi/*.h /usr/include
           # we need to build h5py with the system HDF5 lib backend
           export HDF5_MPI="ON"
           CC=mpicc python -m pip install --no-binary=h5py h5py
       - name: Install darshan-runtime
         run: |
+          export C_INCLUDE_PATH=$C_INCLUDE_PATH:/usr/include/hdf5/openmpi/
           mkdir darshan_install
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install
           git submodule update --init
@@ -43,7 +40,7 @@ jobs:
           cd darshan-runtime
           mkdir build
           cd build
-          CC=mpicc ../configure --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=SLURM_JOBID --enable-hdf5-mod
+          CC=mpicc ../configure --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE --enable-hdf5-mod
           make
           make install
       - name: Install darshan-util

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ maint/config/ltoptions.m4
 maint/config/ltsugar.m4
 maint/config/ltversion.m4
 maint/config/lt~obsolete.m4
+
+__pycache__/

--- a/darshan-test/python_mpi_scripts/runtime_prog_issue_690.py
+++ b/darshan-test/python_mpi_scripts/runtime_prog_issue_690.py
@@ -1,0 +1,23 @@
+import numpy as np
+import h5py
+from mpi4py import MPI
+from numpy.testing import assert_array_equal
+
+def h5oopen_h5py_roundtrip():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    # round trip HDF5 IO test
+    file_path = f"./test_rank_{rank}.hdf5"
+    n_bytes = 10 * (rank + 1)
+    bytes_to_write = np.ones(shape=n_bytes, dtype=np.int8)
+
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("dataset", data=bytes_to_write)
+
+    with h5py.File(file_path, "r") as g:
+        retrieved_data = np.asarray(g['dataset'])
+        assert_array_equal(retrieved_data, bytes_to_write)
+
+if __name__ == "__main__":
+    h5oopen_h5py_roundtrip()

--- a/darshan-test/python_runtime_tests.py
+++ b/darshan-test/python_runtime_tests.py
@@ -1,0 +1,53 @@
+import glob
+import subprocess
+import os
+
+import darshan
+import numpy as np
+import pytest
+
+
+def test_h5oopen_h5py_roundtrip(tmpdir):
+    # regression test for gh-690
+    n_ranks = 1
+    root_path = os.environ.get("DARSHAN_ROOT_PATH")
+    darshan_install_path = os.environ.get("DARSHAN_INSTALL_PATH")
+    test_script_path = os.path.join(root_path,
+                                    "darshan-test",
+                                    "python_mpi_scripts",
+                                    "runtime_prog_issue_690.py")
+    darshan_lib_path = os.path.join(darshan_install_path,
+                                    "lib",
+                                    "libdarshan.so")
+    hdf5_lib_path = os.environ.get("HDF5_LIB")
+
+    with tmpdir.as_cwd():
+        cwd = os.getcwd()
+        subprocess.check_output(["mpirun",
+                     "--allow-run-as-root",
+                     "-n",
+                     f"{n_ranks}",
+                     "-x",
+                     f"LD_PRELOAD={darshan_lib_path}:{hdf5_lib_path}",
+                     "-x",
+                     f"DARSHAN_LOGPATH={cwd}",
+                     "python",
+                     f"{test_script_path}"])
+
+        log_file_list = glob.glob("*.darshan")
+        # only a single log file should be generated
+        # by darshan
+        assert len(log_file_list) == 1
+        path_to_log = os.path.join(cwd, log_file_list[0])
+        report = darshan.DarshanReport(path_to_log)
+        print("report:", report)
+        h5f_df_counters = report.records["H5F"].to_df()["counters"]
+        h5d_df_counters = report.records["H5D"].to_df()["counters"]
+
+        # each rank should open an HDF5 file once for
+        # reading and one for writing
+        assert h5f_df_counters["H5F_OPENS"].to_numpy() == n_ranks * 2
+        assert h5d_df_counters["H5D_OPENS"].to_numpy() == n_ranks * 2
+        # only 1 read/write event per rank
+        assert h5d_df_counters["H5D_READS"].to_numpy() == n_ranks
+        assert h5d_df_counters["H5D_WRITES"].to_numpy() == n_ranks


### PR DESCRIPTION
* this adds end-to-end functional CI testing from
the darshan runtime monitoring MPI IO activity
right through to the Python bindings checking
for the expected result; you can run this locally (containerized)
with the `act` tool with i.e.,
`act -j test_runtime`

* when cherry-picked into gh-751, this reproduces
the exact error I was hoping CI could catch as
described here:
https://github.com/darshan-hpc/darshan/pull/751#issuecomment-1150197393

* otherwise, running this locally produces the expected failure
to capture `H5D` events when reading with `h5py`, with
only the write, but not the read event going through
the expected API path until Shane's PR (gh-751) is
ready

```
| >           assert h5d_df_counters["H5D_OPENS"].to_numpy() == n_ranks * 2
| E           assert array([1]) == (1 * 2)
| E            +  where array([1]) = <bound method IndexOpsMixin.to_numpy of 0    1\nName: H5D_OPENS, dtype: int64>()
| E            +    where <bound method IndexOpsMixin.to_numpy of 0    1\nName: H5D_OPENS, dtype: int64> = 0    1\nName: H5D_OPENS, dtype: int64.to_numpy
|
| darshan-test/python_runtime_tests.py:50: AssertionError
```

* there are many reasons I've opted not to use `pytest-mpi` at this
time, and gh-752 is only one of them

* if you'd like me to write an example test using C code, that should
be quite doable as well, we'd just have the `pytest` test compile
the source appropriately and then use the same approach; developing
this infrastructure was fairly time consuming though so I may want to
defer that to a follow-up if it is "ok"

* I'm not sure how many ranks we can safely use simultaneously
on the same free open source virtual machines, but this still
seems like a pretty big step up from "no runtime testing whatsoever"
in the CI

* this also opens up the possibility for i.e., using `gcov` to
produce reports of coverage of the C runtime code in CI, and so on..

* we may benefit from caching some steps.. building `h5py` from
source is time consuming in my local tests with `act`