### PR TITLE
MAINT: darshan-util library discovery changes for pydarshan

### DIFF
--- a/darshan-util/pydarshan/darshan/discover_darshan.py
+++ b/darshan-util/pydarshan/darshan/discover_darshan.py
@@ -86,15 +86,15 @@ def discover_darshan_pkgconfig():
 
     import subprocess
 
-    args = ['pkg-config', '--path', 'darshan-util']
+    args = ['pkg-config', '--variable=prefix', 'darshan-util']
     p = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd='.')
     out,err = p.communicate()
     retval = p.wait()
 
-    path = os.path.dirname(out.decode('ascii').strip())
+    path = out.decode('ascii').strip()
 
     if path:
-        return os.path.realpath(path + '/../../')
+        return os.path.realpath(path)
     else:
         raise RuntimeError('Could not discover darshan! Is darshan-util installed?')
 

--- a/darshan-util/pydarshan/darshan/discover_darshan.py
+++ b/darshan-util/pydarshan/darshan/discover_darshan.py
@@ -163,6 +163,20 @@ def find_utils(ffi, libdutil):
 
     """
     if libdutil is None:
+        # prefer wheel library discovery method
+        try:
+            darshan_path = discover_darshan_wheel()
+            import glob
+            library_path = glob.glob(f'{darshan_path}/libdarshan-util*.so*')[0]
+            logger.debug(f"Attempting library_path={library_path} in case of binary wheel.")
+            save = os.getcwd()
+            os.chdir(darshan_path)
+            libdutil = ffi.dlopen(library_path)
+            os.chdir(save)
+        except:
+            libdutil = None
+
+    if libdutil is None:
         try:
             libdutil = ffi.dlopen("libdarshan-util.so")
         except:
@@ -190,19 +204,6 @@ def find_utils(ffi, libdutil):
         except:
             libdutil = None
 
-    if libdutil is None:
-        try:
-            darshan_path = discover_darshan_wheel()
-            import glob
-            library_path = glob.glob(f'{darshan_path}/libdarshan-util*.so*')[0]
-            logger.debug(f"Attempting library_path={library_path} in case of binary wheel.")
-            save = os.getcwd()
-            os.chdir(darshan_path)
-            libdutil = ffi.dlopen(library_path)
-            os.chdir(save)
-        except:
-            libdutil = None
-    
     if libdutil is None:
         try:
             darshan_path = discover_darshan_pyinstaller()


### PR DESCRIPTION
- prefer library discovery method based on wheels, since these are shipped with their own libraries that should be used over other Darshan installs (e.g., Darshan installs provided by a facility)
- fix pkg-config based library discovery, originally mentioned in #383 
  - `--path` does not seem to be a valid `pkg-config` option, but we can extract the `prefix` variable from the file as I have done here  