### PR TITLE
MAINT: unpin matplotlib

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,8 +8,7 @@ task:
     /opt/homebrew/opt/python@3.10/bin/python3 -m venv ~/py_310
     source ~/py_310/bin/activate
     python -m pip install --upgrade pip
-    python -m pip install --upgrade pytest lxml
-    python -m pip install 'matplotlib<3.5'
+    python -m pip install --upgrade pytest lxml matplotlib packaging
     brew install automake libtool binutils
     mkdir -p /tmp/darshan_install
     export DARSHAN_INSTALL_PATH=/tmp/darshan_install

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -31,10 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml
-          # matplotlib is pinned because of
-          # gh-479
-          python -m pip install 'matplotlib<3.5'
+          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml matplotlib packaging
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |

--- a/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_dxt_heatmap.py
@@ -3,7 +3,9 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pandas as pd
 import seaborn as sns
+import matplotlib
 import matplotlib.pyplot as plt
+from packaging import version
 
 import darshan
 from darshan.experimental.plots import heatmap_handling, plot_dxt_heatmap
@@ -389,10 +391,16 @@ def test_adjust_for_colorbar(filepath):
         # since `dxt.darshan` has 1 rank, the colorbar doesn't have
         # to go closer to the edge of the figure
         assert cbar_positions.x0 == 0.82
-        assert cbar_positions.x1 == 0.8416135084427767
+        if version.parse(matplotlib.__version__) < version.parse("3.5.0"):
+            assert cbar_positions.x1 == 0.8416135084427767
+        else:
+            assert cbar_positions.x1 == 1.72
     else:
         assert cbar_positions.x0 == 0.85
-        assert cbar_positions.x1 == 0.8716135084427767
+        if version.parse(matplotlib.__version__) < version.parse("3.5.0"):
+            assert cbar_positions.x1 == 0.8716135084427767
+        else:
+            assert cbar_positions.x1 == 1.75
 
 @pytest.mark.parametrize(
     "filepath",

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -14,9 +14,10 @@ skip = [
     "*_s390x"
 ]
 test-requires = [
+    "packaging",
     "pytest",
     "lxml",
-    "matplotlib<3.5",
+    "matplotlib",
     "importlib_resources;python_version<'3.9'"
 ]
 before-test = "pip install -U git+https://github.com/darshan-hpc/darshan-logs.git@main"


### PR DESCRIPTION
* Fixes #479

* `test_adjust_for_colorbar()` has been failing with `matplotlib >= 3.5.0` for almost a year now, which is pretty annoying because building old versions of `matplotlib` with more recent Python versions can be painful (there is no binary sometimes)

* since I don't see any actual problems with the heatmap/colorbar layouts with the newer matplotlib, add a
[PEP440](https://peps.python.org/pep-0440/)-compliant version conditional inside `test_adjust_for_colorbar()` that uses a different colorbar coordinate value with newer versions of `matplotlib`; I think it is encouraging that the new values are offset by the same value (`0.3`) as the old ones; I don't think it is worth trying to figure out which `matplotlib` commit changed the coord layout values, but we could probably do that if we really wanted..

* so, unpin `matplotlib` version in a few CI/build system locations, and add `packaging` for the PEP-compliant version comparison at test time