### PR TITLE
DOC: PyDarshan doc improvements

### DIFF
--- a/darshan-util/pydarshan/README.rst
+++ b/darshan-util/pydarshan/README.rst
@@ -2,16 +2,16 @@
 PyDarshan Documentation
 =======================
 
-Python utilities to interact with Darshan log records of HPC applications.
-PyDarshan requires darshan-utils version 3.3 or higher to be installed.
+Python utilities to interact with `Darshan <https://www.mcs.anl.gov/research/projects/darshan/>`__
+log records of HPC applications.
 
 Features
 --------
 
-* Darshan Report Object for common interactive analysis tasks
-* Low-level CFFI bindings for efficient access to darshan log files
-* Plots typically found in the darshan reports (matplotlib)
-* Bundled with darshan-utils while allowing site's darshan-utils to take precedence
+* Job summary tool for generating HTML reports of I/O activity in a Darshan log
+* Darshan Report interface for common interactive analysis tasks
+* Low-level CFFI bindings for efficient access to Darshan log files
+* Generic plotting capabilities (matplotlib) for Darshan log data
 
 
 Usage
@@ -19,26 +19,7 @@ Usage
 
 For examples and Jupyter notebooks to get started with PyDarshan make sure
 to check out the `examples` subdirectory.
-
-A brief examples showing some of the basic functionality is the following::
-
-    import darshan
-
-    # Open darshan log
-    with darshan.DarshanReport('example.darshan', read_all=False) as report:
-
-        # Load some report data
-        report.mod_read_all_records('POSIX')
-        report.mod_read_all_records('MPI-IO')
-        # or fetch all
-        report.read_all_generic_records()
-
-        # ...
-        # Generate summaries for currently loaded data
-        # Note: aggregations are still experimental and have to be activated:
-        darshan.enable_experimental()
-        report.summarize()
-
+Brief usage examples are also provided in :ref:`usage`.
 
 
 Installation
@@ -46,9 +27,9 @@ Installation
 
 To install in most cases the following will work::
 
-    pip install --user darshan
+    pip install darshan
 
-For alternative installation instructions and installation from source refer to <docs/install.rst>
+For more detailed installation instructions, refer to :ref:`installation`.
 
 
 Testing
@@ -75,10 +56,9 @@ Conformance to PEPs can be tested using flake8 via::
 Documentation
 -------------
 
-Documentation for the python bindings is generated seperatedly from the 
-darshan-utils C library in the interest of using Sphinx. After installing the
-developement requirements using `pip install -r requirements_dev.txt` the
-documentation can be build using make as follows::
+Documentation for the Python bindings is generated seperately from the
+darshan-util C library in the interest of using Sphinx. After installing the
+developement requirements the documentation can be built using make as follows::
 
     pip install -r requirements_dev.txt
     make docs

--- a/darshan-util/pydarshan/README.rst
+++ b/darshan-util/pydarshan/README.rst
@@ -40,7 +40,7 @@ test suite use::
 
     make test
 
-Or to test against different version of Python using Tox::
+Or to test against a different version of Python using Tox::
 
     make test-all
 
@@ -56,9 +56,9 @@ Conformance to PEPs can be tested using flake8 via::
 Documentation
 -------------
 
-Documentation for the Python bindings is generated seperately from the
+Documentation for the Python bindings is generated separately from the
 darshan-util C library in the interest of using Sphinx. After installing the
-developement requirements the documentation can be built using make as follows::
+development requirements the documentation can be built using make as follows::
 
     pip install -r requirements_dev.txt
     make docs
@@ -69,17 +69,17 @@ File List
 * darshan::
     core darshan python module code
 * devel::
-    scripts for building python wheel
+    scripts for building Python wheel
 * docs::
     markdown documentation used by sphinx to auto-generate HTML RTD style doc
 * examples::
     Jupyter notebooks showing PyDarshan usage with log files
 * tests::
-    PyDarshan specific test cases
+    PyDarshan-specific test cases
 * requirements.txt::
-    pip requirement file for minimum set of depednencies
+    pip requirement file for minimum set of dependencies
 * requirements_dev.txt::
-    pip requirement file for depednencies needed to run development tools
+    pip requirement file for dependencies needed to run development tools
 * setup.py::
     python file for building/generating PyDarshan package
 * setup.cfg::

