### PR TITLE
ENH: add darshan-runtime configure option for specifying a username env var

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -200,6 +200,18 @@ if test "x$enable_darshan_runtime" = xyes ; then
       GOT_JOBID=yes
    fi
 
+   AC_ARG_WITH([username-env],
+      [AS_HELP_STRING([--with-username-env=NAME],
+                      [Name of environment variable that stores the username])],
+      [], [with_username_env=no]
+   )
+   if test "x$with_username_env" = xyes; then
+      AC_MSG_ERROR(--with-username-env must be given a name)
+   elif test "x$with_username_env" != xno; then
+      AC_DEFINE_UNQUOTED([__DARSHAN_USERNAME_ENV], "$with_username_env",
+                         [Name of the environment variable that stores the username])
+   fi
+
    AC_ARG_WITH([mod-mem],
       [AS_HELP_STRING([--with-mod-mem=NUM],
                       [Maximum runtime memory consumption per process

--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -90,6 +90,7 @@ make install
 * `--with-username-env=NAME`: this specifies the environment variable that Darshan
   should check to determine the username for a job. If not specified, Darshan
   will use internal mechanisms to try to determine the username.
+** NOTE: Darshan relies on the `LOGNAME` environment variable to determine a username, but this method isn't always reliable (e.g., on Slurm systems, `LOGNAME` can be wiped when specifying additional environment variables using the `--export` option to `srun`). This configure option allows specification of an additional environment variable to extract a username from (e.g., `SLURM_JOB_USER`).
 * `--with-log-path=DIR` (this, or `--with-log-path-by-env`, is mandatory): This
   specifies the parent directory for the directory tree where Darshan logs will
   be placed.
@@ -699,8 +700,10 @@ and installation path, respectively.
 module swap PrgEnv-pgi PrgEnv-gnu
 ./configure \
  --with-log-path=/shared-file-system/darshan-logs \
- --prefix=/soft/darshan-2.2.3 \
- --with-jobid-env=PBS_JOBID CC=cc
+ --prefix=/soft/darshan-3.3.0 \
+ --with-jobid-env=SLURM_JOBID \
+ --with-username-env=SLURM_JOB_USER \
+ CC=cc
 make install
 module swap PrgEnv-gnu PrgEnv-pgi
 ----
@@ -708,7 +711,10 @@ module swap PrgEnv-gnu PrgEnv-pgi
 .Rationale
 [NOTE]
 ====
-The job ID is set to `PBS_JOBID` for use with a Torque or PBS based scheduler.
+The job ID is set to `SLURM_JOBID` for use with a Slurm based scheduler.
+An additional environment variable for querying a job's username (`SLURM_JOB_USER`)
+is provided as a fallback in case the default environment variable `LOGNAME`
+is not properly set (e.g., as is the case when using Slurm's `--export` option to `srun`).
 The `CC` variable is configured to point the standard MPI compiler.
 ====
 
@@ -774,8 +780,8 @@ following locations (depending on how you specified the --prefix option in
 the previous section):
 
 ----
-/soft/darshan-2.2.3/share/craype-1.x/modulefiles/darshan
-/soft/darshan-2.2.3/share/craype-2.x/modulefiles/darshan
+/soft/darshan-3.3.0/share/craype-1.x/modulefiles/darshan
+/soft/darshan-3.3.0/share/craype-2.x/modulefiles/darshan
 ----
 
 Select the one that is appropriate for your Cray programming environment
@@ -798,7 +804,7 @@ install location can be added to your local module path with the following
 command:
 
 ----
-module use /soft/darshan-2.2.3/share/craype-<VERSION>/modulefiles
+module use /soft/darshan-3.3.0/share/craype-<VERSION>/modulefiles
 ----
 
 From this point, Darshan instrumentation can be enabled for all future

--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -87,6 +87,9 @@ make install
   scheduler does not advertise the job ID) then you can specify `NONE` here.
   Darshan will fall back to using the pid of the rank 0 process if the
   specified environment variable is not set.
+* `--with-username-env=NAME`: this specifies the environment variable that Darshan
+  should check to determine the username for a job. If not specified, Darshan
+  will use internal mechanisms to try to determine the username.
 * `--with-log-path=DIR` (this, or `--with-log-path-by-env`, is mandatory): This
   specifies the parent directory for the directory tree where Darshan logs will
   be placed.

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -1379,8 +1379,19 @@ static void darshan_get_user_name(char *cuser)
      * work in statically compiled binaries.
      */
 
+#ifdef __DARSHAN_USERNAME_ENV
+    logname_string = getenv(__DARSHAN_USERNAME_ENV);
+    if(logname_string)
+    {
+        strncpy(cuser, logname_string, (L_cuserid-1));
+    }
+#endif
+
 #ifdef __DARSHAN_ENABLE_CUSERID
-    cuserid(cuser);
+    if(strcmp(cuser, "") == 0)
+    {
+        cuserid(cuser);
+    }
 #endif
 
     /* if cuserid() didn't work, then check the environment */


### PR DESCRIPTION
This should address a longstanding issue with Darshan not always being able to determine the username associated with a job on Cray systems that use Slurm. Specifically, when Slurm users use the `--export` option to `srun` to set additional environment variables, this can wipe out env vars like `LOGNAME`, which Darshan uses to determine the associated username with a job.

This new configure option allows users to specify additional env vars that can be considered for determining a job's username (e.g., `SLURM_JOB_USER`). If specified, Darshan will consider this provided env var _first_.

In my testing on NERSC Cori, this is all working as expected:
- if this new config option is not specified, Darshan can not determine the username if the user uses the `--export` option to `srun`
- if this new config option is set to `SLURM_JOB_USER`, then Darshan can properly determine the username irrespective of whether the user uses `--export`