### PR TITLE
MAINT, CI: logs repo for cibuildwheel

### DIFF
--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -19,6 +19,7 @@ test-requires = [
     "matplotlib<3.5",
     "importlib_resources;python_version<'3.9'"
 ]
+before-test = "pip install -U git+https://github.com/darshan-hpc/darshan-logs.git@main"
 test-command = "pytest {package}"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Fixes #744

* install the darshan logs project prior to running
the `cibuildwheel` testsuite so that the release
manager can be more confident in the quality
of wheels prior to future releases

* we thought this was blocked on making a PyPI
package for the logs repo, but it is not because
we can just use `pip` to install manually from the
GitHub address as done here

* since the tests currently run on a single core
for these CI jobs, it will likely add 5-6 minutes
per wheel build to the CI time, but I think this is
worth it if it helps avoid a premature release for
the release manager

* a single-wheel spot check locally shows the extra
tests running on this branch vs. latest `main`:

`CIBW_BUILD="cp39-*" cibuildwheel --platform linux darshan-util/pydarshan`

```
414 passed, 2 xfailed, 12 warnings in 375.05s (0:06:15) # this branch
318 passed, 60 skipped, 12 warnings in 111.50s (0:01:51) # main
```

* I'll add the wheel build tag to this PR, since it explicitly
changes the wheel building infra

[wheel build]