### PR TITLE
HDF5 autoconf changes + hyperslab instrumentation fixes

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -370,12 +370,23 @@ if test "x$enable_darshan_runtime" = xyes ; then
       if test $hdf5_version_major -gt 1 || (test $hdf5_version_major -eq 1 && test $hdf5_version_minor -ge 10) ; then
          AC_DEFINE([DARSHAN_HDF5_VERS_1_10_PLUS], 1,
                    [Define if HDF5 module built with version 1.10+])
-         DARSHAN_HDF5_ADD_DFLUSH_LD_OPTS="--undefined=H5Dflush --wrap=H5Dflush"
          AC_MSG_RESULT(yes)
       else
-         DARSHAN_HDF5_ADD_DFLUSH_LD_OPTS=""
          AC_MSG_RESULT(no)
       fi
+
+      # check for specific HDF5 functions wrapped or used by Darshan
+      DARSHAN_HDF5_ADD_LD_OPTS=""
+      NL=$'\n'
+      old_cflags="$CFLAGS"
+      old_libs="$LIBS"
+      CFLAGS="$CFLAGS -I ${with_hdf5}/include"
+      LIBS="$LIBS -L ${with_hdf5}/lib -lhdf5 -lm -ldl -lz"
+      AC_CHECK_FUNCS([H5Dflush],
+                     [DARSHAN_HDF5_ADD_LD_OPTS+="--undefined=H5Dflush${NL}--wrap=H5Dflush${NL}"])
+      AC_CHECK_FUNCS([H5Sget_regular_hyperslab])
+      CFLAGS="$old_cflags"
+      LIBS="$old_libs"
 
       AC_MSG_CHECKING([whether HDF5 is built with parallel support])
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -685,7 +696,7 @@ if test "x$enable_darshan_runtime" = xyes ; then
    AC_SUBST(DARSHAN_VERSION)
    AC_SUBST(MPICH_LIB_OLD)
    AC_SUBST(DARSHAN_STDIO_ADD_FSCANF_LD_OPTS)
-   AC_SUBST(DARSHAN_HDF5_ADD_DFLUSH_LD_OPTS)
+   AC_SUBST(DARSHAN_HDF5_ADD_LD_OPTS)
    AC_SUBST(DARSHAN_HDF5_LD_FLAGS)
    AC_SUBST(DARSHAN_LUSTRE_LD_FLAGS)
    AC_SUBST(with_papi)

--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -623,10 +623,6 @@ herr_t DARSHAN_DECL(H5Dread)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spac
     size_t type_size;
     ssize_t file_sel_npoints;
     H5S_sel_type file_sel_type;
-    hsize_t start_dims[H5D_MAX_NDIMS] = {0};
-    hsize_t stride_dims[H5D_MAX_NDIMS] = {0};
-    hsize_t count_dims[H5D_MAX_NDIMS] = {0};
-    hsize_t block_dims[H5D_MAX_NDIMS] = {0};
     int64_t common_access_vals[H5D_MAX_NDIMS+H5D_MAX_NDIMS+1] = {0};
     struct darshan_common_val_counter *cvc;
     int i;
@@ -661,15 +657,17 @@ herr_t DARSHAN_DECL(H5Dread)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spac
                 file_sel_npoints = H5Sget_select_npoints(file_space_id);
                 file_sel_type = H5Sget_select_type(file_space_id);
             }
-#ifdef DARSHAN_HDF5_VERS_1_10_PLUS
-            if(file_sel_type == H5S_SEL_ALL)
-                rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] += 1;
-            else if(file_sel_type == H5S_SEL_POINTS)
+            if(file_sel_type == H5S_SEL_POINTS)
                 rec_ref->dataset_rec->counters[H5D_POINT_SELECTS] += 1;
             else if (file_sel_type == H5S_SEL_HYPERSLABS)
             {
+#ifdef HAVE_H5SGET_REGULAR_HYPERSLAB
                 if(H5Sis_regular_hyperslab(file_space_id))
                 {
+                    hsize_t start_dims[H5D_MAX_NDIMS] = {0};
+                    hsize_t stride_dims[H5D_MAX_NDIMS] = {0};
+                    hsize_t count_dims[H5D_MAX_NDIMS] = {0};
+                    hsize_t block_dims[H5D_MAX_NDIMS] = {0};
                     rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] += 1;
                     H5Sget_regular_hyperslab(file_space_id,
                         start_dims, stride_dims, count_dims, block_dims);
@@ -683,17 +681,14 @@ herr_t DARSHAN_DECL(H5Dread)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spac
                 }
                 else
                     rec_ref->dataset_rec->counters[H5D_IRREGULAR_HYPERSLAB_SELECTS] += 1;
