### PR TITLE
MAINT: integer r/w vals for data access

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -543,8 +543,8 @@ def plot_data(fig: Any,
         # convert to MiB using 1048576 (ie: 2**20)
         bytes_read = bytes_rd_series[filesystem]/1048576
         bytes_written = bytes_wr_series[filesystem]/1048576
-        files_written = file_wr_series[filesystem]
-        files_read = file_rd_series[filesystem]
+        files_written = int(file_wr_series[filesystem])
+        files_read = int(file_rd_series[filesystem])
 
         # scale to fit longer filesystem
         # strings on the left side of the plots
@@ -586,7 +586,7 @@ def plot_data(fig: Any,
                                       transform=ax_filesystem_counts.transAxes,
                                       va="center")
         else:
-            ax_filesystem_counts.text(0, 0.75, f' # files read ({files_read:.2E})',
+            ax_filesystem_counts.text(0, 0.75, f' # files read ({files_read})',
                                       transform=ax_filesystem_counts.transAxes,
                                       va="center")
 
@@ -595,7 +595,7 @@ def plot_data(fig: Any,
                                       transform=ax_filesystem_counts.transAxes,
                                       va="center")
         else:
-            ax_filesystem_counts.text(0, 0.25, f' # files written ({files_written:.2E})',
+            ax_filesystem_counts.text(0, 0.25, f' # files written ({files_written})',
                                       transform=ax_filesystem_counts.transAxes,
                                       va="center")
 

--- a/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/tests/test_data_access_by_filesystem.py
@@ -273,8 +273,8 @@ def test_plot_data(file_rd_series, file_wr_series, bytes_rd_series, bytes_wr_ser
         if isinstance(child, matplotlib.text.Text):
             actual_list_text_in_fig.append(child.get_text())
 
-    for expected_text_entry in [matplotlib.text.Text(0, 1, ' # files read (3.00E+00)'),
-                                matplotlib.text.Text(0, 0, ' # files written (1.40E+01)')]:
+    for expected_text_entry in [matplotlib.text.Text(0, 1, ' # files read (3)'),
+                                matplotlib.text.Text(0, 0, ' # files written (14)')]:
         assert expected_text_entry.get_text() in actual_list_text_in_fig
 
     # enforce invisibile right-side spine so that


### PR DESCRIPTION
* deals with one of the user requests in gh-804--display "Data Access by Category" # files read/written using plain integers instead of scientific notation

* it may also seem weird to prefix a `0` value and append all other integer values, but there
was no specific feedback on this aspect of the display so I've left it untouched

Before/after samples for `ior_hdf5_example.darshan` and `treddy_runtime_heatmap_inactive_ranks.darshan` are below.

![image](https://user-images.githubusercontent.com/7903078/190220021-afd92cc1-8454-4068-857f-9d24d78bbc99.png)
![image](https://user-images.githubusercontent.com/7903078/190220280-807069a9-a322-45d9-b742-3019dd0892df.png)
![image](https://user-images.githubusercontent.com/7903078/190219871-2f15fc77-7508-4a68-8068-b1cbcdb182a5.png)
![image](https://user-images.githubusercontent.com/7903078/190219924-b8f94f5b-1b05-4094-bfd9-eab052bc9be0.png)
