### PR TITLE
WIP, ENH: add df->rec converter

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -8,6 +8,30 @@ darshan release.
 
 
 header = """/* from darshan-logutils.h */
+
+struct darshan_file_category_counters {
+    int64_t count;                   /* number of files in this category */
+    int64_t total_read_volume_bytes; /* total read traffic volume */
+    int64_t total_write_volume_bytes;/* total write traffic volume */
+    int64_t max_read_volume_bytes;   /* maximum read traffic volume to 1 file */
+    int64_t max_write_volume_bytes;  /* maximum write traffic volume to 1 file */
+    int64_t total_max_offset_bytes;  /* summation of max_offsets */
+    int64_t max_offset_bytes;        /* largest max_offset */
+    int64_t nprocs;                  /* how many procs accessed (-1 for "all") */
+};
+
+struct darshan_derived_metrics {
+    int64_t total_bytes;
+    double unique_io_total_time_by_slowest;
+    double unique_rw_only_time_by_slowest;
+    double unique_md_only_time_by_slowest;
+    int unique_io_slowest_rank;
+    double shared_io_total_time_by_slowest;
+    double agg_perf_by_slowest;
+    double agg_time_by_slowest;
+    struct darshan_file_category_counters category_counters[7];
+};
+
 struct darshan_mnt_info
 {
     char mnt_type[3015];
@@ -22,6 +46,20 @@ struct darshan_mod_info
     int	idx;
     int partial_flag;
 };
+
+/* opaque accumulator reference */
+struct darshan_accumulator_st;
+typedef struct darshan_accumulator_st* darshan_accumulator;
+
+/* NOTE: darshan_module_id is technically an enum in the C API, but we'll
+ * just use an int for now (equivalent type) to avoid warnings from cffi
+ * that we have not defined explicit enum values.  We don't need that
+ * functionality.
+ */
+int darshan_accumulator_create(int darshan_module_id, int64_t, darshan_accumulator*);
+int darshan_accumulator_inject(darshan_accumulator, void*, int);
+int darshan_accumulator_emit(darshan_accumulator, struct darshan_derived_metrics*, void* aggregation_record);
+int darshan_accumulator_destroy(darshan_accumulator);
 
 /* from darshan-log-format.h */
 typedef uint64_t darshan_record_id;

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -679,10 +679,7 @@ def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
 
     Returns
     -------
-    buf: CFFI data object containing a buffer of record(s) or a single
-          record; when multiple records are present this will effectively
-          be a raw char array; with a single record, it should be cast
-          to a struct of the appropriate type
+    buf: Raw char array containing a buffer of record(s) or a single record.
     """
     counters_df = rec_dict["counters"]
     fcounters_df = rec_dict["fcounters"]

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -684,7 +684,6 @@ def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
           be a raw char array; with a single record, it should be cast
           to a struct of the appropriate type
     """
-    mod_type = _structdefs[mod_name]
     counters_df = rec_dict["counters"]
     fcounters_df = rec_dict["fcounters"]
     counters_n_cols = counters_df.shape[1]

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -657,3 +657,64 @@ def _log_get_heatmap_record(log):
     libdutil.darshan_free(buf[0])
     
     return rec
+
+
+def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
+    mod_type = _structdefs[mod_name]
+    counters_n_cols = rec_dict["counters"].shape[1]
+    fcounters_n_cols = rec_dict["fcounters"].shape[1]
+    size = (counters_n_cols +
+            fcounters_n_cols -
+            # id and rank columns are duplicated
+            # in counters and fcounters
+            2)
+    rbuf_orig = np.empty(shape=(size,), dtype=np.float64)
+    rbuf = ffi.cast(mod_type, ffi.from_buffer(rbuf_orig))
+    rbuf[0] = ffi.from_buffer(rbuf_orig)
+    for counter_name, dtype, cols in zip(["counters", "fcounters"],
+                                         [np.int64, np.float64],
+                                         [counters_n_cols, fcounters_n_cols]):
+        df = rec_dict[counter_name]
+        record = df.iloc[rec_index_of_interest, ...]
+        data = np.ascontiguousarray(record[:cols - 2].to_numpy(), dtype=dtype)
+        if counter_name == "fcounters":
+            rbuf[0].fcounters = data.tolist()
+        else:
+            rbuf[0].counters = data.tolist()
+    #rbuf[0].base_rec.rank = np.int64(record.loc["rank"])
+    #rbuf[0].base_rec.id = np.uint64(record.id)
+    return rbuf
+
+
+def _df_to_rec_array(rec_dict, mod_name):
+    # same _df_to_rec, but first allocate a contiguous
+    # buffer into which we can add ALL the records
+    # in the pandas data structures
+    # TODO: looping like this in Python/pandas is
+    # inefficient for many reasons--we really should
+    # be doing the data analysis on the DataFrame
+    # long term rather than moving data backwards
+    # like this to the C layer
+    counters_df = rec_dict["counters"]
+    fcounters_df = rec_dict["fcounters"]
+    num_recs_counters = counters_df.shape[0]
+    num_recs_fcounters = fcounters_df.shape[0]
+    size = (counters_df.shape[1] +
+            fcounters_df.shape[1] -
+            # id and rank columns are duplicated
+            # in counters and fcounters
+            2)
+    if num_recs_counters != num_recs_fcounters:
+        raise ValueError(f"{num_recs_counters} counter records "
+                         f"but {num_recs_fcounters} fcounter records")
+    record_array = np.empty(shape=size * num_recs_counters, dtype=np.float64)
+    # NOTE: we may be able to slurp the data in as a single
+    # buffer rather than iterating, but moving data from Python back to C
+    # layer shouldn't be relied upon long-term anyway
+    pos = 0
+    for i, rec_num in enumerate(range(num_recs_counters)):
+        record_array[pos:pos + size] = np.frombuffer(ffi.buffer(_df_to_rec(rec_dict=rec_dict,
+                                                                           mod_name=mod_name,
+                                                                           rec_index_of_interest=i)))
+        pos += size
+    return record_array

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -707,11 +707,8 @@ def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
     if num_recs > 1:
         rec_arr.id = counters_df.iloc[rec_index_of_interest, 0].to_numpy().reshape((num_recs, 1))
         rec_arr.rank = counters_df.iloc[rec_index_of_interest, 1].to_numpy().reshape((num_recs, 1))
-        buf = ffi.new("char[]", (counters_n_cols + fcounters_n_cols - 2) * num_recs * 8)
-        buf = rec_arr.tobytes()
     else:
         rec_arr.id = counters_df.iloc[rec_index_of_interest, 0]
         rec_arr.rank = counters_df.iloc[rec_index_of_interest, 1]
-        buf = ffi.new(mod_type)
-        buf[0] = ffi.from_buffer(rec_arr)
+    buf = rec_arr.tobytes()
     return buf

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -691,7 +691,9 @@ def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
     fcounters_n_cols = fcounters_df.shape[1]
     if rec_index_of_interest is None:
         num_recs = counters_df.shape[0]
-        rec_index_of_interest = ...
+        # newer pandas versions can support ...
+        # but we use a slice for now
+        rec_index_of_interest = slice(0, counters_df.shape[0])
     else:
         num_recs = 1
     # id and rank columns are duplicated

--- a/darshan-util/pydarshan/darshan/tests/test_cffi_misc.py
+++ b/darshan-util/pydarshan/darshan/tests/test_cffi_misc.py
@@ -170,6 +170,8 @@ def test_log_get_generic_record(dtype):
     ("POSIX", 0),
     ("POSIX", 3),
     ("POSIX", 5),
+    ("MPI-IO", 0),
+    ("MPI-IO", 2),
     # less records available for STDIO testing
     # with these logs
     ("STDIO", 0),


### PR DESCRIPTION
* add a per-record converter from DataFrame to darshan-util C record format that passes tests for single records (rows) with `counters` and `fcounters` (but not `rank` & `id` yet)

* add a full df->multi-record converter; this one still leads to segfaults with the C inject func with stuff like (probably corrupted data..):
```
../darshan-logutils-accumulator.c:145: darshan_accumulator_inject: Assertion `rank < acc->job_nprocs' failed.`
```

* one of the two added tests passes, the other xfails, feel free to push in fixes

* as discussed in meeting earlier today (Rob R. seems to agree), this likely shouldn't be a long-term solution--just temporary until we can hoist all analysis infrastructure to the Python level

* some of the accumulator API prototypes are copied in here from other PRs for testing purposes only.. since the main purpose of doing something like this would be to allow filtering DataFrames and then passing the raw records to the C accum interface.. (well, you also avoid re-reading the log file records)

* I'll leave backwards compatibility and support beyond STDIO/POSIX drafted here to Argonne folks most likely