### PR TITLE
BLD: fix editable installs

### DIFF
--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<64.0.0",
 ]
 
 [project]


### PR DESCRIPTION
Fixes #887

* this allows `pip install -e .` to produce a working editable install locally

* the basis for the `setuptools` pin here is based on reading through https://github.com/pypa/setuptools/issues/3548; in short, looks like a behavior change in `setuptools` so let's just pin it for now

* since this only affects Python **developers** for our project I've not added any "regression test"/"CI test" for it, but feel free to add one editable job to the CI if you want