### PR TITLE
MAINT, BUG: pandas 2.0 compatibility

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -316,8 +316,12 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     bin_edge_data = np.linspace(0.0, max_time, xbins + 1)
     # create dummy variables for start/end time data, where dataframe columns
     # are the x-axis bin ranges
+    # pin dtype here because of pandas 2.0+ change--see:
+    # gh-909 and
+    # https://github.com/pandas-dev/pandas/pull/48022#issuecomment-1448755561
     cats_start = pd.get_dummies(
-        pd.cut(agg_df["start_time"], bin_edge_data, precision=16)
+        pd.cut(agg_df["start_time"], bin_edge_data, precision=16),
+        dtype=np.uint8,
     )
     cats_end = pd.get_dummies(pd.cut(agg_df["end_time"], bin_edge_data, precision=16))
     # get series for the elapsed times for each dxt segment


### PR DESCRIPTION
Fixes #909

* make the library compatible with both `pandas 1.5.x` and `pandas 2.0.0rc0` by pinning the dtype we use for one-hot encoding our heatmap data

* see related upstream comment and release notes (`get_dummies()` change):
  - https://github.com/pandas-dev/pandas/pull/48022#issuecomment-1448755561
  - https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html