### PR TITLE
MAINT: simplify get_heatmap_df()

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -350,7 +350,6 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     combo = start_fraction_bin_occupancy.mul(
         end_fraction_bin_occupancy, fill_value=1, axis=0
     )
-    combo.mask(combo > 1, 1, inplace=True)
     # add the start/end dummy variable dataframes
     # and replace any zeros with NaN's
     cats = cats_start.add(cats_end, fill_value=0)


### PR DESCRIPTION
* remove an extraneous step from `get_heatmap_df()`;
there should never be a fractional bin occupancy greater
than 1 achieved by multiplying fractions

* this is performance neutral on our benchmark suite:
`asv continuous -e -b ".*heatmap.*" main treddy_simplify_get_heatmap`,
and also doesn't help with producing html report faster for the
`e3sm_io_heatmap_and_dxt..` and `snyder_acme..` log files

* so, this isn't much of a victory unfortunately apart from -1 LOC;
I did make various attempts in the last two days to simplify
the algorithms here, and while I do have some branches with ~10-15 less
LOC, they take performance hits, so not ready to propose those yet

* one interesting observation is that `np.digitize` basically gives
us the same information as `pd.get_dummies(pd.cut())`, which
we call twice in the current algo, but my attempts to subsitute
have not produced impressive results so far

* I'll probably pivot away from the html DXT-related performance
stuff for a little while at least--the unsurprising reality is that
we spend a lot of time looping through Python objects in
the `get_rd_wr_dfs()` function because of our deeply nested
record collection objects