### PR TITLE
MAINT: I/O cost label spacing

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -173,6 +173,10 @@ def plot_io_cost(report: darshan.DarshanReport) -> Any:
     ax_raw.set_ylabel("Runtime (s)")
     handles, labels = ax_raw.get_legend_handles_labels()
     ax_norm.legend(handles[::-1], labels[::-1], loc="upper left", bbox_to_anchor=(1.22, 1.02))
+    # rotate the xticklabels so they don't overlap
+    for ax in [ax_raw, ax_norm]:
+        for label in ax.get_xticklabels():
+            label.set_rotation(90)
     # adjust the figure to reduce white space
     io_cost_fig.subplots_adjust(right=0.59)
     io_cost_fig.tight_layout()

--- a/darshan-util/pydarshan/darshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_io_cost.py
@@ -272,3 +272,40 @@ def test_combine_hdf5_modules(input_df, expected_df):
 
     # check actual and expected dataframes are identical
     assert_frame_equal(actual_df, expected_df)
+
+
+@pytest.mark.parametrize(
+    "logname, expected_xticks, expected_xlabels", [
+        (
+            "shane_ior-PNETCDF_id438100-438100_11-9-41525-10280033558448664385_1.darshan",
+            range(4),
+            ["POSIX", "MPIIO", "PNETCDF", "STDIO"]
+        ),
+        (
+            "imbalanced-io.darshan",
+            range(3),
+            ["POSIX", "MPIIO", "STDIO"]
+        ),
+    ],
+)
+def test_plot_io_cost_x_ticks_and_labels(logname,
+                                         expected_xticks,
+                                         expected_xlabels):
+    # check the x-axis tick marks are at the appropriate
+    # locations and the labels are as expected
+
+    logpath = get_log_path(logname)
+    with darshan.DarshanReport(logpath) as report:
+        fig = plot_io_cost(report=report)
+    for i, ax in enumerate(fig.axes):
+        # there are only 2 axes, the first being the "raw" data
+        # and the second being the normalized data (percent)
+        actual_xticks = ax.get_xticks()
+        xticklabels = ax.get_xticklabels()
+        actual_xticklabels = [tl.get_text() for tl in xticklabels]
+        assert_allclose(actual_xticks, expected_xticks)
+        assert_array_equal(actual_xticklabels, expected_xlabels)
+        # regression test for gh-881
+        expected_rotations = 90
+        x_rotations = [tl.get_rotation() for tl in xticklabels]
+        assert_allclose(x_rotations, expected_rotations)

--- a/darshan-util/pydarshan/darshan/tests/test_plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/tests/test_plot_io_cost.py
@@ -1,8 +1,10 @@
+from packaging import version
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
+import matplotlib
 
 import darshan
 from darshan.log_utils import get_log_path
@@ -298,6 +300,10 @@ def test_plot_io_cost_x_ticks_and_labels(logname,
     with darshan.DarshanReport(logpath) as report:
         fig = plot_io_cost(report=report)
     for i, ax in enumerate(fig.axes):
+        if i > 0 and version.parse(matplotlib.__version__) < version.parse("3.6.0"):
+            # the second (invisible/twinned) axis is effectively
+            # empty in older matplotlib versions
+            continue
         # there are only 2 axes, the first being the "raw" data
         # and the second being the normalized data (percent)
         actual_xticks = ax.get_xticks()


### PR DESCRIPTION
Fixes #881

* rotate the x axis tick labels by 90 degrees counterclockwise in the I/O cost plot to avoid
label overlap

* add regression test for x axis tick label positions/rotations/content, including for the
exact log in the matching issue and for one other log

Samples of adjusted plots:

- `shane_ior-PNETCDF_id438100-438100_11-9-41525-10280033558448664385_1.darshan`
![image](https://user-images.githubusercontent.com/7903078/208267108-ed031df4-0848-4f84-b034-c5e1329c6b6c.png)

- `imbalanced-io.darshan`
![image](https://user-images.githubusercontent.com/7903078/208267113-1a1aa192-eb6d-4c82-84fd-1c1eb4c931c1.png)
