### PR TITLE
WIP: workaround for hdf undefined symbol error

### DIFF
--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -29,6 +29,14 @@
 
 #include <hdf5.h>
 
+/* NOTE: this is a dummy definition of H5FD_mpio_init() with a weak alias.
+ * It prevents "libdarshan.so: undefined symbol: H5FD_mpio_init" errors if
+ * Darshan is enabled via LD_PRELOAD for non-HDF executables.  This problem
+ * may occur if Darshan itself was compiled against HDF5 1.13.2.
+ */
+hid_t dummy_H5FD_mpio_init(void) { return(0); }
+hid_t H5FD_mpio_init (void) __attribute__ ((weak, alias("dummy_H5FD_mpio_init")));
+
 /* H5F prototypes */
 DARSHAN_FORWARD_DECL(H5Fcreate, hid_t, (const char *filename, unsigned flags, hid_t create_plist, hid_t access_plist));
 DARSHAN_FORWARD_DECL(H5Fopen, hid_t, (const char *filename, unsigned flags, hid_t access_plist));


### PR DESCRIPTION
For discussion.  There may be a cleaner solution, but this works around a potential undefined symbol error on preloaded executables when Darshan is compiled against HDF5 1.13.2.