### PR TITLE
add OLCF Crusher regression testing env

### DIFF
--- a/darshan-test/regression/cray-module-alcf/env.sh
+++ b/darshan-test/regression/cray-module-alcf/env.sh
@@ -32,4 +32,4 @@ export DARSHAN_F90=ftn
 export DARSHAN_RUNJOB=$DARSHAN_TESTDIR/$DARSHAN_PLATFORM/runjob.sh
 
 module unload darshan >& /dev/null
-module load $DARSHAN_PATH/share/craype-2.x/modulefiles/
+module load $DARSHAN_RUNTIME_PATH/share/craype-2.x/modulefiles/

--- a/darshan-test/regression/cray-module-nersc/env.sh
+++ b/darshan-test/regression/cray-module-nersc/env.sh
@@ -32,4 +32,4 @@ export DARSHAN_F90=ftn
 export DARSHAN_RUNJOB=$DARSHAN_TESTDIR/$DARSHAN_PLATFORM/runjob.sh
 
 module unload darshan >& /dev/null
-module load $DARSHAN_PATH/share/craype-2.x/modulefiles/
+module load $DARSHAN_RUNTIME_PATH/share/craype-2.x/modulefiles/

--- a/darshan-test/regression/cray-module-olcf-crusher/env.sh
+++ b/darshan-test/regression/cray-module-olcf-crusher/env.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# General notes
+#######################
+
+# Script to set up the environment for tests on this platform.  Must export
+# the following environment variables:
+# 
+# DARSHAN_CC: command to compile C programs
+# DARSHAN_CXX: command to compile C++ programs
+# DARSHAN_F90: command to compile Fortran90 programs
+# DARSHAN_F77: command to compile Fortran77 programs
+# DARSHAN_RUNJOB: command to execute a job and wait for its completion
+
+# This script may load optional modules (as in a Cray PE), set LD_PRELOAD
+# variables (as in a dynamically linked environment), or generate mpicc
+# wrappers (as in a statically linked environment).
+
+# Notes specific to this platform (cray-module-olcf-crusher)
+########################
+# Use Cray's default compiler wrappers and LD_PRELOAD the darshan library
+# associated with this install
+#
+# RUNJOB is responsible for submitting a Slurm job, waiting for its
+# completion, and checking its return status
+
+export DARSHAN_CC=cc
+export DARSHAN_CXX=CC
+export DARSHAN_F77=ftn
+export DARSHAN_F90=ftn
+
+export DARSHAN_RUNJOB=$DARSHAN_TESTDIR/$DARSHAN_PLATFORM/runjob.sh
+
+export LD_PRELOAD=$DARSHAN_RUNTIME_PATH/lib/libdarshan.so:$LD_PRELOAD

--- a/darshan-test/regression/cray-module-olcf-crusher/runjob.sh
+++ b/darshan-test/regression/cray-module-olcf-crusher/runjob.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PROJ=CSC332_crusher
+
+# submit job and wait for it to return
+sbatch --wait -N 1 -t 10 -A $PROJ -p batch --output $DARSHAN_TMP/$$-tmp.out --error $DARSHAN_TMP/$$-tmp.err $DARSHAN_TESTDIR/$DARSHAN_PLATFORM/slurm-submit.sl "$@"
+
+# exit with return code of this job submission
+exit $?

--- a/darshan-test/regression/cray-module-olcf-crusher/slurm-submit.sl
+++ b/darshan-test/regression/cray-module-olcf-crusher/slurm-submit.sl
@@ -1,0 +1,3 @@
+#!/bin/bash -l
+
+srun -n $DARSHAN_DEFAULT_NPROCS $@

--- a/darshan-test/regression/run-all.sh
+++ b/darshan-test/regression/run-all.sh
@@ -3,11 +3,19 @@
 if [ "$#" -ne 3 ]; then
     echo "Usage: run-all.sh <darshan_install_path> <tmp_path> <platform>" 1>&2
     echo "Example: ./run-all.sh ~/darshan-install /tmp/test ws" 1>&2
