### PR TITLE
bug fix + refactoring of `log_get_namerec` routines

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -637,9 +637,6 @@ int darshan_log_get_namehash(darshan_fd fd, struct darshan_name_record_ref **has
     return(0);
 }
 
-
-
-
 /* darshan_log_get_filtered_namehash()
  *
  * read the set of name records from the darshan log file and add to the
@@ -649,8 +646,7 @@ int darshan_log_get_namehash(darshan_fd fd, struct darshan_name_record_ref **has
  */
 int darshan_log_get_filtered_namehash(darshan_fd fd, 
         struct darshan_name_record_ref **hash,
-        darshan_record_id *whitelist, int whitelist_count
-        )
+        darshan_record_id *whitelist, int whitelist_count)
 {
     struct darshan_fd_int_state *state;
     char *name_rec_buf;
@@ -716,11 +712,6 @@ int darshan_log_get_filtered_namehash(darshan_fd fd,
     free(name_rec_buf);
     return(0);
 }
-
-
-
-
-
 
 /* darshan_log_put_namehash()
  *
@@ -1044,12 +1035,6 @@ static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
     return(buf_processed);
 }
 
-
-
-
-
-
-
 /* whitelist_filter
  *
  * A simple filter function, that tests if a provided value is in 
@@ -1128,8 +1113,7 @@ static int darshan_log_get_filtered_namerecs(void *name_rec_buf, int buf_len,
                 memcpy(ref->name_record, name_rec, rec_len);
 
                 /* add this record to the hash */
-
-                    HASH_ADD(hlink, *hash, name_record->id, sizeof(darshan_record_id), ref);
+                HASH_ADD(hlink, *hash, name_record->id, sizeof(darshan_record_id), ref);
             }
         }
 
@@ -1141,10 +1125,6 @@ static int darshan_log_get_filtered_namerecs(void *name_rec_buf, int buf_len,
 
     return(buf_processed);
 }
-
-
-
-
 
 /* read the header of the darshan log and set internal fd data structures
  * NOTE: this is the only portion of the darshan log that is uncompressed
@@ -2143,9 +2123,9 @@ int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
  *
  * Gets list of modules present in logs and returns the info
  */
-void darshan_log_get_modules (darshan_fd fd,
-                              struct darshan_mod_info **mods,
-                              int* count)
+void darshan_log_get_modules(darshan_fd fd,
+                             struct darshan_mod_info **mods,
+                             int* count)
 {
     int i;
     int j;
@@ -2175,7 +2155,6 @@ void darshan_log_get_modules (darshan_fd fd,
 
     *count = j;
 }
-
 
 /*
  * darshan_log_get_name_records
@@ -2215,7 +2194,6 @@ void darshan_log_get_name_records(darshan_fd fd,
 
 }
 
-
 /*
  * darshan_log_lookup_name_records
  *
@@ -2224,8 +2202,7 @@ void darshan_log_get_name_records(darshan_fd fd,
 void darshan_log_get_filtered_name_records(darshan_fd fd,
                               struct darshan_name_record_info **name_records,
                               int* count,
-                              darshan_record_id *whitelist, int whitelist_count
-        )
+                              darshan_record_id *whitelist, int whitelist_count)
 {
 
     int ret;
@@ -2257,19 +2234,14 @@ void darshan_log_get_filtered_name_records(darshan_fd fd,
 
 }
 
-
-
-
-
-
 /*
  * darshan_log_get_record 
  *
- *   Wrapper to hide the mod_logutils callback functions.
+ * Wrapper to hide the mod_logutils callback functions.
  */
-int  darshan_log_get_record (darshan_fd fd,
-                             int mod_idx,
-                             void **buf)
+int darshan_log_get_record(darshan_fd fd,
+                           int mod_idx,
+                           void **buf)
 {
     int r;
 

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -71,7 +71,8 @@ struct darshan_fd_int_state
     /* log format version-specific function calls for getting
      * data from the log file
      */
-    int (*get_namerecs)(void *, int, int, struct darshan_name_record_ref **);
+    int (*get_namerecs)(void *, int, int, struct darshan_name_record_ref **,
+                        darshan_record_id *, int);
 
     /* compression/decompression stream read/write state */
     struct darshan_dz_state dz;
@@ -88,7 +89,8 @@ struct darshan_mod_logutil_funcs *mod_logutils[DARSHAN_MAX_MODS] =
 /* internal helper functions */
 static int darshan_mnt_info_cmp(const void *a, const void *b);
 static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
-    int swap_flag, struct darshan_name_record_ref **hash);
+    int swap_flag, struct darshan_name_record_ref **hash,
+    darshan_record_id *whitelist, int whitelist_count);
 static int darshan_log_get_header(darshan_fd fd);
 static int darshan_log_put_header(darshan_fd fd);
 static int darshan_log_seek(darshan_fd fd, off_t offset);
