### PR TITLE
BUG: log_get_mounts mem leak

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -153,8 +153,9 @@ void* darshan_log_open(char *);
 int darshan_log_get_job(void *, struct darshan_job *);
 void darshan_log_close(void*);
 int darshan_log_get_exe(void*, char *);
-int darshan_log_get_mounts(void*, struct darshan_mnt_info **, int*);
 void darshan_log_get_modules(void*, struct darshan_mod_info **, int*);
+int darshan_log_get_mounts_cffi(void*, struct darshan_mnt_info *, int*);
+int darshan_log_get_mount_count(void*, int*);
 int darshan_log_get_record(void*, int, void **);
 char* darshan_log_get_lib_version(void);
 

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -171,13 +171,15 @@ def log_get_mounts(log):
     """
 
     mntlst = []
-    mnts = ffi.new("struct darshan_mnt_info **")
     cnt = ffi.new("int *")
-    libdutil.darshan_log_get_mounts(log['handle'], mnts, cnt)
+    libdutil.darshan_log_get_mount_count(log['handle'], cnt)
+    count = cnt[0]
+    mnts = ffi.new(f"struct darshan_mnt_info[{count}]")
+    libdutil.darshan_log_get_mounts_cffi(log['handle'], mnts, cnt)
 
     for i in range(0, cnt[0]):
-        mntlst.append((ffi.string(mnts[0][i].mnt_path).decode("utf-8"),
-            ffi.string(mnts[0][i].mnt_type).decode("utf-8")))
+        mntlst.append((ffi.string(mnts[i].mnt_path).decode("utf-8"),
+            ffi.string(mnts[i].mnt_type).decode("utf-8")))
 
     return mntlst
 


### PR DESCRIPTION
* fix a memory leak at the CFFI interface to `darshan_log_get_mounts()` by allowing CFFI
to first count the number of moint points,
then allocate its own struct of the appropriate
size, and then fill that struct with the mount
points

* solution here is a bit more complex b/c the C code is used elsewhere--I didn't check
that in great detail and instead skirted the issue by writing new C functions I actually
wanted
 
* this is done by adding two new functions that split the logic into bits that allow CFFI to
properly drop unused memory promptly, which
reduces our memory footprint by 3.5 GiB vs.
`main` and gh-813 for the `2.3 KiB` reproducer
log (see comparison memtrace plot at:
https://github.com/darshan-hpc/darshan/issues/811#issuecomment-1248514526)

New trace is nice and stable for that reproducer:
![image](https://user-images.githubusercontent.com/7903078/190494692-7eae7ead-ca33-4bba-ac2b-21557b1688d4.png)

* we may want to add `asv` peak memory usage benchmarks, or open an issue to remind us to do that for regression guard of sorts..
