### PR TITLE
CI: try to fix MacOS CI

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Test with pytest
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          export DYLD_FALLBACK_LIBRARY_PATH=$PWD/darshan_install/lib
           # the test suite should be portable
           # to any directory--it must be possible
           # to check HPC spack installs for example
@@ -87,6 +88,7 @@ jobs:
         name: mypy check
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          export DYLD_FALLBACK_LIBRARY_PATH=$PWD/darshan_install/lib
           cd darshan-util/pydarshan
           mypy darshan
       - name: pyflakes check
@@ -96,6 +98,7 @@ jobs:
       - name: asv check
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          export DYLD_FALLBACK_LIBRARY_PATH=$PWD/darshan_install/lib
           cd darshan-util/pydarshan/benchmarks
           python -m asv check -E existing
       - name: codecov check

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -52,7 +52,7 @@ class ReportFigure:
         self,
         section_title: str,
         fig_title: str,
-        fig_func: Callable,
+        fig_func: Union[Callable, None],
         fig_args: dict,
         fig_description: str = "",
         fig_width: int = 500,


### PR DESCRIPTION
* switch to `DYLD_FALLBACK_LIBRARY_PATH` for `pydarshan` shared library searching on MacOS in GitHub actions

* note that we're already doing this for the M1 Mac testing in Cirrus CI, and I need it locally as well on newer versions of MacOS

* we'll see if CI agrees with my assessment (I don't know all the technical details for justification..)