### PR TITLE
MAINT: more Python 3.6 cleanups

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -5,10 +5,7 @@ import base64
 import argparse
 import datetime
 from collections import OrderedDict
-if sys.version_info >= (3, 7):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
+import importlib.resources as importlib_resources
 
 from typing import Any, Union, Callable
 

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_dxt_heatmap.py
@@ -3,6 +3,7 @@ Module for creating the ranks vs. time IO intensity
 heatmap figure for the Darshan job summary.
 """
 
+from __future__ import annotations
 import functools
 from typing import (Any, List, Sequence, Union,
                     TYPE_CHECKING, Tuple, Optional)
@@ -11,15 +12,6 @@ import numpy as np
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-
-# we can't use PEP563 delayed type
-# evaluations while we have to support
-# Python 3.6 because the __future__ import is not
-# available yet;
-# TODO: delete the mocking and restore the
-# from __future__ import annotations
-from unittest.mock import MagicMock
-npt = MagicMock()
 
 import pandas as pd
 import seaborn as sns

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -4,9 +4,13 @@ requires = [
     "setuptools",
 ]
 
+[project]
+requires-python = ">=3.7"
+
 [tool.cibuildwheel]
 environment = "PYDARSHAN_BUILD_EXT=1"
 skip = [
+    "cp36-*",
     "pp*",
     "*musllinux*",
     "*i686*",

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -5,15 +5,15 @@ from setuptools import setup, find_packages, Extension
 import sys
 import os
 
+if sys.version_info[:2] < (3, 7):
+    raise RuntimeError("Python version >= 3.7 required.")
+
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 
 requirements = ["cffi", "numpy", "pandas", "matplotlib", "seaborn", "mako"]
-
-if sys.version_info == (3, 6):
-    requirements.append("importlib_resources")
 
 setup_requirements = [
     "pytest-runner",
@@ -62,10 +62,11 @@ setup(
         "Intended Audience :: Science/Research",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     description="Python tools to interact with darshan log records of HPC applications.",
     long_description=readme,


### PR DESCRIPTION
Fixes #510

* in the absence of Python `3.6` support, we can safely use [PEP563](https://peps.python.org/pep-0563/) delayed type evaluations and use newer NumPy type hinting machinery; disable the old mocking shims related to this

* remove an `importlib_resources` requirement for Python `3.6`; note that for testing with Python < `3.9` you still want this third-party package I think, but clearly this conditional no longer serves any purpose since we don't support `3.6`

* remove Python `3.6` from the supported list in project metadata, and include `3.10` and `3.11`, both of which are regularly tested in our CI and have wheels available on PyPI

* adjust `cibuildwheel` settings to exclude Python `3.6` from wheel builds moving forward

* adjust `setup.py`/`pyproject.toml` to error out when attempting to build with Python < `3.7` (fail fast, early, and clearly..)

* we should no longer need `importlib_resources` in `summary.py` with 3.7+ guaranteed, so remove that import shim (we may also want to remove the import alias/remapping, but for now that should be harmless)