### PR TITLE
WIP, ENH: add POSIX access pattern plot to darshan job summary

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -12,6 +12,8 @@ import ctypes
 import numpy as np
 import pandas as pd
 
+from collections import namedtuple
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -751,8 +753,8 @@ def accumulate_records(rec_dict, mod_name, nprocs):
         nprocs: Number of processes participating in accumulation.
 
     Returns:
-        Tuple containing darshan_derived_metrics struct (cdata object) and
-        the summary record (dict).
+        namedtuple containing derived_metrics (cdata object) and
+        summary_record (dict).
     """
     mod_idx = mod_name_to_idx(mod_name)
     darshan_accumulator = ffi.new("darshan_accumulator *")
@@ -790,4 +792,7 @@ def accumulate_records(rec_dict, mod_name, nprocs):
                            "stream.")
 
     summary_rec = _make_generic_record(summary_rbuf, mod_name, dtype='pandas')
-    return derived_metrics, summary_rec
+
+    # create namedtuple type to hold return values
+    AccumulatedRecords = namedtuple("AccumulatedRecords", ['derived_metrics', 'summary_record'])
+    return AccumulatedRecords(derived_metrics, summary_rec)

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -739,7 +739,7 @@ def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
     return buf
 
 
-def accumulate_records(rec_dict, mod_name, nprocs, dtype='numpy'):
+def accumulate_records(rec_dict, mod_name, nprocs):
     """
     Passes a set of records (in pandas format) to the Darshan accumulator
     interface, and returns the corresponding derived metrics struct and
@@ -789,5 +789,5 @@ def accumulate_records(rec_dict, mod_name, nprocs, dtype='numpy'):
                            "to retrieve additional information from the stderr "
                            "stream.")
 
-    summary_rec = _make_generic_record(summary_rbuf, mod_name, dtype)
+    summary_rec = _make_generic_record(summary_rbuf, mod_name, dtype='pandas')
     return derived_metrics, summary_rec

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -544,7 +544,8 @@ class ReportData:
                             fig_args=dict(record=acc.summary_record),
                             fig_description="Sequential (offset greater than previous offset) vs. "
                                             "consecutive (offset immediately following previous offset) "
-                                            "file operations.",
+                                            "file operations. Note that, by definition, the sequential "
+                                            "operations are inclusive of consecutive operations.",
                             fig_width=350,
                         )
                         self.figures.append(access_pattern_fig)

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -22,6 +22,7 @@ from darshan.experimental.plots import (
     plot_common_access_table,
     plot_access_histogram,
     plot_opcounts,
+    plot_posix_access_pattern,
     data_access_by_filesystem,
 )
 
@@ -534,6 +535,19 @@ class ReportData:
                                                                     mod_name=mod),
                             text_only_color="blue")
                     self.figures.append(bandwidth_fig)
