### PR TITLE
MAINT: unpin mypy

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest pyflakes asv pytest-cov codecov lxml matplotlib packaging "mypy<1.0.0"
+          python -m pip install --upgrade pytest pyflakes asv pytest-cov codecov lxml matplotlib packaging mypy
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |

--- a/darshan-util/pydarshan/darshan/log_utils.py
+++ b/darshan-util/pydarshan/darshan/log_utils.py
@@ -9,8 +9,7 @@ python_version = platform.python_version_tuple()
 if int(python_version[1]) < 9 and int(python_version[0]) == 3:
     import importlib_resources
 else:
-    # see: https://github.com/python/mypy/issues/1153
-    import importlib.resources as importlib_resources # type: ignore
+    import importlib.resources as importlib_resources
 
 import functools
 import sys

--- a/darshan-util/pydarshan/darshan/tests/conftest.py
+++ b/darshan-util/pydarshan/darshan/tests/conftest.py
@@ -6,8 +6,7 @@ python_version = platform.python_version_tuple()
 if int(python_version[1]) < 9 and int(python_version[0]) == 3:
     import importlib_resources
 else:
-    # see: https://github.com/python/mypy/issues/1153
-    import importlib.resources as importlib_resources # type: ignore
+    import importlib.resources as importlib_resources
 
 
 import pytest


### PR DESCRIPTION
* `mypy` `1.0.0` was released on Feb. 6/2023, and we recently pinned it down to older versions while working on more important things because we had a few new type hinting issues pop up

* fix the type hinting issues, which were actually just ignore directives on `try/except` blocks that are no longer needed, so that's a clear win I think

* I doubt it matters much for us, but `mypy 1.0.0` can be ~40 % faster on large codebases:
https://mypy-lang.blogspot.com/2023/02/mypy-10-released.html