### PR TITLE
BUG: memleak part 3 (CFFI only)

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -638,10 +638,11 @@ def _log_get_heatmap_record(log):
     # write/read bins
     sizeof_64 = ffi.sizeof("int64_t")
     
-    write_bins = np.frombuffer(ffi.buffer(filerec[0].write_bins, sizeof_64*nbins), dtype = np.int64)
+    write_bins = np.copy(np.frombuffer(ffi.buffer(filerec[0].write_bins, sizeof_64*nbins), dtype = np.int64))
     rec['write_bins'] = write_bins
 
-    read_bins = np.frombuffer(ffi.buffer(filerec[0].read_bins, sizeof_64*nbins), dtype = np.int64)
+    read_bins = np.copy(np.frombuffer(ffi.buffer(filerec[0].read_bins, sizeof_64*nbins), dtype = np.int64))
     rec['read_bins'] = read_bins
+    libdutil.darshan_free(buf[0])
     
     return rec

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -341,7 +341,6 @@ def log_get_generic_record(log, mod_name, dtype='numpy'):
     buf = ffi.new("void **")
     r = libdutil.darshan_log_get_record(log['handle'], modules[mod_name]['idx'], buf)
     if r < 1:
-        libdutil.darshan_free(buf[0])
         return None
     rbuf = ffi.cast(mod_type, buf)
 
@@ -463,7 +462,6 @@ def _log_get_lustre_record(log, dtype='numpy'):
     buf = ffi.new("void **")
     r = libdutil.darshan_log_get_record(log['handle'], modules['LUSTRE']['idx'], buf)
     if r < 1:
-        libdutil.darshan_free(buf[0])
         return None
     rbuf = ffi.cast("struct darshan_lustre_record **", buf)
 
@@ -550,7 +548,6 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
     buf = ffi.new("void **")
     r = libdutil.darshan_log_get_record(log['handle'], modules[mod_name]['idx'], buf)
     if r < 1:
-        libdutil.darshan_free(buf[0])
         return None
     filerec = ffi.cast(mod_type, buf)
 


### PR DESCRIPTION
 * this should be reviewed after gh-816, and fixes
    the residual memory leak there so that we get
    a flat memory profile with repeated calls
    to `log_get_generic_record()`; after rebasing, this PR
   should simplify to a few CFFI backend changes to free
   `buf[0]` in a few places and make explicit copies for NumPy
    where it is pointing to the dropped memory buffer
    
 * note that `RUNTIME` heatmap doesn't seem to like
    the extra `free()`, it causes some testing issues,
    so I've excluded that here--hopefully that module
    just doesn't have the same problem..


Gradual mem spike -> flat profile:

![image](https://user-images.githubusercontent.com/7903078/191856812-1a3f7d94-8b41-456a-9344-c74ab10f75a1.png)