+    echo "Example: ./run-all.sh ~/darshan-runtime-install:~/darshan-util-install /tmp/test ws" 1>&2
     exit 1
 fi
 
 # set variables for use by other sub-scripts
-export DARSHAN_PATH=$1
+DARSHAN_PATH=$1
+if [[ "$DARSHAN_PATH" == *":"* ]]; then
+    export DARSHAN_RUNTIME_PATH=`echo $DARSHAN_PATH | cut -f1 -d:`
+    export DARSHAN_UTIL_PATH=`echo $DARSHAN_PATH | cut -f2 -d:`
+else
+    export DARSHAN_RUNTIME_PATH=$DARSHAN_PATH
+    export DARSHAN_UTIL_PATH=$DARSHAN_PATH
+fi
 export DARSHAN_TMP=$2
 export DARSHAN_PLATFORM=$3
 # number of procs that most test jobs will use
@@ -16,9 +24,15 @@ export DARSHAN_DEFAULT_NPROCS=4
 DARSHAN_TESTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 export DARSHAN_TESTDIR
 
-# check darshan path
-if [ ! -x $DARSHAN_PATH/bin/darshan-parser ]; then
-    echo "Error: $DARSHAN_PATH doesn't contain a valid Darshan install." 1>&2
+# check darshan-runtime path
+if [ ! -x $DARSHAN_RUNTIME_PATH/bin/darshan-config ]; then
+    echo "Error: $DARSHAN_RUNTIME_PATH doesn't contain a valid Darshan-runtime install." 1>&2
+    exit 1
+fi
+
+# check darshan-util path
+if [ ! -x $DARSHAN_UTIL_PATH/bin/darshan-parser ]; then
+    echo "Error: $DARSHAN_UTIL_PATH doesn't contain a valid Darshan-util install." 1>&2
     exit 1
 fi
 

--- a/darshan-test/regression/test-cases/access-size-counter-test.sh
+++ b/darshan-test/regression/test-cases/access-size-counter-test.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/cxxpi.sh
+++ b/darshan-test/regression/test-cases/cxxpi.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/fperf-f77.sh
+++ b/darshan-test/regression/test-cases/fperf-f77.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/fperf-f90.sh
+++ b/darshan-test/regression/test-cases/fperf-f90.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/fprintf-fscanf-test.sh
+++ b/darshan-test/regression/test-cases/fprintf-fscanf-test.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/mpi-io-test-dxt.sh
+++ b/darshan-test/regression/test-cases/mpi-io-test-dxt.sh
@@ -24,7 +24,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-dxt-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}-dxt.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-dxt-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}-dxt.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1
@@ -34,7 +34,7 @@ fi
 
 # also, ensure that darshan-parser doesn't complain if given a log file that
 # has DXT data present
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > /dev/null
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > /dev/null
 if [ $? -ne 0 ]; then
     echo "Error: darshan-parser failed to handle ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/mpi-io-test.sh
+++ b/darshan-test/regression/test-cases/mpi-io-test.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1
@@ -42,7 +42,7 @@ fi
 
 # also, ensure that darshan-dxt-parser doesn't complain if given a log file that
 # does not have DXT data present
-$DARSHAN_PATH/bin/darshan-dxt-parser $DARSHAN_LOGFILE > /dev/null
+$DARSHAN_UTIL_PATH/bin/darshan-dxt-parser $DARSHAN_LOGFILE > /dev/null
 if [ $? -ne 0 ]; then
     echo "Error: darshan-dxt-parser failed to handle ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/test-cases/src/cxxpi.cxx
+++ b/darshan-test/regression/test-cases/src/cxxpi.cxx
@@ -25,19 +25,19 @@ int main(int argc,char **argv)
     int  namelen;
     char processor_name[MPI_MAX_PROCESSOR_NAME];
 
