### PR TITLE
BUG: memleak fix CFFI only pt1

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -2207,6 +2207,11 @@ int darshan_log_get_record(darshan_fd fd,
     return r;
 }
 
+void darshan_free(void *ptr)
+{
+    free(ptr);
+}
+
 /*
  * Local variables:
  *  c-indent-level: 4

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -2207,6 +2207,13 @@ int darshan_log_get_record(darshan_fd fd,
     return r;
 }
 
+/*
+ * darshan_free
+ *
+ * We expose free() in this manner so that i.e.,
+ * CFFI can free memory that has been malloc'd
+ * inside the scope of C functions.
+ */
 void darshan_free(void *ptr)
 {
     free(ptr);

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -219,6 +219,7 @@ void darshan_log_get_filtered_name_records(darshan_fd fd,
     struct darshan_name_record_info **mods, int* count,
     darshan_record_id *whitelist, int whitelist_count);
 int darshan_log_get_record(darshan_fd fd, int mod_idx, void **buf);
+void darshan_free(void *ptr);
 
 
 /* convenience macros for printing Darshan counters */

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -157,6 +157,7 @@ int darshan_log_get_mounts(void*, struct darshan_mnt_info **, int*);
 void darshan_log_get_modules(void*, struct darshan_mod_info **, int*);
 int darshan_log_get_record(void*, int, void **);
 char* darshan_log_get_lib_version(void);
+void darshan_free(void *);
 
 int darshan_log_get_namehash(void*, struct darshan_name_record_ref **hash);
 

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -211,6 +211,7 @@ def log_get_modules(log):
 
     # add to cache
     log['modules'] = modules
+    libdutil.darshan_free(mods[0])
 
     return modules
 


### PR DESCRIPTION
* this achieves identical memory leak improvements as gh-813 without touching any of our existing util C API functions (300 MB -> 150 MB footprint for the same benchmark test as there)