### PR TITLE
CI: drop 3.6 & ubuntu switch

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -21,14 +21,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-        # see gh-851
-        exclude:
-          - platform: ubuntu-latest
-            python-version: "3.10"
-        include:
-          - platform: ubuntu-22.04
-            python-version: "3.10"
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
@@ -89,10 +82,7 @@ jobs:
           cd $RUNNER_TEMP
           site_packages=$(pip show darshan | grep Location | cut -d ' ' -f 2)
           pytest -W error::FutureWarning -W error:"The join function was deprecated in Matplotlib" --pyargs darshan --cov-report xml --cov=$site_packages/darshan
-      # Python 3.6 doesn't have access to some
-      # dependencies needed for our type hints
-      - if: ${{matrix.python-version > 3.6}}
-        name: mypy check
+      - name: mypy check
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib
           export DYLD_FALLBACK_LIBRARY_PATH=$PWD/darshan_install/lib


### PR DESCRIPTION
* the Github Actions infrastructure is progressively phasing in a newer base image of Ubuntu:
https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

* that means that we are somewhat randomly going to see images that lack Python `3.6` from the build cache sometimes per:
https://github.com/actions/setup-python/issues/355#issuecomment-1335042510

* instead of pinning to an old version of Ubuntu in GHA for 3.6 support, let's just drop 3.6 from the testing matrix per:
https://github.com/darshan-hpc/darshan/issues/510#issuecomment-1340023264 (it has been EOL for 1 year)

* there's also no reason to retain the special Python `3.10` handling where we use Ubuntu `22.04` for that case, for two reasons: 

1) `22.04` is being rolled out as the new default anyway 
2) gh-851 with the Python garbage collection issues in `3.10` was resolved by using contexts, so special treatment not justified anymore