### PR TITLE
BUG: fix mem leak across C/CFFI boundary

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -2069,7 +2069,7 @@ static int darshan_log_get_namerecs_3_00(void *name_rec_buf, int buf_len,
  * Gets list of modules present in logs and returns the info
  */
 void darshan_log_get_modules(darshan_fd fd,
-                             struct darshan_mod_info **mods,
+                             struct darshan_mod_info mods[DARSHAN_MAX_MODS],
                              int* count)
 {
     int i;
@@ -2082,18 +2082,15 @@ void darshan_log_get_modules(darshan_fd fd,
         return;
     }
 
-    *mods = malloc(sizeof(**mods) * DARSHAN_MAX_MODS);
-    assert(*mods);
-
     for (i = 0, j = 0; i < DARSHAN_KNOWN_MODULE_COUNT; i++)
     {
         if (fd->mod_map[i].len)
         {
-            (*mods)[j].name          = darshan_module_names[i];
-            (*mods)[j].len           = fd->mod_map[i].len;
-            (*mods)[j].ver           = fd->mod_ver[i];
-            (*mods)[j].partial_flag  = DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i);
-            (*mods)[j].idx           = i;
+            (mods)[j].name          = darshan_module_names[i];
+            (mods)[j].len           = fd->mod_map[i].len;
+            (mods)[j].ver           = fd->mod_ver[i];
+            (mods)[j].partial_flag  = DARSHAN_MOD_FLAG_ISSET(fd->partial_flag, i);
+            (mods)[j].idx           = i;
             j += 1;
         }
     }
@@ -2102,10 +2099,10 @@ void darshan_log_get_modules(darshan_fd fd,
         if (fd->mod_map[i].len)
         {
             /* we don't know the names of any modules in this region */
-            (*mods)[j].name = NULL;
-            (*mods)[j].len  = fd->mod_map[i].len;
-            (*mods)[j].ver  = fd->mod_ver[i];
-            (*mods)[j].idx  = i;
+            (mods)[j].name = NULL;
+            (mods)[j].len  = fd->mod_map[i].len;
+            (mods)[j].ver  = fd->mod_ver[i];
+            (mods)[j].idx  = i;
             j += 1;
         }
     }

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -211,7 +211,7 @@ int darshan_log_put_mod(darshan_fd fd, darshan_module_id mod_id,
 void darshan_log_close(darshan_fd file);
 void darshan_log_print_version_warnings(const char *version_string);
 char *darshan_log_get_lib_version(void);
-void darshan_log_get_modules(darshan_fd fd, struct darshan_mod_info **mods,
+void darshan_log_get_modules(darshan_fd fd, struct darshan_mod_info *mods,
     int* count);
 void darshan_log_get_name_records(darshan_fd fd,
     struct darshan_name_record_info **mods, int* count);

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -154,7 +154,7 @@ int darshan_log_get_job(void *, struct darshan_job *);
 void darshan_log_close(void*);
 int darshan_log_get_exe(void*, char *);
 int darshan_log_get_mounts(void*, struct darshan_mnt_info **, int*);
-void darshan_log_get_modules(void*, struct darshan_mod_info **, int*);
+void darshan_log_get_modules(void*, struct darshan_mod_info *, int*);
 int darshan_log_get_record(void*, int, void **);
 char* darshan_log_get_lib_version(void);
 

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -201,13 +201,16 @@ def log_get_modules(log):
 
     modules = {}
 
-    mods = ffi.new("struct darshan_mod_info **")
+    # TODO: we should eventually pull DARSHAN_MAX_MODS
+    # from the C layer instead of using a magic number (64)
+    # here
+    mods = ffi.new("struct darshan_mod_info[64]")
     cnt    = ffi.new("int *")
     libdutil.darshan_log_get_modules(log['handle'], mods, cnt)
     for i in range(0, cnt[0]):
-        modules[ffi.string(mods[0][i].name).decode("utf-8")] = \
-                {'len': mods[0][i].len, 'ver': mods[0][i].ver, 'idx': mods[0][i].idx,
-                 'partial_flag': bool(mods[0][i].partial_flag)}
+        modules[ffi.string(mods[i].name).decode("utf-8")] = \
+                {'len': mods[i].len, 'ver': mods[i].ver, 'idx': mods[i].idx,
+                 'partial_flag': bool(mods[i].partial_flag)}
 
     # add to cache
     log['modules'] = modules


### PR DESCRIPTION
* a few different memory leaks are described in gh-811, and this branch aims to deal with one
surrounding `darshan_log_get_modules()`, where
an internal `malloc` is effectively making a memory decision that is invisible to CFFI, so we can't free it externally--for example, CFFI would end up trying to free a subset of the original memory on the heap, which is prohibited

* this branch refactors `darshan_log_get_modules()` so that an external caller of this function, for example our CFFI use case, can allocate the memory needed for the module information on its own, which means that it has ownership for freeing that memory (which now happens automatically when `mods` drops out of scope in CPython)

* this substantially reduces the memory leak described in the profiling code (https://github.com/darshan-hpc/darshan/issues/811#issuecomment-1248290837), but not completely, since there appear to be other leaks related to opening log files, etc., that I'd prefer to investigate in separate PRs

Here is the somewhat less serious memleak with the same benchmark on this branch (1/2 the total footprint):

![image](https://user-images.githubusercontent.com/7903078/190460672-d76207c7-7cf3-439a-981b-d9e4198aa282.png)
