### PR TITLE
CI, MAINT: Cirrus bump/naming

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 macos_instance:
-  image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
-task:
+macos_M1_native_apple_silicon_py310_task:
   script: |
     brew install python@3.10
     brew install python-tk@3.10


### PR DESCRIPTION
* currently our Cirrus CI job is called nothing more than `main`--let's see if we can name it something more helpful/informative for reviewers

* while I'm at it, let's see if I can use the latest MacOS M1 image from their docs:
https://cirrus-ci.org/guide/macOS/

* also, let's double check I can temporarily disable GitHub actions CI with a commit message tag in this project when we clearly don't need it like here

[skip actions]