### PR TITLE
Fix HDF5 reference issue.

### DIFF
--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -364,6 +364,9 @@ herr_t DARSHAN_DECL(H5Fflush)(hid_t object_id, H5F_scope_t scope)
                     tm1, tm2, rec_ref->last_meta_end);
             }
             H5F_POST_RECORD();
+
+            MAP_OR_FAIL(H5Fclose);
+            __real_H5Fclose(file_id);
         }
     }
 


### PR DESCRIPTION
According to [HDF5 Doc](https://docs.hdfgroup.org/hdf5/develop/group___h5_i.html#title5), the identifier returned by `H5Iget_file_id` needs to be released using `H5Fclose`. 

This fix darshan-hpc/darshan#906