### PR TITLE
TST: Python 3.11

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - darshan-util/**
       - include/**
+      - .github/workflows/**
 
 jobs:
   test_pydarshan:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #795 as well

* Python `3.11.0rc2` is not only API stable with the final release coming in a few weeks, but is also guaranteed ABI stable: https://www.python.org/downloads/release/python-3110rc2/

* let's start testing it in our CI--many upstream projects are already providing pre-built `3.11` binaries on PyPI (`pandas`, `numpy`, `matplotlib`..)

* the run time for this new job using `act` locally seems to be about 10 minutes, which is reasonably in line with the other Python version jobs I'd say