### PR TITLE
make `cuserid()` usage opt-in

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -98,13 +98,13 @@ if test "x$enable_darshan_runtime" = xyes ; then
    fi
 
    AC_ARG_ENABLE([cuserid],
-      [AS_HELP_STRING([--disable-cuserid],
-                      [Disables attempted use of cuserid() at run time])],
-      [], [enable_cuserid=yes]
+      [AS_HELP_STRING([--enable-cuserid],
+                      [Enables attempted use of cuserid() at run time])],
+      [], [enable_cuserid=no]
    )
-   if test "x$enable_cuserid" = "xno" ; then
-      AC_DEFINE([__DARSHAN_DISABLE_CUSERID], 1,
-                [Define if cuserid() should be disabled])
+   if test "x$enable_cuserid" = "xyes" ; then
+      AC_DEFINE([__DARSHAN_ENABLE_CUSERID], 1,
+                [Define if cuserid() should be enabled])
    fi
 
    AC_ARG_ENABLE([group-readable-logs],

--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -99,7 +99,7 @@ make install
 * `--without-mpi`: disables MPI support when building Darshan - MPI support is
   assumed if not specified.
 * `--enable-mmap-logs`: enables the use of Darshan's mmap log file mechanism.
-* `--disable-cuserid`: disables use of cuserid() at runtime.
+* `--enable-cuserid`: enables use of cuserid() at runtime.
 * `--disable-ld-preload`: disables building of the Darshan LD_PRELOAD library
 * `--enable-group-readable-logs`: sets Darshan log file permissions to allow
   group read access.
@@ -690,7 +690,7 @@ module swap PrgEnv-pgi PrgEnv-gnu
 ./configure \
  --with-log-path=/shared-file-system/darshan-logs \
  --prefix=/soft/darshan-2.2.3 \
- --with-jobid-env=PBS_JOBID --disable-cuserid CC=cc
+ --with-jobid-env=PBS_JOBID CC=cc
 make install
 module swap PrgEnv-gnu PrgEnv-pgi
 ----
@@ -700,14 +700,6 @@ module swap PrgEnv-gnu PrgEnv-pgi
 ====
 The job ID is set to `PBS_JOBID` for use with a Torque or PBS based scheduler.
 The `CC` variable is configured to point the standard MPI compiler.
-
-The --disable-cuserid argument is used to prevent Darshan from attempting to
-use the cuserid() function to retrieve the user name associated with a job.
-Darshan automatically falls back to other methods if this function fails,
-but on some Cray environments (notably the Beagle XE6 system as of March 2012)
-the cuserid() call triggers a segmentation fault.  With this option set,
-Darshan will typically use the LOGNAME environment variable to determine a
-userid.
 ====
 
 If instrumentation of the HDF5 library is desired, additionally load an

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -1347,7 +1347,7 @@ static void darshan_get_user_name(char *cuser)
     /* get the username for this job.  In order we will try each of the
      * following until one of them succeeds:
      *
-     * - cuserid()
+     * - cuserid() -- if enabled at configure time (disabled by default)
      * - getenv("LOGNAME")
      * - snprintf(..., geteuid());
      *
@@ -1355,7 +1355,7 @@ static void darshan_get_user_name(char *cuser)
      * work in statically compiled binaries.
      */
 
-#ifndef __DARSHAN_DISABLE_CUSERID
+#ifdef __DARSHAN_ENABLE_CUSERID
     cuserid(cuser);
 #endif
 


### PR DESCRIPTION
PR contains the following:

- updates to `darshan-runtime` autoconf and core code to make `cuserid()` usage opt-in
- corresponding changes/simplifications to docs

Fixes #699