### PR TITLE
ENH: reorganize PyDarshan summary reports and add an overview table

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -41,7 +41,11 @@
           % endif
 
           % for fig_title, fig in report_data.sections[sect_title].items():
-            <div>
+            % if not fig.fig_class:
+                <div>
+            % else:
+                <div class="${fig.fig_class}">
+            % endif
             <h3>${fig_title}</h3>
             <figure style="width: ${fig.fig_width}px;">
             % if fig.fig_html:

--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -46,9 +46,7 @@
             % else:
                 <div class="${fig.fig_class}">
             % endif
-            % if fig.fig_title:
-                <h3>${fig.fig_title}</h3>
-            %endif
+            <h3>${fig.fig_title}</h3>
             <figure style="width: ${fig.fig_width}px;">
             % if fig.fig_html:
               ${fig.fig_html}

--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -41,10 +41,10 @@
           % endif
 
           % for fig in report_data.sections[sect_title]:
-            % if not fig.fig_class:
+            % if not fig.fig_grid_area:
                 <div>
             % else:
-                <div class="${fig.fig_class}">
+                <div class="${fig.fig_grid_area}">
             % endif
             <h3>${fig.fig_title}</h3>
             <figure style="width: ${fig.fig_width}px;">

--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -46,7 +46,9 @@
             % else:
                 <div class="${fig.fig_class}">
             % endif
-            <h3>${fig.fig_title}</h3>
+            % if fig.fig_title:
+                <h3>${fig.fig_title}</h3>
+            %endif
             <figure style="width: ${fig.fig_width}px;">
             % if fig.fig_html:
               ${fig.fig_html}

--- a/darshan-util/pydarshan/darshan/cli/base.html
+++ b/darshan-util/pydarshan/darshan/cli/base.html
@@ -40,13 +40,13 @@
             <div>
           % endif
 
-          % for fig_title, fig in report_data.sections[sect_title].items():
+          % for fig in report_data.sections[sect_title]:
             % if not fig.fig_class:
                 <div>
             % else:
                 <div class="${fig.fig_class}">
             % endif
