### PR TITLE
BUG: logutils up-conversin of partial_flags is broken for darshan versions prior to 3.2.0

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -1173,6 +1173,15 @@ static int darshan_log_get_header(darshan_fd fd)
             (DARSHAN_MAX_MODS-DARSHAN_H5D_MOD-1) * sizeof(uint32_t));
         fd->mod_map[DARSHAN_H5D_MOD].len = fd->mod_map[DARSHAN_H5D_MOD].off = 0;
         fd->mod_ver[DARSHAN_H5D_MOD] = 0;
+
+        uint64_t partial_flag_shift = fd->partial_flag << 1;
+        // zero out bits up to (and including) H5D in shifted flags
+        partial_flag_shift = (partial_flag_shift >> (DARSHAN_H5D_MOD+1)) <<
+            (DARSHAN_H5D_MOD+1);
+        // zero out H5D and all bits higher than it in original flags
+        fd->partial_flag = fd->partial_flag & ((1 << DARSHAN_H5D_MOD) - 1);
+        // combine original flags and shifted flags
+        fd->partial_flag = fd->partial_flag | partial_flag_shift;
     }
 
     /* there may be nothing following the job data, so safety check map */


### PR DESCRIPTION
The logutils library is not properly up-converting the module partial flags contained in the header to account for the H5D module placed after the original HDF5 file module in version 3.2.0. This means that logs prior to 3.2.0 that are parsed by newer versions of Darshan will have an "off-by-1" bug in terms of module partial flags, with this bug affecting all modules following HDF5 in Darshan's module list.

This PR properly shifts the partial flags bitfield for all modules following the HDF5 module on pre 3.2.0 logs so the flags are properly up-converted.