### PR TITLE
CI: use 3.11 final release

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
* Python 3.11 final release/stable release is out now, so use it in CI