### PR TITLE
CI: test darshan-util

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -49,6 +49,7 @@ jobs:
           ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-apxc-mod --enable-apmpi-mod
           make
           make install
+          make check
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan


### PR DESCRIPTION
* turn on `make check` in CI to run the `darshan-util` unit tests Phil added in gh-677 -- they run very quickly so I don't see why we shouldn't just run them

* we could eventually turn on `gcov` to show which lines are being traced through in the C code, but that's a bit more work to fuse into the Python cov report, so delaying that for now...