### PR TITLE
MAINT: invalid log detection

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -497,3 +497,13 @@ def test_heatmap_df_invalid_operation():
     report = darshan.DarshanReport(log_path)
     with pytest.raises(ValueError, match="invalid_op not in heatmap"):
         report.heatmaps["POSIX"].to_df(ops=["invalid_op"])
+
+
+@pytest.mark.parametrize("log_name, error_match", [
+    # see: gh-562
+    ("sample.darshan", "STDIO_F_WRITE_TIME")
+])
+def test_detect_known_invalid_logs(log_name, error_match):
+    log_path = get_log_path(log_name)
+    with pytest.raises(ValueError, match=f"Invalid log file.*{error_match}"):
+        report = darshan.DarshanReport(log_path, strict=True)


### PR DESCRIPTION
* related to gh-564

* add a default-off keyword to `DarshanReport()` that can
detect some obviously-invalid log properties, for now
restricted to invalid time values that are `< -1`.

* add a regression test for this new machinery, with
the known case described in gh-562

* I think the plan is to eventually turn this testing on
for all logs added to the logs repo, though I have
not done that just yet