+
+                    if mod == "POSIX":
+                        access_pattern_fig = ReportFigure(
+                            section_title=sect_title,
+                            fig_title="Access Pattern",
+                            fig_func=plot_posix_access_pattern,
+                            fig_args=dict(record=summary_record),
+                            fig_description="Sequential (offset greater than previous offset) vs. "
+                                            "consecutive (offset immediately following previous offset) "
+                                            "file operations.",
+                            fig_width=350,
+                        )
+                        self.figures.append(access_pattern_fig)
 
                     file_count_summary_fig = ReportFigure(
                             section_title=sect_title,

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -14,7 +14,7 @@ from mako.template import Template
 
 import darshan
 import darshan.cli
-from darshan.backend.cffi_backend import log_get_derived_metrics
+from darshan.backend.cffi_backend import accumulate_records
 from darshan.lib.accum import log_get_bytes_bandwidth, log_file_count_summary_table
 from darshan.experimental.plots import (
     plot_dxt_heatmap,
@@ -521,7 +521,7 @@ class ReportData:
                     # record and derived metrics
                     rec_dict = self.report.records[mod].to_df()
                     nprocs = self.report.metadata['job']['nprocs']
-                    derived_metrics = log_get_derived_metrics(rec_dict, mod, nprocs)
+                    derived_metrics, summary_record = accumulate_records(rec_dict, mod, nprocs, dtype='pandas')
 
                     # this is really just some text
                     # so using ReportFigure feels awkward...

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -522,7 +522,7 @@ class ReportData:
                     # record and derived metrics
                     rec_dict = self.report.records[mod].to_df()
                     nprocs = self.report.metadata['job']['nprocs']
-                    derived_metrics, summary_record = accumulate_records(rec_dict, mod, nprocs, dtype='pandas')
+                    derived_metrics, summary_record = accumulate_records(rec_dict, mod, nprocs)
 
                     # this is really just some text
                     # so using ReportFigure feels awkward...

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -522,7 +522,7 @@ class ReportData:
                     # record and derived metrics
                     rec_dict = self.report.records[mod].to_df()
                     nprocs = self.report.metadata['job']['nprocs']
-                    derived_metrics, summary_record = accumulate_records(rec_dict, mod, nprocs)
+                    acc = accumulate_records(rec_dict, mod, nprocs)
 
                     # this is really just some text
                     # so using ReportFigure feels awkward...
@@ -531,7 +531,7 @@ class ReportData:
                             fig_title="",
                             fig_func=None,
                             fig_args=None,
-                            fig_description=log_get_bytes_bandwidth(derived_metrics=derived_metrics,
+                            fig_description=log_get_bytes_bandwidth(derived_metrics=acc.derived_metrics,
                                                                     mod_name=mod),
                             text_only_color="blue")
                     self.figures.append(bandwidth_fig)
@@ -541,7 +541,7 @@ class ReportData:
                             section_title=sect_title,
                             fig_title="Access Pattern",
                             fig_func=plot_posix_access_pattern,
-                            fig_args=dict(record=summary_record),
+                            fig_args=dict(record=acc.summary_record),
                             fig_description="Sequential (offset greater than previous offset) vs. "
                                             "consecutive (offset immediately following previous offset) "
                                             "file operations.",
@@ -553,7 +553,7 @@ class ReportData:
                             section_title=sect_title,
                             fig_title=f"File Count Summary <br> (estimated by {mod} I/O access offsets)",
                             fig_func=log_file_count_summary_table,
-                            fig_args=dict(derived_metrics=derived_metrics,
+                            fig_args=dict(derived_metrics=acc.derived_metrics,
                                           mod_name=mod),
                             fig_width=805,
                             fig_description="")

--- a/darshan-util/pydarshan/darshan/experimental/plots/__init__.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/__init__.py
@@ -2,3 +2,4 @@ from .plot_access_histogram import plot_access_histogram
 from .plot_opcounts import plot_opcounts
 from .plot_dxt_heatmap2 import plot_dxt_heatmap2
 from .plot_io_cost import plot_io_cost
+from .plot_posix_access_pattern import plot_posix_access_pattern

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
@@ -51,7 +51,7 @@ def plot_posix_access_pattern(record, ax=None):
     ax.set_ylabel('Count')
     ax.set_xticks(x)
     ax.set_xticklabels(labels)
-    ax.legend()
+    ax.legend(loc='center left', bbox_to_anchor=(1.05,.5))
 
     ax.spines[['right', 'top']].set_visible(False)
 

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
@@ -33,7 +33,6 @@ def plot_posix_access_pattern(record, ax=None):
         fig = None
 
     labels = ['read', 'write']
-    # TODO ensure input df one row for now?
     total_data = [record['counters']['POSIX_READS'][0],
                   record['counters']['POSIX_WRITES'][0]]
     seq_data = [record['counters']['POSIX_SEQ_READS'][0],

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
@@ -14,7 +14,7 @@ def autolabel(ax, rects):
             textcoords="offset points",
             ha='center',
             va='bottom',
-            rotation=0,
+            rotation=45,
         )
 
 def plot_posix_access_pattern(record, ax=None):
@@ -52,6 +52,8 @@ def plot_posix_access_pattern(record, ax=None):
     ax.set_xticks(x)
     ax.set_xticklabels(labels)
     ax.legend()
+
+    ax.spines[['right', 'top']].set_visible(False)
 
     autolabel(ax=ax, rects=rects_total)
     autolabel(ax=ax, rects=rects_seq)

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_posix_access_pattern.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+def autolabel(ax, rects):
+    """Attach a text label above each bar in *rects*, displaying its value."""
+    for rect in rects:
+        height = rect.get_height()
+        ax.annotate(
+            '{}'.format(height),
+            xy=(rect.get_x() + rect.get_width() / 2, height),
+            xytext=(0, 3),  # 3 points vertical offset
+            textcoords="offset points",
+            ha='center',
+            va='bottom',
+            rotation=0,
+        )
+
+def plot_posix_access_pattern(record, ax=None):
+    """
+    Plots read/write access patterns (sequential vs consecutive access counts)
+    for a given POSIX module file record.
+
+	Args:
+		record (dict): POSIX module record to plot access pattern for.
+
+    """
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = None
+
+    labels = ['read', 'write']
+    # TODO ensure input df one row for now?
+    total_data = [record['counters']['POSIX_READS'][0],
+                  record['counters']['POSIX_WRITES'][0]]
+    seq_data = [record['counters']['POSIX_SEQ_READS'][0],
+                record['counters']['POSIX_SEQ_WRITES'][0]]
+    consec_data = [record['counters']['POSIX_CONSEC_READS'][0],
+                   record['counters']['POSIX_CONSEC_WRITES'][0]]
+
+    x = np.arange(len(labels))  # the label locations
+    width = 0.2  # the width of the bars
+
+    rects_total = ax.bar(x - width, total_data, width, label = 'total')
+    rects_seq = ax.bar(x, seq_data, width, label = 'sequential')
+    rects_consec = ax.bar(x + width, consec_data, width, label = 'consecutive')
+
+    ax.set_ylabel('Count')
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.legend()
+
+    autolabel(ax=ax, rects=rects_total)
+    autolabel(ax=ax, rects=rects_seq)
+    autolabel(ax=ax, rects=rects_consec)
+
+    plt.tight_layout()
+
+    if fig is not None:
+        plt.close()
+        return fig

--- a/darshan-util/pydarshan/darshan/tests/test_lib_accum.py
+++ b/darshan-util/pydarshan/darshan/tests/test_lib_accum.py
@@ -89,7 +89,7 @@ def test_derived_metrics_bytes_and_bandwidth(log_path, mod_name, expected_str):
                                    match=f"{mod_name} module does not support derived"):
                     accumulate_records(rec_dict, mod_name, nprocs)
             else:
-                derived_metrics = accumulate_records(rec_dict, mod_name, nprocs)[0]
+                derived_metrics = accumulate_records(rec_dict, mod_name, nprocs).derived_metrics
                 actual_str = log_get_bytes_bandwidth(derived_metrics=derived_metrics,
                                                      mod_name=mod_name)
                 assert actual_str == expected_str
@@ -210,7 +210,7 @@ def test_file_count_summary_table(log_name,
         rec_dict = report.records[mod_name].to_df()
         nprocs = report.metadata['job']['nprocs']
 
-    derived_metrics = accumulate_records(rec_dict, mod_name, nprocs)[0]
+    derived_metrics = accumulate_records(rec_dict, mod_name, nprocs).derived_metrics
 
     actual_df = log_file_count_summary_table(derived_metrics=derived_metrics,
                                              mod_name=mod_name).df

--- a/darshan-util/pydarshan/darshan/tests/test_lib_accum.py
+++ b/darshan-util/pydarshan/darshan/tests/test_lib_accum.py
@@ -1,5 +1,5 @@
 import darshan
-from darshan.backend.cffi_backend import log_get_derived_metrics
+from darshan.backend.cffi_backend import accumulate_records
 from darshan.lib.accum import log_get_bytes_bandwidth, log_file_count_summary_table
 from darshan.log_utils import get_log_path
 
@@ -87,9 +87,9 @@ def test_derived_metrics_bytes_and_bandwidth(log_path, mod_name, expected_str):
             if expected_str == "RuntimeError":
                 with pytest.raises(RuntimeError,
                                    match=f"{mod_name} module does not support derived"):
-                    log_get_derived_metrics(rec_dict, mod_name, nprocs)
+                    accumulate_records(rec_dict, mod_name, nprocs)
             else:
-                derived_metrics = log_get_derived_metrics(rec_dict, mod_name, nprocs)
+                derived_metrics = accumulate_records(rec_dict, mod_name, nprocs)[0]
                 actual_str = log_get_bytes_bandwidth(derived_metrics=derived_metrics,
                                                      mod_name=mod_name)
                 assert actual_str == expected_str
@@ -210,7 +210,7 @@ def test_file_count_summary_table(log_name,
         rec_dict = report.records[mod_name].to_df()
         nprocs = report.metadata['job']['nprocs']
 
-    derived_metrics = log_get_derived_metrics(rec_dict, mod_name, nprocs)
+    derived_metrics = accumulate_records(rec_dict, mod_name, nprocs)[0]
 
     actual_df = log_file_count_summary_table(derived_metrics=derived_metrics,
                                              mod_name=mod_name).df

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -99,10 +99,10 @@ def test_main_with_args(tmpdir, argv):
     "argv, expected_img_count, expected_table_count", [
         (["noposix.darshan"], 3, 3),
         (["noposix.darshan", "--output=test.html"], 3, 3),
-        (["sample-dxt-simple.darshan"], 8, 6),
-        (["sample-dxt-simple.darshan", "--output=test.html"], 8, 6),
-        (["nonmpi_dxt_anonymized.darshan"], 6, 5),
-        (["ior_hdf5_example.darshan"], 11, 8),
+        (["sample-dxt-simple.darshan"], 9, 6),
+        (["sample-dxt-simple.darshan", "--output=test.html"], 9, 6),
+        (["nonmpi_dxt_anonymized.darshan"], 7, 5),
+        (["ior_hdf5_example.darshan"], 12, 8),
         ([None], 0, 0),
     ]
 )


### PR DESCRIPTION
See commits for more details.

If things look good, I can add some tests that can at least check some expected `summary_record` counter values returned by `acummulate_records()`.

A few thoughts:
- This is the first plotting routine that takes a dataframe as input (others take a report object). I thought about this a bit, and think it would be good to generalize the plotting routines we provide away from report objects, to allow us to plot data coming from multiple log files. I didn't modify any other plotting routines, but could take a pass at this in another PR if that seems reasonable?
- Related to above, but this new plotting routine is hardcoded to get plot data from the first row of the input dataframe for now. That works fine for the accumulator use case obviously since it's just a single row, but I'm not sure how to best generalize this. Seems like it should be easy? Ultimately, I think it would be nice if you could give the plotting routine a single row (in which case it plots the row values directly) or an entire dataframe (in which case it will need to run the accumulator internally to condense down to a single record). Any thoughts on this?
- Can we convert the derived metrics structure returned by `accumulate_records()` into a more Pythonic object? `summary_record` is a dictionary now (i.e., not a cdata object), so seems that it would be cleaner if both return values are typical Python things, rather than `derived_metrics` being a C-like structure. 