### PR TITLE
MAINT, TST: lxml optional skip

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -65,6 +65,12 @@ jobs:
         name: Install darshan_logs package
         run: |
           python -m pip install git+https://github.com/darshan-hpc/darshan-logs.git@main
+      - if: ${{matrix.python-version == 3.8}}
+        name: Use minimal deps
+        run: |
+          # uninstall deps that are not absolute requirements
+          # to make sure that i.e., tests skip appropriately
+          python -m pip uninstall -y lxml
       - name: Test with pytest
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -14,6 +14,12 @@ from darshan.cli import summary
 from darshan.log_utils import get_log_path, _provide_logs_repo_filepaths
 from darshan.experimental.plots.data_access_by_filesystem import plot_with_report
 
+try:
+    import lxml
+    has_lxml = True
+except ImportError:
+    has_lxml = False
+
 
 @pytest.mark.parametrize(
     "argv", [
@@ -337,6 +343,9 @@ class TestReportData:
     def test_metadata_table(self, log_path, expected_df):
         # regression test for `summary.ReportData.get_metadata_table()`
 
+        if not has_lxml:
+            pytest.skip("Test requires lxml")
+
         log_path = get_log_path(log_path)
         # generate the report data
         R = summary.ReportData(log_path=log_path)
@@ -445,6 +454,9 @@ class TestReportData:
     )
     def test_module_table(self, log_path, expected_df, expected_partial_flags):
         # regression test for `summary.ReportData.get_module_table()`
+
+        if not has_lxml:
+            pytest.skip("Test requires lxml")
 
         log_path = get_log_path(log_path)
         # collect the report data

--- a/darshan-util/pydarshan/mypy.ini
+++ b/darshan-util/pydarshan/mypy.ini
@@ -37,6 +37,9 @@ ignore_missing_imports = True
 [mypy-mako.*]
 ignore_missing_imports = True
 
+[mypy-lxml]
+ignore_missing_imports = True
+
 # pydarshan modules that lack types
 # or currently have errors
 


### PR DESCRIPTION
* discussed a bit with Shane--this allows the test suite to pass with a few skipped tests if a user doesn't have `lxml` installed--I think the 10 extra skips aren't so bad that all value is lost with the pared down testing in this case

* if you run `python -m pytest --pyargs darshan -n 10 -rsx` without and with `lxml` present on this branch you'll get these results respectively:

- `463 passed, 10 skipped, 2 xfailed in 109.11s (0:01:49)`
- `473 passed, 2 xfailed in 109.02s (0:01:49)`

The verbose output will show a bit more detail:
```
SKIPPED [3] ../home/tyler/python_310_darshan_venv/lib/python3.10/site-packages/darshan/tests/test_summary.py:347: Test requires lxml
SKIPPED [7] ../home/tyler/python_310_darshan_venv/lib/python3.10/site-packages/darshan/tests/test_summary.py:459: Test requires lxml
XFAIL tests/test_report.py::test_jobid_type_all_logs_repo_files[/home/tyler/python_310_darshan_venv/lib/python3.10/site-packages/darshan_logs/e3sm_io_heatmaps_and_dxt/e3sm_io_heatmap_and_dxt.darshan]
  reason: large memory requirements
XFAIL tests/test_summary.py::test_main_all_logs_repo_files[/home/tyler/python_310_darshan_venv/lib/python3.10/site-packages/darshan_logs/e3sm_io_heatmaps_and_dxt/e3sm_io_heatmap_and_dxt.darshan]
  reason: large memory requirements
```

* one of the CI matrix entries (Python `3.8`) will now uninstall `lxml` prior to testing--making it a sort of "minimal deps" testing scenario since Python `3.8` testing currently also lacks the logs repo (on purpose)