### PR TITLE
DOC: fixup pydarshan docs

### DIFF
--- a/darshan-util/pydarshan/README.rst
+++ b/darshan-util/pydarshan/README.rst
@@ -17,7 +17,7 @@ Features
 Usage
 -----
 
-For examples and Jupyter notebooks to get started with pydarshan make sure
+For examples and Jupyter notebooks to get started with PyDarshan make sure
 to check out the `examples` subdirectory.
 
 A brief examples showing some of the basic functionality is the following::
@@ -25,19 +25,19 @@ A brief examples showing some of the basic functionality is the following::
     import darshan
 
     # Open darshan log
-    report = darshan.DarshanReport('example.darshan', read_all=False)
+    with darshan.DarshanReport('example.darshan', read_all=False) as report:
 
-    # Load some report data
-    report.mod_read_all_records('POSIX')
-    report.mod_read_all_records('MPI-IO')
-    # or fetch all
-    report.read_all_generic_records()
+        # Load some report data
+        report.mod_read_all_records('POSIX')
+        report.mod_read_all_records('MPI-IO')
+        # or fetch all
+        report.read_all_generic_records()
 
-    # ...    
-    # Generate summaries for currently loaded data
-    # Note: aggregations are still experimental and have to be activated:
-    darshan.enable_experimental()
-    report.summarize()
+        # ...
+        # Generate summaries for currently loaded data
+        # Note: aggregations are still experimental and have to be activated:
+        darshan.enable_experimental()
+        report.summarize()
 
 
 
@@ -93,15 +93,15 @@ File List
 * docs::
     markdown documentation used by sphinx to auto-generate HTML RTD style doc
 * examples::
-    Jupyter notebooks showing pydarshan usage with log files
+    Jupyter notebooks showing PyDarshan usage with log files
 * tests::
-    pydarshan specific test cases
+    PyDarshan specific test cases
 * requirements.txt::
     pip requirement file for minimum set of depednencies
 * requirements_dev.txt::
     pip requirement file for depednencies needed to run development tools
 * setup.py::
-    python file for building/generating pydarshan package
+    python file for building/generating PyDarshan package
 * setup.cfg::
     input for setup.py
 * MANIFEST.in::

--- a/darshan-util/pydarshan/docs/install.rst
+++ b/darshan-util/pydarshan/docs/install.rst
@@ -8,13 +8,13 @@ Installation
 Stable release
 --------------
 
-To install pydarshan, run this command in your terminal:
+To install PyDarshan, run this command in your terminal:
 
 .. code-block:: console
 
-    $ pip install pydarshan
+    $ pip install darshan
 
-This is the preferred method to install pydarshan, as it will always install the most recent stable release.
+This is the preferred method to install PyDarshan, as it will always install the most recent stable release.
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
 
@@ -22,7 +22,7 @@ you through the process.
 .. _Python installation guide: https://www.mcs.anl.gov/research/projects/darshan/
 
 
-Pydarshan assumes that a recent 'darshan-utils' is installed as a shared 
+PyDarshan assumes that a recent 'darshan-utils' is installed as a shared
 library. If darshan-util is not installed consult with the darshan
 documentation or consider using `Spack`_ to install::
 
@@ -35,7 +35,7 @@ documentation or consider using `Spack`_ to install::
 From sources
 ------------
 
-The sources for pydarshan can be downloaded from the `Github repo`_.
+The sources for PyDarshan can be downloaded from the `Github repo`_.
 
 You can either clone the public repository:
 

--- a/darshan-util/pydarshan/docs/usage.rst
+++ b/darshan-util/pydarshan/docs/usage.rst
@@ -10,19 +10,19 @@ To get started with PyDarshan you can simply use::
 
     import darshan
 
-    report = darshan.DarshanReport(filename)
+    with darshan.DarshanReport(filename) as report:
 
-    # read metadata, log records and name records
-    report.read_all_generic_records()
-
-
-    # Python aggregations are still experimental and have to be activated:
-    # calculate or update aggregate statistics for currently loaded records
-    darshan.enable_experimental()
-    report.summarize()
+        # read metadata, log records and name records
+        report.read_all_generic_records()
 
 
-    print(report.report)
+        # Python aggregations are still experimental and have to be activated:
+        # calculate or update aggregate statistics for currently loaded records
+        darshan.enable_experimental()
+        report.summarize()
+
+
+        print(report.report)
 
 
 


### PR DESCRIPTION
* cleanup some usage of "pydarshan" (for either "darshan" or "PyDarshan")
* cleanup docs usage of Darshan report objects to use context managers