--- a/darshan-util/pydarshan/docs/index.rst
+++ b/darshan-util/pydarshan/docs/index.rst
@@ -1,5 +1,5 @@
 .. note::
-    This documenation is only for the PyDarshan log analysis framework.
+    This documentation is only for the PyDarshan log analysis framework.
     Refer to the `darshan-runtime <http://www.mcs.anl.gov/research/projects/darshan/docs/darshan-runtime.html>`__
     and `darshan-util <http://www.mcs.anl.gov/research/projects/darshan/docs/darshan-util.html>`__
     documentation for more information on how to install and use these components.

--- a/darshan-util/pydarshan/docs/index.rst
+++ b/darshan-util/pydarshan/docs/index.rst
@@ -1,5 +1,8 @@
 .. note::
-    This documenation is only for the Darshan Python bindings, for information on the runtime and utility components refer to `Darshan Runtime and Utilities Documentation <https://www.mcs.anl.gov/research/projects/darshan/>`__.
+    This documenation is only for the PyDarshan log analysis framework.
+    Refer to the `darshan-runtime <http://www.mcs.anl.gov/research/projects/darshan/docs/darshan-runtime.html>`__
+    and `darshan-util <http://www.mcs.anl.gov/research/projects/darshan/docs/darshan-util.html>`__
+    documentation for more information on how to install and use these components.
 
 
 

--- a/darshan-util/pydarshan/docs/install.rst
+++ b/darshan-util/pydarshan/docs/install.rst
@@ -17,8 +17,9 @@ releases directly from PyPI:
 
     $ pip install darshan
 
-PyDarshan releases on PyPI include manylinux and macOS wheels that simplify
+PyDarshan releases on PyPI include manylinux and macOS binary wheels that simplify
 distribution of PyDarshan and its dependencies for most users.
+Note that these binary wheels are currently only available for x86 architectures.
 
 .. _pip: https://pip.pypa.io
 
@@ -52,14 +53,22 @@ Users can then use ``pip`` to install the PyDarshan package from source.
     $ pip install .
 
 When building PyDarshan from sources, users need to make a copy of the darshan-util shared
-library available, typically using `LD_LIBRARY_PATH`.
+library available.
+On Linux systems, this is typically accomplished using `LD_LIBRARY_PATH`.
 
 .. code-block:: console
 
     $ export LD_LIBRARY_PATH=/path/to/darshan/install/lib:$LD_LIBRARY_PATH
 
+On macOS systems, `DYLD_FALLBACK_LIBRARY_PATH` should be used instead.
+
+.. code-block:: console
+
+    $ export DYLD_FALLBACK_LIBRARY_PATH=/path/to/darshan/install/lib:$DYLD_FALLBACK_LIBRARY_PATH
+
 Refer to the `darshan-util docs`_ for details on how to install the shared library.
-PyPI- and Spack-based installs typically do not have to worry about this step.
+PyPI- and Spack-based installs typically do not have to worry about this step on platforms
+for which we provide binary wheels.
 Note that PyDarshan requires a compatible darshan-util version (e.g., 3.4.2.x versions of
 PyDarshan require a darshan-util version of 3.4.2).
 

--- a/darshan-util/pydarshan/docs/install.rst
+++ b/darshan-util/pydarshan/docs/install.rst
@@ -70,7 +70,7 @@ Refer to the `darshan-util docs`_ for details on how to install the shared libra
 PyPI- and Spack-based installs typically do not have to worry about this step on platforms
 for which we provide binary wheels.
 Note that PyDarshan requires a compatible darshan-util version (e.g., 3.4.2.x versions of
-PyDarshan require a darshan-util version of 3.4.2).
+PyDarshan requires a darshan-util version of 3.4.2).
 
 .. _Darshan Github repo: https://github.com/darshan-hpc/darshan.git
 .. _darshan-util docs: https://www.mcs.anl.gov/research/projects/darshan/docs/darshan-util.html

--- a/darshan-util/pydarshan/docs/install.rst
+++ b/darshan-util/pydarshan/docs/install.rst
@@ -1,33 +1,36 @@
 .. highlight:: shell
 
+.. _installation:
+
 ============
 Installation
 ============
 
 
-Stable release
---------------
+Stable release (PyPI)
+---------------------
 