-            }
 #else
-            rec_ref->dataset_rec->counters[H5D_POINT_SELECTS] = -1;
-            rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] = -1;
-            rec_ref->dataset_rec->counters[H5D_IRREGULAR_HYPERSLAB_SELECTS] = -1;
-            for(i = 0; i < H5D_MAX_NDIMS; i++)
-            {
-                common_access_vals[1+i] = -1;
-                common_access_vals[1+i+H5D_MAX_NDIMS] = -1;
-            }
+                for(i = 0; i < H5D_MAX_NDIMS; i++)
+                {
+                    common_access_vals[1+i] = -1;
+                    common_access_vals[1+i+H5D_MAX_NDIMS] = -1;
+                }
 #endif
+            }
             type_size = rec_ref->dataset_rec->counters[H5D_DATATYPE_SIZE];
             access_size = file_sel_npoints * type_size;
             rec_ref->dataset_rec->counters[H5D_BYTES_READ] += access_size;
@@ -744,10 +739,6 @@ herr_t DARSHAN_DECL(H5Dwrite)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spa
     size_t type_size;
     ssize_t file_sel_npoints;
     H5S_sel_type file_sel_type;
-    hsize_t start_dims[H5D_MAX_NDIMS] = {0};
-    hsize_t stride_dims[H5D_MAX_NDIMS] = {0};
-    hsize_t count_dims[H5D_MAX_NDIMS] = {0};
-    hsize_t block_dims[H5D_MAX_NDIMS] = {0};
     int64_t common_access_vals[H5D_MAX_NDIMS+H5D_MAX_NDIMS+1] = {0};
     struct darshan_common_val_counter *cvc;
     int i;
@@ -782,15 +773,17 @@ herr_t DARSHAN_DECL(H5Dwrite)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spa
                 file_sel_npoints = H5Sget_select_npoints(file_space_id);
                 file_sel_type = H5Sget_select_type(file_space_id);
             }
-#ifdef DARSHAN_HDF5_VERS_1_10_PLUS
-            if(file_sel_type == H5S_SEL_ALL)
-                rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] += 1;
-            else if(file_sel_type == H5S_SEL_POINTS)
+            if(file_sel_type == H5S_SEL_POINTS)
                 rec_ref->dataset_rec->counters[H5D_POINT_SELECTS] += 1;
             else if (file_sel_type == H5S_SEL_HYPERSLABS)
             {
+#ifdef HAVE_H5SGET_REGULAR_HYPERSLAB
                 if(H5Sis_regular_hyperslab(file_space_id))
                 {
+                    hsize_t start_dims[H5D_MAX_NDIMS] = {0};
+                    hsize_t stride_dims[H5D_MAX_NDIMS] = {0};
+                    hsize_t count_dims[H5D_MAX_NDIMS] = {0};
+                    hsize_t block_dims[H5D_MAX_NDIMS] = {0};
                     rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] += 1;
                     H5Sget_regular_hyperslab(file_space_id,
                         start_dims, stride_dims, count_dims, block_dims);
@@ -804,17 +797,14 @@ herr_t DARSHAN_DECL(H5Dwrite)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spa
                 }
                 else
                     rec_ref->dataset_rec->counters[H5D_IRREGULAR_HYPERSLAB_SELECTS] += 1;
-            }
 #else
-            rec_ref->dataset_rec->counters[H5D_POINT_SELECTS] = -1;
-            rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] = -1;
-            rec_ref->dataset_rec->counters[H5D_IRREGULAR_HYPERSLAB_SELECTS] = -1;
-            for(i = 0; i < H5D_MAX_NDIMS; i++)
-            {
-                common_access_vals[1+i] = -1;
-                common_access_vals[1+i+H5D_MAX_NDIMS] = -1;
-            }
+                for(i = 0; i < H5D_MAX_NDIMS; i++)
+                {
+                    common_access_vals[1+i] = -1;
+                    common_access_vals[1+i+H5D_MAX_NDIMS] = -1;
+                }
 #endif
