### PR TITLE
WIP, ENH: parquet demo

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_common_access_table.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_common_access_table.py
@@ -145,7 +145,11 @@ def plot_common_access_table(report: darshan.DarshanReport, mod: str, n_rows: in
     the `df` or `html` attributes, respectively.
 
     """
-    mod_df = report.records[mod].to_df(attach=None)["counters"]
+    try:
+        mod_df = report.records[mod].to_df(attach=None)["counters"]
+    except AttributeError:
+        # TODO: fix for parquet format
+        mod_df = report.iloc[..., :71]
 
     if mod == "MPI-IO":
         mod = "MPIIO"

--- a/darshan-util/pydarshan/darshan/tests/test_log_utils.py
+++ b/darshan-util/pydarshan/darshan/tests/test_log_utils.py
@@ -1,8 +1,10 @@
 import os
 
 import darshan
-from darshan.log_utils import get_log_path
+from darshan.log_utils import get_log_path, convert_to_parquet
 
+import numpy as np
+import pandas as pd
 import pytest
 
 
@@ -52,3 +54,39 @@ def test_failure_bad_logname():
     with pytest.raises(FileNotFoundError,
                        match="could not be found"):
         get_log_path("garbage_$*(&**.darshan")
+
+
+@pytest.mark.parametrize("log_filename", [
+    "runtime_and_dxt_heatmaps_diagonal_write_only.darshan",
+    ])
+def test_parquet_convert_simple(tmp_path, log_filename):
+    # crude/early stage testing for conversion from
+    # in-house binary darshan log format to parquet
+    # file format
+    try:
+        import pyarrow
+    except ImportError:
+        pytest.skip("pyarrow required for this test")
+    log_path = get_log_path(log_filename)
+    outfile = tmp_path / f"{log_filename}.gzip"
+    convert_to_parquet(log_path, outfile)
+    # check for appropriate data shape
+    # (POSIX module only for now)
+    actual_df = pd.read_parquet(outfile)
+    # there are 32 active ranks, and 71
+    # counter columns + 17 fcounter columns
+    # for POSIX (we don't repeat rank and id)
+    assert actual_df.shape == (32, 88)
+    actual_dtypes = actual_df.dtypes.values
+    # rank is first column and should be int64
+    assert actual_dtypes[0] == np.int64
+    # id is second column and should be uint64
+    assert actual_dtypes[1] == np.uint64
+    # next 30 columns should be int64 counters
+    counter_type = np.unique(actual_dtypes[2:71])
+    assert counter_type.size == 1
+    assert counter_type[0] == np.int64
+    # next 17 columns should float64 fcounters
+    fcounter_type = np.unique(actual_dtypes[71:88])
+    assert fcounter_type.size == 1
+    assert fcounter_type[0] == np.float64


### PR DESCRIPTION
We've had some discussions about supporting a parquet or arrow-like format to avoid the various idiosyncrancies and performance issues related to the in-house binary format, possibly through a converter of the binary format to parquet format. This is more of a demo than something that is meant for serious code review, for now...

* a quick demo with POSIX-only support for a single summary report plot for parquet input, and a converter that only support POSIX and was only tested on a single log file

* this does appear to allow the full test suite to pass while adding incredeibly-crude summary report support for working with a parquet file that has POSIX counter/fcounter data

* there are a few reasons to demo this:

1) It may help spark some discussion about how this should work because I already made some potentially-controversial decisions like concatenating along the columns to fuse counter and fcounters 
2) The various `TODO` comments I added around try/except blocks should give a good indicator of the number of places in the code where changes would be needed to produce a more complete summary report from parquet input
3) Sometimes it is easier to develop from a (crude) prototype if a summer student picks this up (vs. from scratch)

The example below shows what happens when producing the summary report with the 1 parquet file I tested with. It correctly reproduces a single plot in the report since that is all I added support for, for now. Perhaps the other notable observations is that the gzipped parquet file is about 7X larger than the native binary file, and the native binary also contains more raw data because we're currently excluding `DXT_POSIX` for the parquet format, for now. I don't consider file size/compression a priority at this stage of development/consideration though.

`python -m darshan summary /Users/treddy/rough_work/darshan/test_parquet/runtime_and_dxt_heatmaps_diagonal_write_only.parquet.gzip`

![image](https://user-images.githubusercontent.com/7903078/236646218-5c875299-fc2a-429d-ad84-51d6338aeb58.png)