-To install PyDarshan, run this command in your terminal:
+The preferred method for installing PyDarshan is to use `pip`_ to install stable
+releases directly from PyPI:
 
 .. code-block:: console
 
     $ pip install darshan
 
-This is the preferred method to install PyDarshan, as it will always install the most recent stable release.
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
+PyDarshan releases on PyPI include manylinux and macOS wheels that simplify
+distribution of PyDarshan and its dependencies for most users.
 
 .. _pip: https://pip.pypa.io
-.. _Python installation guide: https://www.mcs.anl.gov/research/projects/darshan/
 
 
-PyDarshan assumes that a recent 'darshan-utils' is installed as a shared
-library. If darshan-util is not installed consult with the darshan
-documentation or consider using `Spack`_ to install::
+From Spack
+----------
 
-    spack install darshan-util
+PyDarshan is also available within the `Spack`_ package manager.
 
+.. code-block:: console
+
+    $ spack install py-darshan
 
 .. _Spack: https://spack.io/
 
@@ -35,19 +38,30 @@ documentation or consider using `Spack`_ to install::
 From sources
 ------------
 
-The sources for PyDarshan can be downloaded from the `Github repo`_.
-
-You can either clone the public repository:
+The sources for PyDarshan can be obtained as part of the `Darshan Github repo`_, as shown below.
 
 .. code-block:: console
 
     $ git clone https://github.com/darshan-hpc/darshan.git
     $ cd darshan/darshan-util/pydarshan
 
+Users can then use ``pip`` to install the PyDarshan package from source.
 
 .. code-block:: console
 
-    $ python setup.py install
+    $ pip install .
 
+When building PyDarshan from sources, users need to make a copy of the darshan-util shared
+library available, typically using `LD_LIBRARY_PATH`.
 
-.. _Github repo: https://github.com/darshan-hpc/darshan.git
+.. code-block:: console
+
+    $ export LD_LIBRARY_PATH=/path/to/darshan/install/lib:$LD_LIBRARY_PATH
+
+Refer to the `darshan-util docs`_ for details on how to install the shared library.
+PyPI- and Spack-based installs typically do not have to worry about this step.
+Note that PyDarshan requires a compatible darshan-util version (e.g., 3.4.2.x versions of
+PyDarshan require a darshan-util version of 3.4.2).
+
+.. _Darshan Github repo: https://github.com/darshan-hpc/darshan.git
+.. _darshan-util docs: https://www.mcs.anl.gov/research/projects/darshan/docs/darshan-util.html

--- a/darshan-util/pydarshan/docs/usage.rst
+++ b/darshan-util/pydarshan/docs/usage.rst
@@ -64,7 +64,7 @@ DataFrame. ::
 Darshan CFFI backend interface
 ------------------------------
 
-Generally, it is more convienient to access a Darshan log from Python using the `Report`
+Generally, it is more convenient to access a Darshan log from Python using the `Report`
 interface, which also caches already fetched information such as log records on a
 per-module basis.
 If this seems like an unwanted overhead, the CFFI interface can be used directly to gain

--- a/darshan-util/pydarshan/docs/usage.rst
+++ b/darshan-util/pydarshan/docs/usage.rst
@@ -11,7 +11,7 @@ As a starting point, users can use PyDarshan to generate detailed
 summary HTML reports of I/O activity for a given Darshan log.
 Usage of this job summary tool is described below. ::
 
-    usage: darshan <command> summary [-h] [--output OUTPUT] [--enable_dxt_heatmap] log_path
+    usage: darshan summary [-h] [--output OUTPUT] [--enable_dxt_heatmap] log_path
 
     Generates a Darshan Summary Report
 

--- a/darshan-util/pydarshan/docs/usage.rst
+++ b/darshan-util/pydarshan/docs/usage.rst
@@ -1,41 +1,79 @@
+.. _usage:
+
 =====
 Usage
 =====
 
+Darshan job summary tool
+------------------------
 
-Darshan Report Object Interface
--------------------------------
+As a starting point, users can use PyDarshan to generate detailed
+summary HTML reports of I/O activity for a given Darshan log.
+Usage of this job summary tool is described below. ::
 
