### PR TITLE
ENH: PyDarshan job summary print warning and bail on logs with no data

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -332,6 +332,22 @@ class ReportData:
         """
         self.figures = []
 
+        if not self.report.modules:
+            # no data in report to summarize, print warning and that's it
+            no_data_message = (
+                "This Darshan log file has no instrumentation records,"
+                "there is no data to plot. Did this app do any I/O?"
+            )
+            fig = ReportFigure(
+                section_title="",
+                fig_title="",
+                fig_func=None,
+                fig_args=None,
+                fig_description=no_data_message,
+            )
+            self.figures.append(fig)
+            return
+
         #########################################
         ## Add the runtime and/or DXT heat map(s)
         #########################################

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -209,9 +209,14 @@ def test_main_all_logs_repo_files(tmpdir, log_filepath):
                             stdio_position > -1):
                             assert mpiio_position < posix_position < stdio_position
                     else:
-                        # check that help message is present
-                        assert "Heatmap data is not available for this job" in report_str
-                        assert "Consider enabling the runtime heatmap module" in report_str
+                        if not "empty_log" in log_filepath:
+                            # check that help message is present
+                            assert "Heatmap data is not available for this job" in report_str
+                            assert "Consider enabling the runtime heatmap module" in report_str
+                        else:
+                            # check empty log warning and return
+                            assert "This Darshan log file has no instrumentation records" in report_str
+                            return
 
                     # check if I/O cost figure is present
                     for mod in report.modules:


### PR DESCRIPTION
Detect empty logs, embed a warning in the report, and bail on typical report generation.

Fixes #845.

I won't close #734, as that issue is more tied to the underlying plotting routine throwing the error (plot_io_cost), which I haven't addressed here. I'm hesitant to fix there as it's possible we refactor those routines in the future, so just trying to keep things simple.

In the mean time, this should allow PyDarshan job summary to do something sensible for empty logs.