### PR TITLE
CI: deal with codecov yank

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ macos_M1_native_apple_silicon_py310_task:
   script: |
     brew install python@3.10
     brew install python-tk@3.10
-    /opt/homebrew/opt/python@3.10/bin/python3 -m venv ~/py_310
+    /opt/homebrew/bin/python3.10 -m venv ~/py_310
     source ~/py_310/bin/activate
     python -m pip install --upgrade pip
     python -m pip install --upgrade pytest lxml matplotlib packaging humanize

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest pyflakes asv pytest-cov codecov lxml matplotlib packaging humanize "mypy<1.0.0"
+          python -m pip install --upgrade pytest pyflakes asv pytest-cov lxml matplotlib packaging humanize "mypy<1.0.0"
       - if: ${{matrix.platform == 'macos-latest'}}
         name: Install MacOS deps
         run: |
@@ -99,7 +99,7 @@ jobs:
           cd darshan-util/pydarshan/benchmarks
           python -m asv check -E existing
       - name: codecov check
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: $RUNNER_TEMP/coverage.xml,/home/runner/work/_temp/coverage.xml,/Users/runner/work/_temp/coverage.xml
           fail_ci_if_error: False


### PR DESCRIPTION
* see drama here: https://about.codecov.io/blog/message-regarding-the-pypi-package/

* I think we should just be able to delete the `codecov` PyPI install and use their GHA plugin at this point, but I'll let CI confirm...