### PR TITLE
DOC: update docs to reflect new location of prepare.sh

### DIFF
--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -58,8 +58,9 @@ http://www.mcs.anl.gov/darshan[Darshan web site].
 .Configure and build example (with MPI support)
 ----
 tar -xvzf darshan-<version-number>.tar.gz
-cd darshan-<version-number>/darshan-runtime
+cd darshan-<version-number>/
 ./prepare
+cd darshan-runtime/
 ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID CC=mpicc
 make
 make install
@@ -68,8 +69,9 @@ make install
 .Configure and build example (without MPI support)
 ----
 tar -xvzf darshan-<version-number>.tar.gz
-cd darshan-<version-number>/darshan-runtime
+cd darshan-<version-number>/
 ./prepare
+cd darshan-runtime/
 ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID --without-mpi CC=gcc
 make
 make install

--- a/darshan-util/doc/darshan-util.txt
+++ b/darshan-util/doc/darshan-util.txt
@@ -33,8 +33,9 @@ work in other Unix-like environments as well.
 .Configure and build example
 ----
 tar -xvzf darshan-<version-number>.tar.gz
-cd darshan-<version-number>/darshan-util
+cd darshan-<version-number>/
 ./prepare
+cd darshan-util/
 ./configure
 make
 make install


### PR DESCRIPTION
darshan-runtime and darshan-util docs needed to be updated to reflect the move of `prepare.sh` script to the top-level of the repo.