### PR TITLE
BUG: set DXT heatmap limit

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/heatmap_handling.py
@@ -2,7 +2,7 @@
 Module of data pre-processing functions for constructing the heatmap figure.
 """
 
-from typing import Dict, Any, Tuple, Sequence, TYPE_CHECKING
+from typing import Dict, Any, Tuple, Sequence, TYPE_CHECKING, Optional
 
 import sys
 
@@ -273,7 +273,10 @@ def get_aggregate_data(
     return agg_df
 
 
-def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFrame:
+def get_heatmap_df(agg_df: pd.DataFrame,
+                   xbins: int,
+                   nprocs: int,
+                   max_time: Optional[float] = None) -> pd.DataFrame:
     """
     Builds an array similar to a 2D-histogram, where the y data is the unique
     ranks and the x data is time. Each bin is populated with the data sum
@@ -289,6 +292,9 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     xbins: the number of x-axis bins to create.
 
     nprocs: the number of MPI ranks/processes used at runtime.
+
+    max_time: the maximum time, since input DXT data is not necessarily
+              bounded by wallclock duration
 
     Returns
     -------
@@ -312,7 +318,8 @@ def get_heatmap_df(agg_df: pd.DataFrame, xbins: int, nprocs: int) -> pd.DataFram
     """
     # generate the bin edges by generating an array of length n_bins+1, then
     # taking pairs of data points as the min/max bin value
-    max_time = agg_df["end_time"].max()
+    if max_time is None:
+        max_time = agg_df["end_time"].max()
     bin_edge_data = np.linspace(0.0, max_time, xbins + 1)
     # create dummy variables for start/end time data, where dataframe columns
     # are the x-axis bin ranges


### PR DESCRIPTION
* Fixes #914

* use a new `max_time` argument to compensate for the fact that DXT records are not guaranteed to encompass the wallclock duration of an instrumented runtime

* I could probably use help developing a suitable regression test, that seems a bit tricky without i.e., adding the connected log + reconstituting the plot binary data from the HTML and then parsing that somehow (certainly doable, but annoying)

* could also add a test for usage of `get_heatmap_df()` with/without the new argument for a case where it matters, though that doesn't directly guard against the regression in question

Pertinent part of updated report:

![image](https://user-images.githubusercontent.com/7903078/223865053-7c5e3e31-7dee-4e89-9d02-3655ebd78f95.png)
