### PR TITLE
BUG: Fix handling of forked processes in darshan-runtime

### DIFF
--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -1987,6 +1987,7 @@ static void hdf5_file_cleanup()
 
     free(hdf5_file_runtime);
     hdf5_file_runtime = NULL;
+    h5f_runtime_init_attempted = 0;
 
     HDF5_UNLOCK();
     return;
@@ -2005,6 +2006,7 @@ static void hdf5_dataset_cleanup()
 
     free(hdf5_dataset_runtime);
     hdf5_dataset_runtime = NULL;
+    h5d_runtime_init_attempted = 0;
 
     HDF5_UNLOCK();
     return;

--- a/darshan-runtime/lib/darshan-lustre.c
+++ b/darshan-runtime/lib/darshan-lustre.c
@@ -350,6 +350,7 @@ static void lustre_cleanup()
     darshan_clear_record_refs(&(lustre_runtime->record_id_hash), 1);
     free(lustre_runtime);
     lustre_runtime = NULL;
+    lustre_runtime_init_attempted = 0;
 
     LUSTRE_UNLOCK();
     return;

--- a/darshan-runtime/lib/darshan-mdhim.c
+++ b/darshan-runtime/lib/darshan-mdhim.c
@@ -604,6 +604,7 @@ static void mdhim_cleanup()
 
     free(mdhim_runtime);
     mdhim_runtime = NULL;
+    mdhim_runtime_init_attempted = 0;
 
     MDHIM_UNLOCK();
     return;

--- a/darshan-runtime/lib/darshan-mpiio.c
+++ b/darshan-runtime/lib/darshan-mpiio.c
@@ -1786,6 +1786,7 @@ static void mpiio_cleanup()
 
     free(mpiio_runtime);
     mpiio_runtime = NULL;
+    mpiio_runtime_init_attempted = 0;
 
     MPIIO_UNLOCK();
     return;

--- a/darshan-runtime/lib/darshan-pnetcdf.c
+++ b/darshan-runtime/lib/darshan-pnetcdf.c
@@ -482,6 +482,7 @@ static void pnetcdf_cleanup()
 
     free(pnetcdf_runtime);
     pnetcdf_runtime = NULL;
+    pnetcdf_runtime_init_attempted = 0;
 
     PNETCDF_UNLOCK();
     return;

--- a/darshan-runtime/lib/darshan-posix.c
+++ b/darshan-runtime/lib/darshan-posix.c
@@ -2620,6 +2620,7 @@ static void posix_cleanup()
 
     free(posix_runtime);
     posix_runtime = NULL;
+    posix_runtime_init_attempted = 0;
 
     POSIX_UNLOCK();
     return;

--- a/darshan-runtime/lib/darshan-stdio.c
+++ b/darshan-runtime/lib/darshan-stdio.c
@@ -1508,6 +1508,7 @@ static void stdio_cleanup()
 
     free(stdio_runtime);
     stdio_runtime = NULL;
+    stdio_runtime_init_attempted = 0;
 
     STDIO_UNLOCK();
     return;

--- a/darshan-test/python_mpi_scripts/runtime_prog_issue_786.py
+++ b/darshan-test/python_mpi_scripts/runtime_prog_issue_786.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import os
+
+def parent_child_io():
+    # parent creates a file record before fork
+    f = open("./pre-fork-parent", "w")
+    f.close()
+
+    pid = os.fork()
+    if pid > 0:
+        # parent process creates a file record after the fork
+        f = open("./post-fork-parent", "w")
+        f.close()
+    else:
+        # child process creates a file record after the fork
+        f = open("./post-fork-child", "w")
+        f.close()
+
+if __name__ == "__main__":
+    parent_child_io()

--- a/darshan-test/python_runtime_tests.py
+++ b/darshan-test/python_runtime_tests.py
@@ -197,6 +197,8 @@ def test_forked_process(tmpdir):
                      "-x",
                      f"LD_PRELOAD={darshan_lib_path}",
                      "-x",
+                     "DARSHAN_ENABLE_NONMPI=1",
+                     "-x",
                      f"DARSHAN_LOGPATH={cwd}",
                      "python",
                      f"{test_script_path}"])

--- a/darshan-test/python_runtime_tests.py
+++ b/darshan-test/python_runtime_tests.py
@@ -64,7 +64,6 @@ def test_runtime_heatmap_div_by_zero(tmpdir):
                                     "darshan-test",
                                     "c_mpi_progs",
                                     "runtime_prog_issue_730.c")
-    hdf5_lib_path = os.environ.get("HDF5_LIB")
 
     with tmpdir.as_cwd():
         cwd = os.getcwd()
@@ -175,3 +174,34 @@ def test_env_vars_config(tmpdir):
         report = darshan.DarshanReport(path_to_log)
         # NOTE: could eventually do some more sanity
         # checks on the report data here
+
+def test_forked_process(tmpdir):
+    # regression test for gh-786
+    n_ranks = 1
+    root_path = os.environ.get("DARSHAN_ROOT_PATH")
+    darshan_install_path = os.environ.get("DARSHAN_INSTALL_PATH")
+    test_script_path = os.path.join(root_path,
+                                    "darshan-test",
+                                    "python_mpi_scripts",
+                                    "runtime_prog_issue_786.py")
+    darshan_lib_path = os.path.join(darshan_install_path,
+                                    "lib",
+                                    "libdarshan.so")
+
+    with tmpdir.as_cwd():
+        cwd = os.getcwd()
+        subprocess.check_output(["mpirun",
+                     "--allow-run-as-root",
+                     "-n",
+                     f"{n_ranks}",
+                     "-x",
+                     f"LD_PRELOAD={darshan_lib_path}",
+                     "-x",
+                     f"DARSHAN_LOGPATH={cwd}",
+                     "python",
+                     f"{test_script_path}"])
+
+        log_file_list = glob.glob("*.darshan")
+        # only a single log file should be generated
+        # by darshan
+        assert len(log_file_list) == 1


### PR DESCRIPTION
Darshan's ability to instrument forked processes was broken by some optimizations to the module registration code path that were  applied as part of #703.

This PR includes fixes to each module that resets the module's `runtime_init_attempted` flag at module `cleanup()` time. If this flag isn't reset, then modules can not be re-initialized after they have shut down -- Darshan's fork handling relies on this ability to cleanup and re-initialize modules and was leading to fork children not being able to register records in the Darshan log.

Additionally, this PR includes a regression test to detect whether this functionality is broken again going forward.

[WIP tag while I fine tune the regression test]