### PR TITLE
BUG: fix mount memleak (CFFI only)

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -178,6 +178,7 @@ def log_get_mounts(log):
     for i in range(0, cnt[0]):
         mntlst.append((ffi.string(mnts[0][i].mnt_path).decode("utf-8"),
             ffi.string(mnts[0][i].mnt_type).decode("utf-8")))
+    libdutil.darshan_free(mnts[0])
 
     return mntlst
 


### PR DESCRIPTION
* this achieves the same 3.5 GB memory reduction as gh-815 without touching
our current C API functions

* this should be reviewed after gh-816, at which point this will simplify to
a 1-line patch in the CFFI backend module