### PR TITLE
BUG: memleak part 4

### DIFF
--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -2143,7 +2143,10 @@ void darshan_log_get_name_records(darshan_fd fd,
     HASH_ITER(hlink, name_hash, curr, tmp)
     {
         (*name_records)[i].id = curr->name_record->id;
-        (*name_records)[i].name = curr->name_record->name;
+        (*name_records)[i].name = strdup(curr->name_record->name);
+        HASH_DELETE(hlink, name_hash, curr);
+        free(curr->name_record);
+        free(curr);
         i++;
     }
  
@@ -2183,7 +2186,10 @@ void darshan_log_get_filtered_name_records(darshan_fd fd,
     HASH_ITER(hlink, name_hash, curr, tmp)
     {
         (*name_records)[i].id = curr->name_record->id;
-        (*name_records)[i].name = curr->name_record->name;
+        (*name_records)[i].name = strdup(curr->name_record->name);
+        HASH_DELETE(hlink, name_hash, curr);
+        free(curr->name_record);
+        free(curr);
         i++;
     }
  

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -2143,6 +2143,16 @@ void darshan_log_get_name_records(darshan_fd fd,
     HASH_ITER(hlink, name_hash, curr, tmp)
     {
         (*name_records)[i].id = curr->name_record->id;
+        /* NOTE: darshan_log_get_namehash() call above returns a
+         * hash table that has allocated name record memory for records
+         * in the log file. This hash table is not exposed to callers,
+         * though, so it's this function's responsibility to destroy the
+         * table and free corresponding memory before returning, as is
+         * done below. This also requires that we strdup() record names
+         * that are returned to callers, who are then responsible for
+         * freeing this memory, just as they are responsible for freeing
+         * the name_records array allocated above.
+         */
         (*name_records)[i].name = strdup(curr->name_record->name);
         HASH_DELETE(hlink, name_hash, curr);
         free(curr->name_record);
@@ -2186,6 +2196,16 @@ void darshan_log_get_filtered_name_records(darshan_fd fd,
     HASH_ITER(hlink, name_hash, curr, tmp)
     {
         (*name_records)[i].id = curr->name_record->id;
+        /* NOTE: darshan_log_get_filtered_namehash() call above returns a
+         * hash table that has allocated name record memory for records
+         * in the log file. This hash table is not exposed to callers,
+         * though, so it's this function's responsibility to destroy the
+         * table and free corresponding memory before returning, as is
+         * done below. This also requires that we strdup() record names
+         * that are returned to callers, who are then responsible for
+         * freeing this memory, just as they are responsible for freeing
+         * the name_records array allocated above.
+         */
         (*name_records)[i].name = strdup(curr->name_record->name);
         HASH_DELETE(hlink, name_hash, curr);
         free(curr->name_record);

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -242,7 +242,8 @@ def log_get_name_records(log):
 
     for i in range(0, cnt[0]):
         name_records[nrecs[0][i].id] = ffi.string(nrecs[0][i].name).decode("utf-8")
-
+        libdutil.darshan_free(nrecs[0][i].name)
+    libdutil.darshan_free(nrecs[0])
 
     # add to cache
     log['name_records'] = name_records
@@ -277,6 +278,8 @@ def log_lookup_name_records(log, ids=[]):
 
     for i in range(0, cnt[0]):
         name_records[nrecs[0][i].id] = ffi.string(nrecs[0][i].name).decode("utf-8")
+        libdutil.darshan_free(nrecs[0][i].name)
+    libdutil.darshan_free(nrecs[0])
 
     # add to cache
     log['name_records'] = name_records


### PR DESCRIPTION
* `dup()` returned record name and destroy the name record hash table and all associated memory in functions `darshan_log_get_name_records()` and `darshan_log_get_filtered_name_records()`
* free allocated array of record_id,record_name tuples passed back from above functions in CFFI backend
* free individual record names passed back frome above functions in CFFI backend

Fixes #824 