### PR TITLE
bug fix: PnetCDF vard APIs when filetype is MPI_DATATYPE_NULL

### DIFF
--- a/darshan-runtime/lib/darshan-pnetcdf-api.m4
+++ b/darshan-runtime/lib/darshan-pnetcdf-api.m4
@@ -136,8 +136,12 @@ define(`CALC_VARN_ACCESS_INFO',
 dnl
 define(`CALC_VARD_ACCESS_INFO',
     `int mpi_size;
-            PMPI_Type_size(filetype, &mpi_size);
-            $3 = mpi_size;')dnl
+            if (filetype == MPI_DATATYPE_NULL)
+                $3 = 0;
+            else {
+                MPI_Type_size(filetype, &mpi_size);
+                $3 = mpi_size;
+            }')dnl
 dnl
 define(`CALC_ACCESS_INFO',
     `ifelse(


### PR DESCRIPTION
When argument filetype is MPI_DATATYPE_NULL in vard APIs, it indicates this request is of zero length. Thus we can skip updating the counters.

Failed test program:
https://github.com/Parallel-NetCDF/PnetCDF/blob/master/test/testcases/test_vard_multiple.c