-    MPI::Init(argc,argv);
-    numprocs = MPI::COMM_WORLD.Get_size();
-    myid     = MPI::COMM_WORLD.Get_rank();
-    MPI::Get_processor_name(processor_name,namelen);
+    MPI_Init(&argc,&argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+    MPI_Get_processor_name(processor_name,&namelen);
 
     cout << "Process " << myid << " of " << numprocs << " is on " <<
 	processor_name << endl;
 
     n = 10000;			/* default # of rectangles */
     if (myid == 0)
-	startwtime = MPI::Wtime();
+	startwtime = MPI_Wtime();
 
-    MPI::COMM_WORLD.Bcast(&n, 1, MPI_INT, 0);
+    MPI_Bcast(&n, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
     h   = 1.0 / (double) n;
     sum = 0.0;
@@ -49,15 +49,15 @@ int main(int argc,char **argv)
     }
     mypi = h * sum;
 
-    MPI::COMM_WORLD.Reduce(&mypi, &pi, 1, MPI_DOUBLE, MPI_SUM, 0);
+    MPI_Reduce(&mypi, &pi, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
 
     if (myid == 0) {
-	endwtime = MPI::Wtime();
+	endwtime = MPI_Wtime();
 	cout << "pi is approximately " << pi << " Error is " <<
 	    fabs(pi - PI25DT) << endl;
 	cout << "wall clock time = " << endwtime-startwtime << endl;
     }
 
-    MPI::Finalize();
+    MPI_Finalize();
     return 0;
 }

--- a/darshan-test/regression/test-cases/src/cxxpi.cxx
+++ b/darshan-test/regression/test-cases/src/cxxpi.cxx
@@ -4,6 +4,12 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+/* NOTE: This example originated from the MPICH repo:
+ * (https://github.com/pmodels/mpich/blob/main/examples/cxx/cxxpi.cxx).
+ * We have since modified the code to stop using MPI C++ bindings as
+ * they have been deprecated and can cause compile failures.
+ */
+
 #include "mpi.h"
 #include <iostream>
 using namespace std;

--- a/darshan-test/regression/test-cases/stdio-test.sh
+++ b/darshan-test/regression/test-cases/stdio-test.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # parse log
-$DARSHAN_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
+$DARSHAN_UTIL_PATH/bin/darshan-parser $DARSHAN_LOGFILE > $DARSHAN_TMP/${PROG}.darshan.txt
 if [ $? -ne 0 ]; then
     echo "Error: failed to parse ${DARSHAN_LOGFILE}" 1>&2
     exit 1

--- a/darshan-test/regression/workstation-cc-wrapper/env.sh
+++ b/darshan-test/regression/workstation-cc-wrapper/env.sh
@@ -24,28 +24,28 @@
 
 # The runjob command is just mpiexec, no scheduler
 
-$DARSHAN_PATH/bin/darshan-gen-cc.pl `which mpicc` --output $DARSHAN_TMP/mpicc
+$DARSHAN_RUNTIME_PATH/bin/darshan-gen-cc.pl `which mpicc` --output $DARSHAN_TMP/mpicc
 if [ $? -ne 0 ]; then
     echo "Error: failed to generate c compiler." 1>&2
     exit 1
 fi
 export DARSHAN_CC=$DARSHAN_TMP/mpicc
 
-$DARSHAN_PATH/bin/darshan-gen-cxx.pl `which mpicxx` --output $DARSHAN_TMP/mpicxx
+$DARSHAN_RUNTIME_PATH/bin/darshan-gen-cxx.pl `which mpicxx` --output $DARSHAN_TMP/mpicxx
 if [ $? -ne 0 ]; then
     echo "Error: failed to generate c compiler." 1>&2
     exit 1
 fi
 export DARSHAN_CXX=$DARSHAN_TMP/mpicxx
 
-$DARSHAN_PATH/bin/darshan-gen-fortran.pl `which mpif77` --output $DARSHAN_TMP/mpif77
+$DARSHAN_RUNTIME_PATH/bin/darshan-gen-fortran.pl `which mpif77` --output $DARSHAN_TMP/mpif77
 if [ $? -ne 0 ]; then
     echo "Error: failed to generate f77 compiler." 1>&2
     exit 1
 fi
 export DARSHAN_F77=$DARSHAN_TMP/mpif77
 
-$DARSHAN_PATH/bin/darshan-gen-fortran.pl `which mpif90` --output $DARSHAN_TMP/mpif90
+$DARSHAN_RUNTIME_PATH/bin/darshan-gen-fortran.pl `which mpif90` --output $DARSHAN_TMP/mpif90
 if [ $? -ne 0 ]; then
     echo "Error: failed to generate f90 compiler." 1>&2
     exit 1

--- a/darshan-test/regression/workstation-ld-preload/env.sh
+++ b/darshan-test/regression/workstation-ld-preload/env.sh
@@ -35,7 +35,7 @@ FULL_MPICC_PATH=`which mpicc`
 # we must prepend libfmpich.so to the LD_PRELOAD variable, but with a fully
 # resolve path.  To find a path we locate mpicc and speculate that
 # libfmich.so can be found in ../lib.
-export LD_PRELOAD=`dirname $FULL_MPICC_PATH`/../lib/libfmpich.so:$DARSHAN_PATH/lib/libdarshan.so:$LD_PRELOAD
+export LD_PRELOAD=`dirname $FULL_MPICC_PATH`/../lib/libfmpich.so:$DARSHAN_RUNTIME_PATH/lib/libdarshan.so:$LD_PRELOAD
 
 export DARSHAN_RUNJOB="mpiexec -n $DARSHAN_DEFAULT_NPROCS"
 

--- a/darshan-test/regression/workstation-profile-conf-dynamic/env.sh
+++ b/darshan-test/regression/workstation-profile-conf-dynamic/env.sh
@@ -30,12 +30,12 @@ export DARSHAN_CXX=mpicxx
 export DARSHAN_F77=mpif77
 export DARSHAN_F90=mpif90
 
-export MPICC_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-cc
-export MPICXX_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-cxx
-export MPIF90_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-f
-export MPIF77_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-f
+export MPICC_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-cc
+export MPICXX_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-cxx
+export MPIF90_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-f
+export MPIF77_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-f
 # MPICH 3.1.1 and newer use MPIFORT rather than MPIF90 and MPIF77 in env var
 # name
-export MPIFORT_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-f
+export MPIFORT_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-f
 
 export DARSHAN_RUNJOB="mpiexec -n $DARSHAN_DEFAULT_NPROCS"

--- a/darshan-test/regression/workstation-profile-conf-static/env.sh
+++ b/darshan-test/regression/workstation-profile-conf-static/env.sh
@@ -30,12 +30,12 @@ export DARSHAN_CXX=mpicxx
 export DARSHAN_F77=mpif77
 export DARSHAN_F90=mpif90
 
-export MPICC_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-cc-static
-export MPICXX_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-cxx-static
-export MPIF90_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-f-static
-export MPIF77_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-f-static
+export MPICC_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-cc-static
+export MPICXX_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-cxx-static
+export MPIF90_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-f-static
+export MPIF77_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-f-static
 # MPICH 3.1.1 and newer use MPIFORT rather than MPIF90 and MPIF77 in env var
 # name
-export MPIFORT_PROFILE=$DARSHAN_PATH/share/mpi-profile/darshan-f-static
+export MPIFORT_PROFILE=$DARSHAN_RUNTIME_PATH/share/mpi-profile/darshan-f-static
 
 export DARSHAN_RUNJOB="mpiexec -n $DARSHAN_DEFAULT_NPROCS"


### PR DESCRIPTION
In addition to the new system environment, this commit has 2 additional changes:
- cxxpi test case has been updated to stop using C++ MPI bindings, as these were causing compile failures and are apparently no longer in the standard
- regression test script was updated to allow input Darshan install prefix specifications like `darshan_runtime_install:darshan_util_install` (rather than a single install prefix for both) to support cases where both components aren't installed in one spot (e.g., with Spack)