### PR TITLE
CI: remove shared flag

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -46,7 +46,7 @@ jobs:
           cd darshan-util
           mkdir build
           cd build
-          ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-apxc-mod --enable-apmpi-mod
+          ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-apxc-mod --enable-apmpi-mod
           make
           make install
       - name: Install pydarshan

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -49,7 +49,7 @@ jobs:
           cd darshan-util
           mkdir build
           cd build
-          ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-shared --enable-apxc-mod --enable-apmpi-mod
+          ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-apxc-mod --enable-apmpi-mod
           make
           make install
       - name: Install pydarshan


### PR DESCRIPTION
* based on discussion with Shane, apparently we no longer need to use `--enable-shared` because shared libs are built by default in the "new" build system

* I believe Shane will clean up some docs related to this, like here:
https://www.mcs.anl.gov/research/projects/darshan/docs/darshan-util.html