@@ -115,14 +117,10 @@ static int darshan_log_dzunload(darshan_fd fd, struct darshan_log_map *map_p);
 static int darshan_log_noz_read(darshan_fd fd, struct darshan_log_map map,
     void *buf, int len, int reset_strm_flag);
 
-
-/* filtered namerecs test */
-static int darshan_log_get_filtered_namerecs(void *name_rec_buf, int buf_len, int swap_flag, struct darshan_name_record_ref **hash, darshan_record_id *whitelist, int whitelist_count);
-
-
 /* backwards compatibility functions */
-int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
-    int swap_flag, struct darshan_name_record_ref **hash);
+static int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
+    int swap_flag, struct darshan_name_record_ref **hash,
+    darshan_record_id *whitelist, int whitelist_count);
 
 static char *darshan_util_lib_ver = PACKAGE_VERSION;
 
@@ -574,73 +572,13 @@ int darshan_log_put_mounts(darshan_fd fd, struct darshan_mnt_info *mnt_data_arra
  */
 int darshan_log_get_namehash(darshan_fd fd, struct darshan_name_record_ref **hash)
 {
-    struct darshan_fd_int_state *state;
-    char *name_rec_buf;
-    int name_rec_buf_sz;
-    int read;
-    int read_req_sz;
-    int buf_len = 0;
-    int buf_processed;
-
-    if(!fd)
-    {
-        fprintf(stderr, "Error: invalid Darshan log file handle.\n");
-        return(-1);
-    }
-    state = fd->state;
-    assert(state);
-
-    /* just return if there is no name record mapping data */
-    if(fd->name_map.len == 0)
-    {
-        *hash = NULL;
-        return(0);
-    }
-
-    /* default to buffer twice as big as default compression buf */
-    name_rec_buf_sz = DARSHAN_DEF_COMP_BUF_SZ * 2;
-    name_rec_buf = malloc(name_rec_buf_sz);
-    if(!name_rec_buf)
-        return(-1);
-    memset(name_rec_buf, 0, name_rec_buf_sz);
-
-    do
-    {
-        /* read chunks of the darshan record id -> name mapping from log file,
-         * constructing a hash table in the process
-         */
-        read_req_sz = name_rec_buf_sz - buf_len;
-        read = darshan_log_dzread(fd, DARSHAN_NAME_MAP_REGION_ID,
-            name_rec_buf + buf_len, read_req_sz);
-        if(read < 0)
-        {
-            fprintf(stderr, "Error: failed to read name hash from darshan log file.\n");
-            free(name_rec_buf);
-            return(-1);
-        }
-        buf_len += read;
-
-        /* extract any name records in the buffer */
-        buf_processed = state->get_namerecs(name_rec_buf, buf_len, fd->swap_flag, hash);
-
-        /* copy any leftover data to beginning of buffer to parse next */
-        memcpy(name_rec_buf, name_rec_buf + buf_processed, buf_len - buf_processed);
-        buf_len -= buf_processed;
-
-        /* we keep reading until we get a short read informing us we have
-         * read all of the record hash
-         */
-    } while(read == read_req_sz);
-    assert(buf_len == 0);
-
-    free(name_rec_buf);
-    return(0);
+    return(darshan_log_get_filtered_namehash(fd, hash, NULL, 0));
 }
 
 /* darshan_log_get_filtered_namehash()
  *
  * read the set of name records from the darshan log file and add to the
- * given hash table
+ * given hash table, optionally applying a whitelist
  *
  * returns 0 on success, -1 on failure
  */
@@ -695,9 +633,8 @@ int darshan_log_get_filtered_namehash(darshan_fd fd,
         buf_len += read;
 
         /* extract any name records in the buffer */
-        //buf_processed = state->get_namerecs(name_rec_buf, buf_len, fd->swap_flag, hash);
-        //buf_processed = state->get_filtered_namerecs(name_rec_buf, buf_len, fd->swap_flag, hash);
-        buf_processed = darshan_log_get_filtered_namerecs(name_rec_buf, buf_len, fd->swap_flag, hash, whitelist, whitelist_count);
+        buf_processed = state->get_namerecs(name_rec_buf, buf_len, fd->swap_flag, hash,
+            whitelist, whitelist_count);
 
         /* copy any leftover data to beginning of buffer to parse next */
         memcpy(name_rec_buf, name_rec_buf + buf_processed, buf_len - buf_processed);
@@ -972,69 +909,6 @@ static int darshan_mnt_info_cmp(const void *a, const void *b)
         return(0);
 }
 
-static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
-    int swap_flag, struct darshan_name_record_ref **hash)
-{
-    struct darshan_name_record_ref *ref;
-    struct darshan_name_record *name_rec;
-    char *tmp_p;
-    int buf_processed = 0;
-    int rec_len;
-
-    /* work through the name record buffer -- deserialize the record data
-     * and add to the output hash table
-     * NOTE: these mapping pairs are variable in length, so we have to be able
-     * to handle incomplete mappings temporarily here
-     */
-    name_rec = (struct darshan_name_record *)name_rec_buf;
-    while(buf_len > sizeof(darshan_record_id) + 1)
-    {
-        if(strnlen(name_rec->name, buf_len - sizeof(darshan_record_id)) ==
-            (buf_len - sizeof(darshan_record_id)))
-        {
-            /* if this record name's terminating null character is not
-             * present, we need to read more of the buffer before continuing
-             */
-            break;
-        }
-        rec_len = sizeof(darshan_record_id) + strlen(name_rec->name) + 1;
-
-        if(swap_flag)
-        {
-            /* we need to sort out endianness issues before deserializing */
-            DARSHAN_BSWAP64(&(name_rec->id));
-        }
-
-        HASH_FIND(hlink, *hash, &(name_rec->id), sizeof(darshan_record_id), ref);
-        if(!ref)
-        {
-            ref = malloc(sizeof(*ref));
-            if(!ref)
-                return(-1);
-
-            ref->name_record = malloc(rec_len);
-            if(!ref->name_record)
-            {
-                free(ref);
-                return(-1);
-            }
-
-            /* copy the name record over from the hash buffer */
-            memcpy(ref->name_record, name_rec, rec_len);
-
-            /* add this record to the hash */
-            HASH_ADD(hlink, *hash, name_record->id, sizeof(darshan_record_id), ref);
-        }
-
-        tmp_p = (char *)name_rec + rec_len;
-        name_rec = (struct darshan_name_record *)tmp_p;
-        buf_len -= rec_len;
-        buf_processed += rec_len;
-    }
-
-    return(buf_processed);
-}
-
 /* whitelist_filter
  *
  * A simple filter function, that tests if a provided value is in 
@@ -1052,16 +926,9 @@ int whitelist_filter(darshan_record_id val, darshan_record_id *whitelist, int wh
     return 0;
 }
 
-/* darshan_log_get_filtered_namerecs
- *
- * Buffered reader to to reconstruct name records from logfile
- *
- */
-static int darshan_log_get_filtered_namerecs(void *name_rec_buf, int buf_len,
+static int darshan_log_get_namerecs(void *name_rec_buf, int buf_len,
     int swap_flag, struct darshan_name_record_ref **hash,
-    darshan_record_id *whitelist, int whitelist_count
-    )
-// JL: would change interface to allow filter callback function instead of whitelist for more flexibility
+    darshan_record_id *whitelist, int whitelist_count)
 {
     struct darshan_name_record_ref *ref;
     struct darshan_name_record *name_rec;
@@ -1094,27 +961,25 @@ static int darshan_log_get_filtered_namerecs(void *name_rec_buf, int buf_len,
         }
 
         HASH_FIND(hlink, *hash, &(name_rec->id), sizeof(darshan_record_id), ref);
-
-        if ( whitelist_filter(name_rec->id, whitelist, whitelist_count) ) {  
+        if(!ref && (!whitelist ||
+            whitelist_filter(name_rec->id, whitelist, whitelist_count)))
+        {
+            ref = malloc(sizeof(*ref));
             if(!ref)
+                return(-1);
+
+            ref->name_record = malloc(rec_len);
+            if(!ref->name_record)
             {
-                ref = malloc(sizeof(*ref));
-                if(!ref)
-                    return(-1);
-
-                ref->name_record = malloc(rec_len);
-                if(!ref->name_record)
-                {
-                    free(ref);
-                    return(-1);
-                }
-
-                /* copy the name record over from the hash buffer */
-                memcpy(ref->name_record, name_rec, rec_len);
-
-                /* add this record to the hash */
-                HASH_ADD(hlink, *hash, name_record->id, sizeof(darshan_record_id), ref);
+                free(ref);
+                return(-1);
             }
+
+            /* copy the name record over from the hash buffer */
+            memcpy(ref->name_record, name_rec, rec_len);
+
+            /* add this record to the hash */
+            HASH_ADD(hlink, *hash, name_record->id, sizeof(darshan_record_id), ref);
         }
 
         tmp_p = (char *)name_rec + rec_len;
@@ -2042,7 +1907,8 @@ static int darshan_log_dzunload(darshan_fd fd, struct darshan_log_map *map_p)
  ********************************************************/
 
 int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
-    int swap_flag, struct darshan_name_record_ref **hash)
+    int swap_flag, struct darshan_name_record_ref **hash,
+    darshan_record_id *whitelist, int whitelist_count)
 {
     struct darshan_name_record_ref *ref;
     char *buf_ptr;
@@ -2082,7 +1948,8 @@ int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
             DARSHAN_BSWAP64(rec_id_ptr);
 
         HASH_FIND(hlink, *hash, rec_id_ptr, sizeof(darshan_record_id), ref);
-        if(!ref)
+        if(!ref && (!whitelist ||
+            whitelist_filter(*rec_id_ptr, whitelist, whitelist_count)))
         {
             ref = malloc(sizeof(*ref));
             if(!ref)

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -1906,7 +1906,7 @@ static int darshan_log_dzunload(darshan_fd fd, struct darshan_log_map *map_p)
  *          backwards compatibility functions           *
  ********************************************************/
 
-int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
+static int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
     int swap_flag, struct darshan_name_record_ref **hash,
     darshan_record_id *whitelist, int whitelist_count)
 {

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -184,6 +184,8 @@ int darshan_log_get_mounts(darshan_fd fd, struct darshan_mnt_info **mnt_data_arr
 int darshan_log_put_mounts(darshan_fd fd, struct darshan_mnt_info *mnt_data_array,
     int count);
 int darshan_log_get_namehash(darshan_fd fd, struct darshan_name_record_ref **hash);
+int darshan_log_get_filtered_namehash(darshan_fd fd, struct darshan_name_record_ref **hash,
+    darshan_record_id *whitelist, int whitelist_count);
 int darshan_log_put_namehash(darshan_fd fd, struct darshan_name_record_ref *hash);
 int darshan_log_get_mod(darshan_fd fd, darshan_module_id mod_id,
     void *mod_buf, int mod_buf_sz);
@@ -192,17 +194,14 @@ int darshan_log_put_mod(darshan_fd fd, darshan_module_id mod_id,
 void darshan_log_close(darshan_fd file);
 void darshan_log_print_version_warnings(const char *version_string);
 char *darshan_log_get_lib_version(void);
-void darshan_log_get_modules (darshan_fd fd, struct darshan_mod_info **mods, int* count);
+void darshan_log_get_modules(darshan_fd fd, struct darshan_mod_info **mods,
+    int* count);
 void darshan_log_get_name_records(darshan_fd fd,
-                              struct darshan_name_record_info **mods,
-                              int* count);
-int darshan_log_get_record (darshan_fd fd, int mod_idx, void **buf);
-
+    struct darshan_name_record_info **mods, int* count);
 void darshan_log_get_filtered_name_records(darshan_fd fd,
-                              struct darshan_name_record_info **mods,
-                              int* count,
-                              darshan_record_id *whitelist, int whitelist_count
-                              );
+    struct darshan_name_record_info **mods, int* count,
+    darshan_record_id *whitelist, int whitelist_count);
+int darshan_log_get_record(darshan_fd fd, int mod_idx, void **buf);
 
 
 /* convenience macros for printing Darshan counters */


### PR DESCRIPTION
PyDarshan makes use of a `darshan_log_get_filtered_namehash()` routine that does not have proper handling in place to account for some log format changes that affected name records from 3.00 to 3.01 format version. This causes darshan-util library to abort on affected log format versions (3.00), as follows:

```
[chiusole@cori09:cori]$ python
Python 3.9.12 (main, Jun  1 2022, 11:38:51)
>>> import darshan
>>> report = darshan.DarshanReport("/global/cscratch1/sd/chiusole/logfile_causing_assertion_error.darshan")
python: darshan-logutils.c:714: darshan_log_get_filtered_namehash: Assertion `buf_len == 0' failed.
Aborted
```

I refactored all of the namehash/namerec routines to share as much code as possible, and to ensure the routine mentioned above properly handles backwards compatibility.

Fixes #762