### PR TITLE
BUG: LUSTRE fcounters guard

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -354,7 +354,8 @@ def log_get_generic_record(log, mod_name, dtype='numpy'):
         rec['file_rec_id'] = rbuf[0].file_rec_id
 
     clst = np.copy(np.frombuffer(ffi.buffer(rbuf[0].counters), dtype=np.int64))
-    flst = np.copy(np.frombuffer(ffi.buffer(rbuf[0].fcounters), dtype=np.float64))
+    if mod_name != "LUSTRE":
+        flst = np.copy(np.frombuffer(ffi.buffer(rbuf[0].fcounters), dtype=np.float64))
     libdutil.darshan_free(buf[0])
 
     c_cols = counter_names(mod_name)
@@ -362,7 +363,8 @@ def log_get_generic_record(log, mod_name, dtype='numpy'):
 
     if dtype == "numpy":
         rec['counters'] = clst
-        rec['fcounters'] = flst
+        if mod_name != "LUSTRE":
+            rec['fcounters'] = flst
 
     elif dtype == "dict":
         rec['counters'] = dict(zip(c_cols, clst))

--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -497,3 +497,16 @@ def test_heatmap_df_invalid_operation():
     report = darshan.DarshanReport(log_path)
     with pytest.raises(ValueError, match="invalid_op not in heatmap"):
         report.heatmaps["POSIX"].to_df(ops=["invalid_op"])
+
+
+@pytest.mark.parametrize("mod_name", [
+        "LUSTRE",
+        "POSIX",
+        "STDIO",
+        ])
+def test_mod_records(mod_name):
+    # regression test for gh-831
+    log_path = get_log_path("imbalanced-io.darshan")
+    report = darshan.DarshanReport(log_path)
+    gen = report.mod_records(mod_name)
+    next(gen)


### PR DESCRIPTION
Fixes #831

* prevent `log_get_generic_record()` from attempting to access the `LUSTRE` `fcounters` field, which
apparently does not exist