### PR TITLE
fix index when ndims is large

### DIFF
--- a/darshan-runtime/lib/darshan-pnetcdf-api.m4
+++ b/darshan-runtime/lib/darshan-pnetcdf-api.m4
@@ -87,7 +87,7 @@ define(`CALC_VARA_ACCESS_INFO',
                 if (ndims > PNETCDF_VAR_MAX_NDIMS)
                     start_ndx = ndims - PNETCDF_VAR_MAX_NDIMS;
                 for (i = start_ndx; i < ndims; i++) {
-                    common_access_vals[1+i] = count[i];
+                    common_access_vals[1+i-start_ndx] = count[i];
                 }
             }
             else {
@@ -98,18 +98,19 @@ dnl
 define(`CALC_VARS_ACCESS_INFO',
     `int ndims = rec_ref->var_rec->counters[PNETCDF_VAR_NDIMS];
             if (ndims > 0) {
-                int i, start_ndx = 0;
+                int i, j, start_ndx = 0;
                 $3 = count[0];
                 for (i = 1; i < ndims; i++)
                     $3 *= count[i];
                 if (ndims > PNETCDF_VAR_MAX_NDIMS)
                     start_ndx = ndims - PNETCDF_VAR_MAX_NDIMS;
                 for (i = start_ndx; i < ndims; i++) {
-                    common_access_vals[1+i] = count[i];
+                    j = i - start_ndx;
+                    common_access_vals[1+j] = count[i];
                     if (stride)
-                        common_access_vals[1+i+PNETCDF_VAR_MAX_NDIMS] = stride[i];
+                        common_access_vals[1+j+PNETCDF_VAR_MAX_NDIMS] = stride[i];
                     else
-                        common_access_vals[1+i+PNETCDF_VAR_MAX_NDIMS] = 1;
+                        common_access_vals[1+j+PNETCDF_VAR_MAX_NDIMS] = 1;
                 }
             }
             else {


### PR DESCRIPTION
Resolve the Segmentation fault. Below are the gdb traces.
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f1a2aea2907 in ncmpi_put_vars_int_all (ncid=0, varid=0, start=0x19e08c0, count=0x198fbf0, stride=0x1991c00, 
    buf=0x7f1a25eec010) at ./darshan-pnetcdf-api.c:11151
11151	                    common_access_vals[1+i] = count[i];

#0  0x00007f2f784f393e in ncmpi_put_vars_int_all (ncid=0, varid=0, start=0x1c7b8c0, count=0x1c2abf0, stride=0x1c2cc00, 
    buf=0x7f2f7353d010) at ./darshan-pnetcdf-api.c:11153
11153	                        common_access_vals[1+i+PNETCDF_VAR_MAX_NDIMS] = stride[i];

#0  0x00007fa89f55307f in ncmpi_get_vars_int_all (ncid=0, varid=0, start=0xca38c0, count=0xc52bf0, stride=0xc54c00, 
    buf=0x7fa89a58b010) at ./darshan-pnetcdf-api.c:13080
13080	                    common_access_vals[1+i] = count[i];
```