-            <h3>${fig_title}</h3>
+            <h3>${fig.fig_title}</h3>
             <figure style="width: ${fig.fig_width}px;">
             % if fig.fig_html:
               ${fig.fig_html}

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -531,7 +531,6 @@ template {
 .overview { grid-area: overview; font-weight: bold; }
 .file_tbl { grid-area: file_tbl; }
 .op_counts { grid-area: op_counts; }
-.op_pattern { grid-area: op_pattern; }
 .acc_hist { grid-area: acc_hist; }
 .common_acc_tbl { grid-area: common_acc_tbl; }
 
@@ -546,7 +545,7 @@ template {
   grid-template-areas:
     'overview   overview'
     'file_tbl   file_tbl'
-    'op_counts  op_pattern'
+    'op_counts  .'
     'acc_hist   common_acc_tbl';
   gap: 5px;
 }

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -540,8 +540,9 @@ template {
 
 .grid-wrapper {
   display: grid;
-  /* set 2-column-wide grid with auto width scaling*/
+  /* set 2-column-wide grid with auto width scaling */
   grid-template-columns: repeat(2, auto);
+  /* explicit grid areas to control placement of module figures */
   grid-template-areas:
     'overview   overview'
     'file_tbl   file_tbl'

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -527,9 +527,21 @@ template {
 .fixed-footer{
     bottom: 0;
 }
+
+.perf_est { grid-area: perf_est; }
+.file_tbl { grid-area: file_tbl; }
+.op_counts { grid-area: op_counts; }
+.op_pattern { grid-area: op_pattern; }
+.acc_hist { grid-area: acc_hist; }
+.common_acc_tbl { grid-area: common_acc_tbl; }
 .grid-wrapper {
   display: grid;
   /* set 2-column-wide grid with auto width scaling*/
   grid-template-columns: repeat(2, auto);
+  grid-template-areas:
+    'perf_est   perf_est'
+    'file_tbl   file_tbl'
+    'op_counts  op_pattern'
+    'acc_hist   common_acc_tbl';
   gap: 5px;
 }

--- a/darshan-util/pydarshan/darshan/cli/style.css
+++ b/darshan-util/pydarshan/darshan/cli/style.css
@@ -528,18 +528,23 @@ template {
     bottom: 0;
 }
 
-.perf_est { grid-area: perf_est; }
+.overview { grid-area: overview; font-weight: bold; }
 .file_tbl { grid-area: file_tbl; }
 .op_counts { grid-area: op_counts; }
 .op_pattern { grid-area: op_pattern; }
 .acc_hist { grid-area: acc_hist; }
 .common_acc_tbl { grid-area: common_acc_tbl; }
+
+.overview tr:last-child td {
+   color: blue;
+}
+
 .grid-wrapper {
   display: grid;
   /* set 2-column-wide grid with auto width scaling*/
   grid-template-columns: repeat(2, auto);
   grid-template-areas:
-    'perf_est   perf_est'
+    'overview   overview'
     'file_tbl   file_tbl'
     'op_counts  op_pattern'
     'acc_hist   common_acc_tbl';

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -66,8 +66,6 @@ class ReportFigure:
         text_only_color: str = "red",
     ):
         self.section_title = section_title
-        if not fig_title:
-            fig_title = "&nbsp;"
         self.fig_title = fig_title
         self.fig_func = fig_func
         self.fig_args = fig_args

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -540,8 +540,7 @@ class ReportData:
                                             "consecutive (offset immediately following previous offset) "
                                             "file operations. Note that, by definition, the sequential "
                                             "operations are inclusive of consecutive operations.",
-                            fig_width=350,
-                            fig_class="op_pattern"
+                            fig_width=350
                         )
                         self.figures.append(access_pattern_fig)
 

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -66,6 +66,8 @@ class ReportFigure:
         text_only_color: str = "red",
     ):
         self.section_title = section_title
+        if not fig_title:
+            fig_title = "&nbsp;"
         self.fig_title = fig_title
         self.fig_func = fig_func
         self.fig_args = fig_args

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -15,7 +15,7 @@ from mako.template import Template
 import darshan
 import darshan.cli
 from darshan.backend.cffi_backend import accumulate_records
-from darshan.lib.accum import log_get_bytes_bandwidth, log_file_count_summary_table
+from darshan.lib.accum import log_file_count_summary_table, module_overview_table
 from darshan.experimental.plots import (
     plot_dxt_heatmap,
     plot_io_cost,
@@ -506,18 +506,16 @@ class ReportData:
                     rec_dict = self.report.records[mod].to_df()
                     acc = accumulate_records(rec_dict, mod, self.report.metadata['job']['nprocs'])
 
-                    # this is really just some text
-                    # so using ReportFigure feels awkward...
-                    bandwidth_fig = ReportFigure(
+                    mod_overview_fig = ReportFigure(
                             section_title=sect_title,
-                            fig_title="",
-                            fig_func=None,
-                            fig_args=None,
-                            fig_description=log_get_bytes_bandwidth(derived_metrics=acc.derived_metrics,
-                                                                    mod_name=mod),
-                            text_only_color="blue",
-                            fig_class="perf_est")
-                    self.figures.append(bandwidth_fig)
+                            fig_title=f"Overview",
+                            fig_func=module_overview_table,
+                            fig_args=dict(derived_metrics=acc.derived_metrics,
+                                          mod_name=mod),
+                            fig_width=805,
+                            fig_description="",
+                            fig_class="overview")
+                    self.figures.append(mod_overview_fig)
 
                     file_count_summary_fig = ReportFigure(
                             section_title=sect_title,

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -632,12 +632,12 @@ class ReportData:
         self.sections = {}
         for fig in self.figures:
             # if a section title is not already in sections, add
-            # the section title and a corresponding empty dictionary
+            # the section title and a corresponding empty list
             # to store its figures
             if fig.section_title not in self.sections:
-                self.sections[fig.section_title] = {}
+                self.sections[fig.section_title] = []
             # add the image to its corresponding section
-            self.sections[fig.section_title][fig.fig_title] = fig
+            self.sections[fig.section_title].append(fig)
 
 
 def setup_parser(parser: argparse.ArgumentParser):

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -15,7 +15,7 @@ from mako.template import Template
 import darshan
 import darshan.cli
 from darshan.backend.cffi_backend import accumulate_records
-from darshan.lib.accum import log_file_count_summary_table, module_overview_table
+from darshan.lib.accum import log_file_count_summary_table, log_module_overview_table
 from darshan.experimental.plots import (
     plot_dxt_heatmap,
     plot_io_cost,
@@ -511,7 +511,7 @@ class ReportData:
                     mod_overview_fig = ReportFigure(
                             section_title=sect_title,
                             fig_title=f"Overview",
-                            fig_func=module_overview_table,
+                            fig_func=log_module_overview_table,
                             fig_args=dict(derived_metrics=acc.derived_metrics,
                                           mod_name=mod),
                             fig_width=805,

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -47,6 +47,8 @@ class ReportFigure:
 
     fig_width : the width of the figure in pixels.
 
+    fig_class : figure class name for use in style sheet templates.
+
     """
     def __init__(
         self,
@@ -56,6 +58,7 @@ class ReportFigure:
         fig_args: dict,
         fig_description: str = "",
         fig_width: int = 500,
+        fig_class: str = "",
         # when there is no HTML data generated
         # for the figure (i.e., no image/plot),
         # we have the option of changing the caption
@@ -70,6 +73,7 @@ class ReportFigure:
         self.fig_args = fig_args
         self.fig_description = fig_description
         self.fig_width = fig_width
+        self.fig_class = fig_class
         # temporary handling for DXT disabled cases
         # so special error message can be passed
         # in place of an encoded image
@@ -496,6 +500,64 @@ class ReportData:
             else:
                 sect_title = f"Per-Module Statistics: {mod}"
 
+            try:
+                if mod in ["POSIX", "MPI-IO", "STDIO"]:
+                    # get the module's record dataframe and then pass to
+                    # Darshan accumulator interface to generate a cumulative
+                    # record and derived metrics
+                    rec_dict = self.report.records[mod].to_df()
+                    acc = accumulate_records(rec_dict, mod, self.report.metadata['job']['nprocs'])
+
+                    # this is really just some text
+                    # so using ReportFigure feels awkward...
+                    bandwidth_fig = ReportFigure(
+                            section_title=sect_title,
+                            fig_title="",
+                            fig_func=None,
+                            fig_args=None,
+                            fig_description=log_get_bytes_bandwidth(derived_metrics=acc.derived_metrics,
+                                                                    mod_name=mod),
+                            text_only_color="blue",
+                            fig_class="perf_est")
+                    self.figures.append(bandwidth_fig)
+
+                    file_count_summary_fig = ReportFigure(
+                            section_title=sect_title,
+                            fig_title=f"File Count Summary <br> (estimated by {mod} I/O access offsets)",
+                            fig_func=log_file_count_summary_table,
+                            fig_args=dict(derived_metrics=acc.derived_metrics,
+                                          mod_name=mod),
+                            fig_width=805,
+                            fig_description="",
+                            fig_class="file_tbl")
+                    self.figures.append(file_count_summary_fig)
+
+                    if mod == "POSIX":
+                        access_pattern_fig = ReportFigure(
+                            section_title=sect_title,
+                            fig_title="Access Pattern",
+                            fig_func=plot_posix_access_pattern,
+                            fig_args=dict(record=acc.summary_record),
+                            fig_description="Sequential (offset greater than previous offset) vs. "
+                                            "consecutive (offset immediately following previous offset) "
+                                            "file operations. Note that, by definition, the sequential "
+                                            "operations are inclusive of consecutive operations.",
+                            fig_width=350,
+                            fig_class="op_pattern"
+                        )
+                        self.figures.append(access_pattern_fig)
+
+            except (RuntimeError, KeyError):
+                # the module probably doesn't support derived metrics
+                # calculations, but the C code doesn't distinguish other
+                # types of errors
+
+                # the KeyError appears to be needed for a subset of logs
+                # for which _structdefs lacks APMPI or APXC entries;
+                # for example `e3sm_io_heatmap_only.darshan` in logs
+                # repo
+                pass
+
             if mod in ["POSIX", "MPI-IO", "H5D", "PNETCDF_VAR"]:
                 access_hist_description = (
                     "Histogram of read and write access sizes. The specific values "
@@ -509,6 +571,7 @@ class ReportData:
                     fig_args=dict(report=self.report, mod=mod),
                     fig_description=access_hist_description,
                     fig_width=350,
+                    fig_class="acc_hist"
                 )
                 self.figures.append(access_hist_fig)
                 if mod == "MPI-IO":
@@ -525,6 +588,7 @@ class ReportData:
                     fig_args=dict(report=self.report, mod=mod),
                     fig_description=com_acc_tbl_description,
                     fig_width=350,
+                    fig_class="common_acc_tbl"
                 )
                 self.figures.append(com_acc_tbl_fig)
 
@@ -537,63 +601,9 @@ class ReportData:
                     fig_args=dict(report=self.report, mod=mod),
                     fig_description="Histogram of I/O operation frequency.",
                     fig_width=350,
+                    fig_class="op_counts"
                 )
                 self.figures.append(opcount_fig)
-
-            try:
-                if mod in ["POSIX", "MPI-IO", "STDIO"]:
-                    # get the module's record dataframe and then pass to
-                    # Darshan accumulator interface to generate a cumulative
-                    # record and derived metrics
-                    rec_dict = self.report.records[mod].to_df()
-                    nprocs = self.report.metadata['job']['nprocs']
-                    acc = accumulate_records(rec_dict, mod, nprocs)
-
-                    # this is really just some text
-                    # so using ReportFigure feels awkward...
-                    bandwidth_fig = ReportFigure(
-                            section_title=sect_title,
-                            fig_title="",
-                            fig_func=None,
-                            fig_args=None,
-                            fig_description=log_get_bytes_bandwidth(derived_metrics=acc.derived_metrics,
-                                                                    mod_name=mod),
-                            text_only_color="blue")
-                    self.figures.append(bandwidth_fig)
-
-                    if mod == "POSIX":
-                        access_pattern_fig = ReportFigure(
-                            section_title=sect_title,
-                            fig_title="Access Pattern",
-                            fig_func=plot_posix_access_pattern,
-                            fig_args=dict(record=acc.summary_record),
-                            fig_description="Sequential (offset greater than previous offset) vs. "
-                                            "consecutive (offset immediately following previous offset) "
-                                            "file operations. Note that, by definition, the sequential "
-                                            "operations are inclusive of consecutive operations.",
-                            fig_width=350,
-                        )
-                        self.figures.append(access_pattern_fig)
-
-                    file_count_summary_fig = ReportFigure(
-                            section_title=sect_title,
-                            fig_title=f"File Count Summary <br> (estimated by {mod} I/O access offsets)",
-                            fig_func=log_file_count_summary_table,
-                            fig_args=dict(derived_metrics=acc.derived_metrics,
-                                          mod_name=mod),
-                            fig_width=805,
-                            fig_description="")
-                    self.figures.append(file_count_summary_fig)
-            except (RuntimeError, KeyError):
-                # the module probably doesn't support derived metrics
-                # calculations, but the C code doesn't distinguish other
-                # types of errors
-
-                # the KeyError appears to be needed for a subset of logs
-                # for which _structdefs lacks APMPI or APXC entries;
-                # for example `e3sm_io_heatmap_only.darshan` in logs
-                # repo
-                pass
 
 
         #########################

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -47,7 +47,7 @@ class ReportFigure:
 
     fig_width : the width of the figure in pixels.
 
-    fig_class : figure class name for use in style sheet templates.
+    fig_grid_area : figure name corresponding to grid-area definitions specified in the CSS.
 
     """
     def __init__(
@@ -58,7 +58,7 @@ class ReportFigure:
         fig_args: dict,
         fig_description: str = "",
         fig_width: int = 500,
-        fig_class: str = "",
+        fig_grid_area: str = "",
         # when there is no HTML data generated
         # for the figure (i.e., no image/plot),
         # we have the option of changing the caption
@@ -73,7 +73,12 @@ class ReportFigure:
         self.fig_args = fig_args
         self.fig_description = fig_description
         self.fig_width = fig_width
-        self.fig_class = fig_class
+        # grid areas should correspond to defintions of a grid-area
+        # in the CSS code (style.css)
+        # use of grid areas is optional -- if not specified,
+        # figures are placed in insertion order into first available
+        # open grid spaces in the default grid
+        self.fig_grid_area = fig_grid_area
         # temporary handling for DXT disabled cases
         # so special error message can be passed
         # in place of an encoded image
@@ -516,7 +521,7 @@ class ReportData:
                                           mod_name=mod),
                             fig_width=805,
                             fig_description="",
-                            fig_class="overview")
+                            fig_grid_area="overview")
                     self.figures.append(mod_overview_fig)
 
                     file_count_summary_fig = ReportFigure(
@@ -527,7 +532,7 @@ class ReportData:
                                           mod_name=mod),
                             fig_width=805,
                             fig_description="",
-                            fig_class="file_tbl")
+                            fig_grid_area="file_tbl")
                     self.figures.append(file_count_summary_fig)
 
                     if mod == "POSIX":
@@ -568,7 +573,7 @@ class ReportData:
                     fig_args=dict(report=self.report, mod=mod),
                     fig_description=access_hist_description,
                     fig_width=350,
-                    fig_class="acc_hist"
+                    fig_grid_area="acc_hist"
                 )
                 self.figures.append(access_hist_fig)
                 if mod == "MPI-IO":
@@ -585,7 +590,7 @@ class ReportData:
                     fig_args=dict(report=self.report, mod=mod),
                     fig_description=com_acc_tbl_description,
                     fig_width=350,
-                    fig_class="common_acc_tbl"
+                    fig_grid_area="common_acc_tbl"
                 )
                 self.figures.append(com_acc_tbl_fig)
 
