### PR TITLE
CI: bump cibuildwheel to newest release

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,7 +13,7 @@ on:
       - main
     paths:
       - darshan-util/**
-      - include/*
+      - include/**
       - .github/workflows/build_wheels.yml
   workflow_dispatch:
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - darshan-util/**
       - include/**
+      - .github/workflows/build_wheels.yml
   pull_request:
     branches:
       - main
     paths:
       - darshan-util/**
       - include/*
+      - .github/workflows/build_wheels.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.11.2
         with:
           package-dir: ./darshan-util/pydarshan
 


### PR DESCRIPTION
bump to v2.11.2

note there's also a typo fix in current path inclusions (forgotten `*`), as well as addition of a new inclusion for updates to the build wheels workflow file