### PR TITLE
CI: pin to mpy<1.0.0

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov lxml matplotlib packaging
+          python -m pip install --upgrade pytest pyflakes asv pytest-cov codecov lxml matplotlib packaging "mypy<1.0.0"
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |


### PR DESCRIPTION
Address new CI failures popping up in #886 related to a recent release of mypy by pinning for now.