@@ -598,7 +603,7 @@ class ReportData:
                     fig_args=dict(report=self.report, mod=mod),
                     fig_description="Histogram of I/O operation frequency.",
                     fig_width=350,
-                    fig_class="op_counts"
+                    fig_grid_area="op_counts"
                 )
                 self.figures.append(opcount_fig)
 

--- a/darshan-util/pydarshan/darshan/lib/accum.py
+++ b/darshan-util/pydarshan/darshan/lib/accum.py
@@ -100,6 +100,31 @@ def log_file_count_summary_table(derived_metrics,
     df.drop(columns="index", inplace=True)
     ret = plot_common_access_table.DarshanReportTable(df,
                                                       col_space=200,
+                                                      border=0,
                                                       justify="center",
                                                       index_names=False)
+    return ret
+
+def module_overview_table(derived_metrics,
+                          mod_name: str):
+    mod_overview = []
+    total_cat = derived_metrics.category_counters[0]
+
+    total_files = total_cat.count
+    indices = ["files accessed", "bytes read", "bytes written", "performance estimate"]
+    mod_overview.append(f"{total_files}")
+    total_bytes_read = total_cat.total_read_volume_bytes
+    total_bytes_read_str = humanize.naturalsize(total_bytes_read, binary=True, format="%.2f")
+    total_bytes_written = total_cat.total_write_volume_bytes
+    total_bytes_written_str = humanize.naturalsize(total_bytes_written, binary=True, format="%.2f")
+    mod_overview.append(f"{total_bytes_read_str}")
+    mod_overview.append(f"{total_bytes_written_str}")
+    total_bw = derived_metrics.agg_perf_by_slowest
+    mod_overview.append(f"{total_bw:.2f} MiB/s (average)")
+    df = pd.DataFrame(mod_overview, index=indices)
+
+    ret = plot_common_access_table.DarshanReportTable(df,
+                                                      col_space=500,
+                                                      border=0,
+                                                      header=False)
     return ret

--- a/darshan-util/pydarshan/darshan/lib/accum.py
+++ b/darshan-util/pydarshan/darshan/lib/accum.py
@@ -111,7 +111,7 @@ def module_overview_table(derived_metrics,
     total_cat = derived_metrics.category_counters[0]
 
     total_files = total_cat.count
-    indices = ["files accessed", "bytes read", "bytes written", "performance estimate"]
+    indices = ["files accessed", "bytes read", "bytes written", "I/O performance estimate"]
     mod_overview.append(f"{total_files}")
     total_bytes_read = total_cat.total_read_volume_bytes
     total_bytes_read_str = humanize.naturalsize(total_bytes_read, binary=True, format="%.2f")

--- a/darshan-util/pydarshan/darshan/lib/accum.py
+++ b/darshan-util/pydarshan/darshan/lib/accum.py
@@ -8,57 +8,6 @@ import pandas as pd
 import humanize
 
 
-def log_get_bytes_bandwidth(derived_metrics, mod_name: str) -> str:
-    """
-    Summarize I/O performance for a given darshan module.
-
-    Parameters
-    ----------
-    derived_metrics:
-        structure (cdata object) describing metrics derived from a
-        set of records passed to the Darshan accumulator interface
-    mod_name: str
-        Name of the darshan module to summarize the I/O
-        performance for.
-
-    Returns
-    -------
-    out: str
-        A short string summarizing the performance of the given module
-        in the provided log file, including bandwidth and total data
-        transferred.
-
-    Raises
-    ------
-    RuntimeError
-        When a provided module name is not supported for the accumulator
-        interface for provision of the summary data, or for any other
-        error that occurs in the C/CFFI interface.
-    ValueError
-        When a provided module name does not exist in the log file.
-
-    Examples
-    --------
-
-    >>> from darshan.log_utils import get_log_path
-    >>> from darshan.lib.accum import log_get_bytes_bandwidth
-
-    >>> log_path = get_log_path("imbalanced-io.darshan")
-    >>> log_get_bytes_bandwidth(log_path, "POSIX")
-    I/O performance estimate (at the POSIX layer): transferred 101785.8 MiB at 164.99 MiB/s
-
-    >>> log_get_bytes_bandwidth(log_path, "MPI-IO")
-    I/O performance estimate (at the MPI-IO layer): transferred 126326.8 MiB at 101.58 MiB/s
-    """
-    # get total bytes (in MiB) and bandwidth (in MiB/s) for
-    # a given module -- this information was commonly reported
-    # in the old perl-based summary reports
-    total_mib = derived_metrics.total_bytes / 2 ** 20
-    total_bw = derived_metrics.agg_perf_by_slowest
-    ret_str = f"I/O performance estimate (at the {mod_name} layer): transferred {total_mib:.1f} MiB at {total_bw:.2f} MiB/s"
-    return ret_str
-
-
 def log_file_count_summary_table(derived_metrics,
                                  mod_name: str):
     # the darshan_file_category enum is not really
@@ -105,8 +54,8 @@ def log_file_count_summary_table(derived_metrics,
                                                       index_names=False)
     return ret
 
-def module_overview_table(derived_metrics,
-                          mod_name: str):
+def log_module_overview_table(derived_metrics,
+                              mod_name: str):
     mod_overview = []
     total_cat = derived_metrics.category_counters[0]
 

--- a/darshan-util/pydarshan/darshan/tests/test_lib_accum.py
+++ b/darshan-util/pydarshan/darshan/tests/test_lib_accum.py
@@ -1,99 +1,11 @@
 import darshan
 from darshan.backend.cffi_backend import accumulate_records
-from darshan.lib.accum import log_get_bytes_bandwidth, log_file_count_summary_table
+from darshan.lib.accum import log_file_count_summary_table, log_module_overview_table
 from darshan.log_utils import get_log_path
 
 import pytest
 import pandas as pd
 from pandas.testing import assert_frame_equal
-
-@pytest.mark.parametrize("log_path, mod_name, expected_str", [
-    # the expected bytes/bandwidth strings are pasted
-    # directly from the old perl summary reports;
-    # exceptions noted below
-    # in some cases we defer to darshan-parser for the expected
-    # values; see discussion in gh-839
-    ("imbalanced-io.darshan",
-     "STDIO",
-     "I/O performance estimate (at the STDIO layer): transferred 1.1 MiB at 0.01 MiB/s"),
-    ("imbalanced-io.darshan",
-     "MPI-IO",
-     "I/O performance estimate (at the MPI-IO layer): transferred 126326.8 MiB at 101.58 MiB/s"),
-    # imbalanced-io.darshan does have LUSTRE data,
-    # but it doesn't support derived metrics at time
-    # of writing
-    ("imbalanced-io.darshan",
-     "LUSTRE",
-     "RuntimeError"),
-    # APMPI doesn't support derived metrics either
-    ("e3sm_io_heatmap_only.darshan",
-     "APMPI",
-     "RuntimeError"),
-    ("imbalanced-io.darshan",
-     "POSIX",
-     "I/O performance estimate (at the POSIX layer): transferred 101785.8 MiB at 164.99 MiB/s"),
-    ("laytonjb_test1_id28730_6-7-43012-2131301613401632697_1.darshan",
-     "STDIO",
-     "I/O performance estimate (at the STDIO layer): transferred 0.0 MiB at 4.22 MiB/s"),
-    ("runtime_and_dxt_heatmaps_diagonal_write_only.darshan",
-     "POSIX",
-     "I/O performance estimate (at the POSIX layer): transferred 0.0 MiB at 0.02 MiB/s"),
-    ("treddy_mpi-io-test_id4373053_6-2-60198-9815401321915095332_1.darshan",
-     "STDIO",
-     "I/O performance estimate (at the STDIO layer): transferred 0.0 MiB at 16.47 MiB/s"),
-    ("e3sm_io_heatmap_only.darshan",
-     "STDIO",
-     "I/O performance estimate (at the STDIO layer): transferred 0.0 MiB at 3.26 MiB/s"),
-    ("e3sm_io_heatmap_only.darshan",
-     "MPI-IO",
-     "I/O performance estimate (at the MPI-IO layer): transferred 73880.2 MiB at 105.69 MiB/s"),
-    ("partial_data_stdio.darshan",
-     "MPI-IO",
-     "I/O performance estimate (at the MPI-IO layer): transferred 32.0 MiB at 2317.98 MiB/s"),
-    ("partial_data_stdio.darshan",
-     "STDIO",
-     "I/O performance estimate (at the STDIO layer): transferred 16336.0 MiB at 2999.14 MiB/s"),
-    # the C derived metrics code can't distinguish
-    # between different kinds of errors at this time,
-    # but we can still intercept in some cases...
-    ("partial_data_stdio.darshan",
-     "GARBAGE",
-     "ValueError"),
-    ("skew-app.darshan",
-     "POSIX",
-     "I/O performance estimate (at the POSIX layer): transferred 41615.8 MiB at 157.49 MiB/s"),
-    ("skew-app.darshan",
-     "MPI-IO",
-     "I/O performance estimate (at the MPI-IO layer): transferred 41615.8 MiB at 55.22 MiB/s"),
-])
-def test_derived_metrics_bytes_and_bandwidth(log_path, mod_name, expected_str):
-    # test the basic scenario of retrieving
-    # the total data transferred and bandwidth
-    # for all records in a given module; the situation
-    # of accumulating derived metrics with filtering
-    # (i.e., for a single filename) is not tested here
-
-    log_path = get_log_path(log_path)
-    with darshan.DarshanReport(log_path, read_all=True) as report:
-        if expected_str == "ValueError":
-            with pytest.raises(ValueError,
-                               match=f"mod {mod_name} is not available"):
-                report.mod_read_all_records(mod_name, dtype="pandas")
-        else:
-            report.mod_read_all_records(mod_name, dtype="pandas")
-            rec_dict = report.records[mod_name][0]
-            nprocs = report.metadata['job']['nprocs']
-
-            if expected_str == "RuntimeError":
-                with pytest.raises(RuntimeError,
-                                   match=f"{mod_name} module does not support derived"):
-                    accumulate_records(rec_dict, mod_name, nprocs)
-            else:
-                derived_metrics = accumulate_records(rec_dict, mod_name, nprocs).derived_metrics
-                actual_str = log_get_bytes_bandwidth(derived_metrics=derived_metrics,
-                                                     mod_name=mod_name)
-                assert actual_str == expected_str
-
 
 @pytest.mark.parametrize("log_name, mod_name, expected", [
     # we try to match the "File Count Summary"
@@ -215,3 +127,98 @@ def test_file_count_summary_table(log_name,
     actual_df = log_file_count_summary_table(derived_metrics=derived_metrics,
                                              mod_name=mod_name).df
     assert_frame_equal(actual_df, expected_df)
+
+
+@pytest.mark.parametrize("log_path, mod_name, expected", [
+    ("imbalanced-io.darshan",
+     "STDIO",
+     # <files accessed> <bytes read> <bytes written> <I/O performance estimate>
+     [["12", "1.81 KiB", "1.09 MiB", "0.01 MiB/s (average)"]]),
+    ("imbalanced-io.darshan",
+     "MPI-IO",
+     [["3", "49.30 GiB", "74.06 GiB", "101.58 MiB/s (average)"]]),
+    # imbalanced-io.darshan does have LUSTRE data,
+    # but it doesn't support derived metrics at time
+    # of writing
+    ("imbalanced-io.darshan",
+     "LUSTRE",
+     "RuntimeError"),
+    # APMPI doesn't support derived metrics either
+    ("e3sm_io_heatmap_only.darshan",
+     "APMPI",
+     "RuntimeError"),
+    ("imbalanced-io.darshan",
+     "POSIX",
+     [["1026", "50.10 GiB", "49.30 GiB", "164.99 MiB/s (average)"]]),
+    ("laytonjb_test1_id28730_6-7-43012-2131301613401632697_1.darshan",
+     "STDIO",
+     [["1", "0 Bytes", "151 Bytes", "4.22 MiB/s (average)"]]),
+    ("runtime_and_dxt_heatmaps_diagonal_write_only.darshan",
+     "POSIX",
+     [["32", "0 Bytes", "32 Bytes", "0.02 MiB/s (average)"]]),
+    ("treddy_mpi-io-test_id4373053_6-2-60198-9815401321915095332_1.darshan",
+     "STDIO",
+     [["1", "0 Bytes", "1.59 KiB", "16.47 MiB/s (average)"]]),
+    ("e3sm_io_heatmap_only.darshan",
+     "STDIO",
+     [["1", "0 Bytes", "5.80 KiB", "3.26 MiB/s (average)"]]),
+    ("e3sm_io_heatmap_only.darshan",
+     "MPI-IO",
+     [["3", "24.53 MiB", "72.12 GiB", "105.69 MiB/s (average)"]]),
+    ("partial_data_stdio.darshan",
+     "MPI-IO",
+     [["1", "16.00 MiB", "16.00 MiB", "2317.98 MiB/s (average)"]]),
+    ("partial_data_stdio.darshan",
+     "STDIO",
+     [["1022", "0 Bytes", "15.95 GiB", "2999.14 MiB/s (average)"]]),
+    # the C derived metrics code can't distinguish
+    # between different kinds of errors at this time,
+    # but we can still intercept in some cases...
+    ("partial_data_stdio.darshan",
+     "GARBAGE",
+     "ValueError"),
+    ("skew-app.darshan",
+     "POSIX",
+     [["1", "0 Bytes", "40.64 GiB", "157.49 MiB/s (average)"]]),
+    ("skew-app.darshan",
+     "MPI-IO",
+     [["1", "0 Bytes", "40.64 GiB", "55.22 MiB/s (average)"]]),
+])
+def test_module_overview_table(log_path, mod_name, expected):
+    # test the basic scenario of retrieving
+    # an overview table for a given module
+    log_path = get_log_path(log_path)
+    with darshan.DarshanReport(log_path, read_all=False) as report:
+        if expected == "ValueError":
+            with pytest.raises(ValueError,
+                               match=f"mod {mod_name} is not available"):
+                report.mod_read_all_records(mod_name)
+        else:
+            nprocs = report.metadata['job']['nprocs']
+            if expected == "RuntimeError":
+                # rec_dict not needed to raise this error
+                rec_dict = {}
+                with pytest.raises(RuntimeError,
+                                   match=f"{mod_name} module does not support derived"):
+                    accumulate_records(rec_dict, mod_name, nprocs)
+            else:
+                report.mod_read_all_records(mod_name)
+                rec_dict = report.records[mod_name].to_df()
+
+                derived_metrics = accumulate_records(
+                    rec_dict,
+                    mod_name,
+                    nprocs).derived_metrics
+
+                actual_df = log_module_overview_table(
+                    derived_metrics=derived_metrics,
+                    mod_name=mod_name).df
+
+                # transpose expected series to get a column of expected data
+                expected_df = pd.DataFrame(expected).T
+                expected_df.index = ["files accessed",
+                                     "bytes read",
+                                     "bytes written",
+                                     "I/O performance estimate"]
+
+                assert_frame_equal(actual_df, expected_df)

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -97,13 +97,13 @@ def test_main_with_args(tmpdir, argv):
 
 @pytest.mark.parametrize(
     "argv, expected_img_count, expected_table_count", [
-        (["noposix.darshan"], 3, 3),
-        (["noposix.darshan", "--output=test.html"], 3, 3),
-        (["sample-dxt-simple.darshan"], 7, 6),
-        (["sample-dxt-simple.darshan", "--output=test.html"], 7, 6),
-        (["sample-dxt-simple.darshan", "--enable_dxt_heatmap"], 9, 6),
-        (["nonmpi_dxt_anonymized.darshan"], 6, 5),
-        (["ior_hdf5_example.darshan"], 10, 8),
+        (["noposix.darshan"], 3, 4),
+        (["noposix.darshan", "--output=test.html"], 3, 4),
+        (["sample-dxt-simple.darshan"], 7, 8),
+        (["sample-dxt-simple.darshan", "--output=test.html"], 7, 8),
+        (["sample-dxt-simple.darshan", "--enable_dxt_heatmap"], 9, 8),
+        (["nonmpi_dxt_anonymized.darshan"], 6, 7),
+        (["ior_hdf5_example.darshan"], 10, 11),
         ([None], 0, 0),
     ]
 )


### PR DESCRIPTION
I tried to accomplish a couple of goals here:

1. Force specific module figures to always appear in the same location  for each module.
2. Add a simple overview table for modules that support accumulation that replaces the performance estimate string.

Without 1), our current CSS grid for module data just packs 2 figures to a row without any real mechanisms to control how many figures can go on a line, which figures can be positioned side-by-side, etc. Figures are currently added in the order they are registered in the summary code, but different modules have different number of figures so there's not really a simple way to ensure figure organization is uniform across modules.

To help with this, I quickly adopted some CSS code to more explicitly place module figures in a fixed grid. The summary code can now specify a `class` for registered report figures which corresponds to grid areas maintained in the CSS stylesheet. This allows us to ensure figures are placed in certain locations, that some figures are not meant to share lines, etc. We will need to take care to maintain this as we add new figures -- if figures don't specify an explicit grid area they are placed in the first available grid area, which might throw things off. New figures are added seldom enough that I doubt this is a huge deal.

For 2), I've just added a new overview table that highlights a few key details about modules that support accumulation. This includes the performance estimate, which still is displayed in blue text (though this is accomplished via CSS now) -- pandas `style` seems to require Jinja and I'd like to avoid bringing it in if we can help it.

A couple of smaller things I've done:
- changed `report_data.sections` from dict to a list
    - I was tinkering and noticed that adding 2 text boxes to a single report section currently doesn't work because the dictionary is keyed using the figure title (which is usually blank for text boxes). There's not really a good reason to use a dictionary over a list, so I made this small change to avoid this going forward.
- ~~updated the base HTML code to avoid placing an `<h3></h3>` heading for a figure title if one is not provided to avoid unnecessary whitespace around text boxes~~

TODO before merge:

- [x] add tests
    - I'm open to suggestions, but at the very least this involves adding similar testing to what we have for the prior performance estimate string, as well as some simple tests to ensure certain figures come before or after other figures in module sections or something like that?
- [x] update docstrings to explain new `class` option used for placing figures in a CSS grid