### PR TITLE
[BUG] darshan-runtime: small fix to HDF5 autodetect autoconf logic

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -353,7 +353,7 @@ if test "x$enable_darshan_runtime" = xyes ; then
          # autodetect HDF5 install prefix and set with_hdf5
          with_hdf5=$(dirname $(dirname $H5DUMP_CHECK))
       fi
-      if test "x$H5DUMP_CHECK" = xno ; then
+      if test "x$H5DUMP_CHECK" = xno || ! test -d "${with_hdf5}/lib" ; then
          AC_MSG_ERROR(m4_normalize([Darshan HDF5 module enabled but no valid HDF5 install found,
                        use --with-hdf5 to provide the HDF5 install prefix, if needed.]))
       fi


### PR DESCRIPTION
The autoconf logic that allows for autodiscovery of HDF5 prefixes using the location of `h5dump` binary is broken, at least on Cray systems. It looks like the organization of Cray software module install directories has changed slightly (as shown below), with us not being able to find a `lib` folder at the same directory level of the `bin` folder containing `h5dump`:

```
snyder@thetalogin4:~/software/darshan/darshan-dev/build> which h5dump
/opt/cray/pe/hdf5-parallel/1.10.6.1/bin/h5dump
snyder@thetalogin4:~/software/darshan/darshan-dev/build> ls /opt/cray/pe/hdf5-parallel/1.10.6.1/
bin  COPYING  crayclang  CRAYCLANG  gnu  GNU  include  intel  INTEL  set_pkgconfig_default_hdf5-parallel  share
```

Ultimately, this issue results in autoconf silently using a bad `lib` path for HDF5 which is then embedded in the RPATH of generated executables. This does not result in error for me on Cray systems, since having the `cray-hdf5-parallel` module loaded in my environment means that the appropriate library location is supplied on the compile line, but we should still fix this.

This PR adds an additional check in autoconf to ensure a `lib` folder is present where we expect it to be, else an error is printed encouraging user to use `--with-hdf5` to provide the right install prefix.