+            }
             type_size = rec_ref->dataset_rec->counters[H5D_DATATYPE_SIZE];
             access_size = file_sel_npoints * type_size;
             rec_ref->dataset_rec->counters[H5D_BYTES_WRITTEN] += access_size;
@@ -1102,6 +1092,10 @@ static struct hdf5_dataset_record_ref *hdf5_track_new_dataset_record(
 
 #ifndef HAVE_H5DFLUSH
     rec_ref->dataset_rec->counters[H5D_FLUSHES] = -1;
+#endif
+#ifndef HAVE_H5SGET_REGULAR_HYPERSLAB
+    rec_ref->dataset_rec->counters[H5D_REGULAR_HYPERSLAB_SELECTS] = -1;
+    rec_ref->dataset_rec->counters[H5D_IRREGULAR_HYPERSLAB_SELECTS] = -1;
 #endif
 
     return(rec_ref);

--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -42,7 +42,7 @@ DARSHAN_FORWARD_DECL(H5Dopen1, hid_t, (hid_t loc_id, const char *name));
 DARSHAN_FORWARD_DECL(H5Dopen2, hid_t, (hid_t loc_id, const char *name, hid_t dapl_id));
 DARSHAN_FORWARD_DECL(H5Dread, herr_t, (hid_t dataset_id, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, void * buf));
 DARSHAN_FORWARD_DECL(H5Dwrite, herr_t, (hid_t dataset_id, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, const void * buf));
-#ifdef DARSHAN_HDF5_VERS_1_10_PLUS
+#ifdef HAVE_H5DFLUSH
 DARSHAN_FORWARD_DECL(H5Dflush, herr_t, (hid_t dataset_id));
 #endif
 DARSHAN_FORWARD_DECL(H5Dclose, herr_t, (hid_t dataset_id));
@@ -857,7 +857,7 @@ herr_t DARSHAN_DECL(H5Dwrite)(hid_t dataset_id, hid_t mem_type_id, hid_t mem_spa
     return(ret);
 }
 
-#ifdef DARSHAN_HDF5_VERS_1_10_PLUS
+#ifdef HAVE_H5DFLUSH
 herr_t DARSHAN_DECL(H5Dflush)(hid_t dataset_id)
 {
     struct hdf5_dataset_record_ref *rec_ref;
@@ -1100,8 +1100,7 @@ static struct hdf5_dataset_record_ref *hdf5_track_new_dataset_record(
     rec_ref->dataset_rec = dataset_rec;
     hdf5_dataset_runtime->rec_count++;
 
-#ifndef DARSHAN_HDF5_VERS_1_10_PLUS
-    /* flushes weren't introduced until H5 version 1.10+ */
+#ifndef HAVE_H5DFLUSH
     rec_ref->dataset_rec->counters[H5D_FLUSHES] = -1;
 #endif
 

--- a/darshan-runtime/share/ld-opts/darshan-hdf5-ld-opts.in
+++ b/darshan-runtime/share/ld-opts/darshan-hdf5-ld-opts.in
@@ -10,4 +10,4 @@
 --wrap=H5Dread
 --wrap=H5Dwrite
 --wrap=H5Dclose
-@DARSHAN_HDF5_ADD_DFLUSH_LD_OPTS@
+@DARSHAN_HDF5_ADD_LD_OPTS@


### PR DESCRIPTION
This PR contains a few changes to the runtime component of our HDF5 module:

* autoconf changes to conditionally compile in support for various functions (e.g., `H5Dflush`, `H5Sget_regular_hyperslab`) based on `AC_CHECK_FUNCS` checks rather than checking the HDF5 version number
* don't attribute read/write accesses to entire HDF5 datasets (i.e., 'ALL' selections) to `H5D_REGULAR_HYPERSLAB_SELECTS` counter -- there is no `ALL` variant of Darshan counters, but it can be deduced from current counters (total number of reads/writes minus total point/regular-hyperslab/irregular-hyperslab counts)
* compiler warning fixes for HDF5 versions greater than or equal to 1.8 and less than 1.10