### PR TITLE
fix segfault affecting DARSHAN_MOD_DISABLE/ENABLE env vars

### DIFF
--- a/darshan-runtime/lib/darshan-config.c
+++ b/darshan-runtime/lib/darshan-config.c
@@ -382,7 +382,7 @@ void darshan_parse_config_env(struct darshan_config *cfg)
     /* allow disabling of specific Darshan instrumentation modules */
     if(mod_disable_str)
     {
-        string = strdup(envstr);
+        string = strdup(mod_disable_str);
         tmp_mod_flags = darshan_module_csv_to_flags(string);
         cfg->mod_disabled_flags |= tmp_mod_flags;
         free(string);
@@ -390,7 +390,7 @@ void darshan_parse_config_env(struct darshan_config *cfg)
     /* allow enabling of specific Darshan instrumentation modules */
     if(mod_enable_str)
     {
-        string = strdup(envstr);
+        string = strdup(mod_enable_str);
         tmp_mod_flags = darshan_module_csv_to_flags(string);
         cfg->mod_enabled_flags |= tmp_mod_flags;
         free(string);


### PR DESCRIPTION
As mentioned in #743, Darshan seg faults on any attempts to set `DARSHAN_MOD_DISABLE`/`DARSHAN_MOD_ENABLE` env vars.

This was a simple fix, I had not properly accounted for some variable name changes I made right before merging this in.

Fixes #743