### PR TITLE
CI: run `make distcheck` for runtime CI workflow

### DIFF
--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -37,21 +37,21 @@ jobs:
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install
           git submodule update --init
           ./prepare.sh
-          cd darshan-runtime
-          mkdir build
-          cd build
-          CC=mpicc ../configure --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE --enable-hdf5-mod
+          mkdir build-runtime
+          cd build-runtime
+          CC=mpicc ../configure --disable-darshan-util --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE --enable-hdf5-mod
           make
           make install
+          make distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-darshan-util --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE --enable-hdf5-mod"
       - name: Install darshan-util
         run: |
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install
-          cd darshan-util
-          mkdir build
-          cd build
-          ../configure --prefix=$DARSHAN_INSTALL_PATH --enable-apxc-mod --enable-apmpi-mod
+          mkdir build-util
+          cd build-util
+          ../configure --disable-darshan-runtime --prefix=$DARSHAN_INSTALL_PATH --enable-apxc-mod --enable-apmpi-mod
           make
           make install
+          make distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-darshan-runtime --enable-apxc-mod --enable-apmpi-mod"
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan


### PR DESCRIPTION
Building off suggestion from @wkliao in #844 

These changes allow us to build runtime and util portions of Darshan with different options (i.e., util with AutoPerf, runtime without AutoPerf) and test each independently with `make distcheck`. It seems to work fine for me locally, but will see what the CI says.