### PR TITLE
CI: add non-MPI test case

### DIFF
--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/darshan_install/lib
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install
+          export DARSHAN_NONMPI_INSTALL_PATH=$PWD/darshan_nonmpi_install
           export DARSHAN_ROOT_PATH=$PWD
           export HDF5_LIB=/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so
           python -m pytest darshan-test/python_runtime_tests.py

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -50,7 +50,8 @@ jobs:
           cd darshan-runtime
           mkdir build_nonmpi
           cd build_nonmpi
-          CC=gcc ../configure --without-mpi --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE
+          # Note that darshan-util is not needed here, we can use the one built below
+          CC=gcc ../configure --disable-darshan-util --without-mpi --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE
           make
           make install
       - name: Install darshan-util

--- a/.github/workflows/runtime_ci.yml
+++ b/.github/workflows/runtime_ci.yml
@@ -43,6 +43,16 @@ jobs:
           CC=mpicc ../configure --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE --enable-hdf5-mod
           make
           make install
+      - name: Install darshan-runtime (non-MPI)
+        run: |
+          mkdir darshan_nonmpi_install
+          export DARSHAN_INSTALL_PATH=$PWD/darshan_nonmpi_install
+          cd darshan-runtime
+          mkdir build_nonmpi
+          cd build_nonmpi
+          CC=gcc ../configure --without-mpi --prefix=$DARSHAN_INSTALL_PATH --with-log-path-by-env=DARSHAN_LOGPATH --with-jobid-env=NONE
+          make
+          make install
       - name: Install darshan-util
         run: |
           export DARSHAN_INSTALL_PATH=$PWD/darshan_install

--- a/darshan-test/python_runtime_tests.py
+++ b/darshan-test/python_runtime_tests.py
@@ -175,10 +175,8 @@ def test_env_vars_config(tmpdir):
         # NOTE: could eventually do some more sanity
         # checks on the report data here
 
-def test_forked_process(tmpdir):
-    # regression test for gh-786
+def do_forked_process_test(tmpdir, darshan_install_path):
     root_path = os.environ.get("DARSHAN_ROOT_PATH")
-    darshan_install_path = os.environ.get("DARSHAN_INSTALL_PATH")
     test_script_path = os.path.join(root_path,
                                     "darshan-test",
                                     "python_mpi_scripts",
@@ -221,3 +219,13 @@ def test_forked_process(tmpdir):
             if "post-fork-child" in v:
                 post_fork_child_found=True
         assert post_fork_child_found
+
+def test_forked_process_nonmpi(tmpdir):
+    # regression test for gh-786, non-mpi version
+    darshan_install_path = os.environ.get("DARSHAN_NONMPI_INSTALL_PATH")
+    do_forked_process_test(tmpdir, darshan_install_path)
+
+def test_forked_process_mpi(tmpdir):
+    # regression test for gh-786, mpi version
+    darshan_install_path = os.environ.get("DARSHAN_INSTALL_PATH")
+    do_forked_process_test(tmpdir, darshan_install_path)


### PR DESCRIPTION
* builds a non-MPI version of darshan-runtime
* adds MPI and non-MPI versions of existing runtime CI tests for forked processes