-To get started with PyDarshan you can simply use::
+    usage: darshan <command> summary [-h] [--output OUTPUT] [--enable_dxt_heatmap] log_path
+
+    Generates a Darshan Summary Report
+
+    positional arguments:
+      log_path              Specify path to darshan log.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --output OUTPUT       Specify output filename.
+      --enable_dxt_heatmap  Enable DXT-based versions of I/O activity heatmaps.
+
+For example, the following command would generate an HTML job summary report
+for a Darshan log file named `example.darshan`.
+
+.. code-block:: console
+
+    $ python -m darshan summary example.darshan
+
+If ``--output`` option is not specified, the output HTML report will be based
+on the input log file name (i.e., the above command would generate an HTML
+report named `example_report.html`).
+
+Darshan Report interface
+------------------------
+
+Users can use the Darshan `Report` interface to help develop custom log analysis tools.
+The example below demonstrates how to use this interface to open a Darshan log file,
+read in log metadata and instrumentation records, and export record data to a pandas
+DataFrame. ::
 
     import darshan
 
-    with darshan.DarshanReport(filename) as report:
+    # open a Darshan log file and read all data stored in it
+    with darshan.DarshanReport(filename, read_all=True) as report:
 
-        # read metadata, log records and name records
-        report.read_all_generic_records()
+        # print the metadata dict for this log
+        print("metadata: ", report.metadata)
+        # print job runtime and nprocs
+        print("run_time: ", report.metadata['job']['run_time'])
+        print("nprocs: ", report.metadata['job']['nprocs'])
 
+        # print modules contained in the report
+        print("modules: ", list(report.modules.keys()))
 
-        # Python aggregations are still experimental and have to be activated:
-        # calculate or update aggregate statistics for currently loaded records
-        darshan.enable_experimental()
-        report.summarize()
-
-
-        print(report.report)
-
-
-
-Directly interfacing through the CFFI Interface Wrappers
---------------------------------------------------------
-
-Generally, it is more convienient to access a darshan log from Python using the default report object interface which also caches already fetched information such as log records on a per module basis.
-If this seems like an unwanted overhead the CFFI interface can be used to gain fine-grained control about which information are being loaded.
+        # export POSIX module records to DataFrame and print
+        posix_df = report.records['POSIX'].to_df()
+        print("POSIX df: ", posix_df)
 
 
-To use pydarshan.cffi_parser in a project::
+Darshan CFFI backend interface
+------------------------------
 
-    import darshan.backends.cffi_backend as darshanll
+Generally, it is more convienient to access a Darshan log from Python using the `Report`
+interface, which also caches already fetched information such as log records on a
+per-module basis.
+If this seems like an unwanted overhead, the CFFI interface can be used directly to gain
+fine-grained control over what log data is being loaded.
+
+The example below demonstrates some usage of the CFFI backend for opening a
+log file and accessing different types of log data::
+
+    import darshan.backend.cffi_backend as darshanll
 
     log = darshanll.log_open("example.darshan")
 
@@ -57,13 +95,11 @@ To use pydarshan.cffi_parser in a project::
     #  'LUSTRE': {'len': 87, 'ver': 1, 'idx': 6},
     #  'STDIO': {'len': 3234, 'ver': 1, 'idx': 7}}
 
-
-    # Access different record types as numpy arrays, with integer and float counters seperated
+    # Access different record types as numpy arrays, with integer and float counters separated
     # Example Return: {'counters': array([...], dtype=uint64), 'fcounters': array([...])}
-    posix_record = darshanll.log_get_posix_record(log)
-    mpiio_record = darshanll.log_get_mpiio_record(log)
-    stdio_record = darshanll.log_get_stdio_record(log)
+    posix_record = darshanll.log_get_record(log, "POSIX")
+    mpiio_record = darshanll.log_get_record(log, "MPI-IO")
+    stdio_record = darshanll.log_get_record(log, "STDIO")
     # ...
-
 
     darshanll.log_close(log)


### PR DESCRIPTION
Some users have pointed out that PyDarshan docs are stale, example code snippets aren't working, etc. I suspect it's been awhile since this has been updated and we've obviously been making lots of changes to the code so this isn't particularly surprising.

I made a general pass over the PyDarshan docs to make sure they are clear, up-to-date, and to make sure examples provided are functional. Commit messages detail a little more explicitly what has changed. I tried to shift almost all of the text related to installation/usage into the standalone pages to avoid duplicating too much between those and the `README.rst`.