### PR TITLE
MAINT: mpl join() deprecation

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -72,7 +72,7 @@ jobs:
           # to check HPC spack installs for example
           cd $RUNNER_TEMP
           site_packages=$(pip show darshan | grep Location | cut -d ' ' -f 2)
-          pytest -W error::FutureWarning --pyargs darshan --cov-report xml --cov=$site_packages/darshan
+          pytest -W error::FutureWarning -W error:"The join function was deprecated in Matplotlib" --pyargs darshan --cov-report xml --cov=$site_packages/darshan
       # Python 3.6 doesn't have access to some
       # dependencies needed for our type hints
       - if: ${{matrix.python-version > 3.6}}

--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -530,10 +530,10 @@ def plot_data(fig: Any,
                                               2,
                                               row * 2 + 2)
         if row > 0:
-            ax_filesystem_bytes.get_shared_x_axes().join(ax_filesystem_bytes, list_byte_axes[row - 1])
+            ax_filesystem_bytes.sharex(list_byte_axes[row - 1])
             if use_log[0]:
                 ax_filesystem_bytes.set_xscale('symlog')
-            ax_filesystem_counts.get_shared_x_axes().join(ax_filesystem_counts, list_count_axes[row - 1])
+            ax_filesystem_counts.sharex(list_count_axes[row - 1])
             if use_log[1]:
                 ax_filesystem_counts.set_xscale('symlog')
 


### PR DESCRIPTION
* when using latest stable `matplotlib` our testsuite produces hundreds of warnings like this (example log from gh-819 :https://github.com/darshan-hpc/darshan/actions/runs/3137604371/jobs/5095963509) :

```
tests/test_data_access_by_filesystem.py: 54 warnings
tests/test_summary.py: 99 warnings
  /home/tyler/python_310_darshan_venv/lib/python3.10/site-packages/darshan/experimental/plots/data_access_by_filesystem.py:536:
MatplotlibDeprecationWarning: The join function was deprecated in
Matplotlib 3.6 and will be removed two minor releases later.
    ax_filesystem_counts.get_shared_x_axes().join(ax_filesystem_counts,
list_count_axes[row - 1])
```

* this originates from this upstream PR: https://github.com/matplotlib/matplotlib/pull/21584

* turn this warning into an error in our CI, to prevent further introductions of the deprecated functionality, and fix it up where we already use it, based on the directions in the PR above