### PR TITLE
BUG: never disable "shared reductions" for heatmap mod

### DIFF
--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -637,11 +637,19 @@ void darshan_core_shutdown(int write_log)
                 }
 
                 /* allow the module an opportunity to reduce shared files */
-                if(this_mod->mod_funcs.mod_redux_func && (mod_shared_rec_cnt > 0) &&
-                   !final_core->config.disable_shared_redux_flag)
+                if(this_mod->mod_funcs.mod_redux_func && (mod_shared_rec_cnt > 0))
                 {
-                    this_mod->mod_funcs.mod_redux_func(mod_buf, final_core->mpi_comm,
-                        mod_shared_recs, mod_shared_rec_cnt);
+                    /* run reductions as long as they aren't disabled */
+                    /* NOTE: shared reductions should never be disabled for the
+                     *       HEATMAP module, as the shared reduction step is used
+                     *       to produce a consistent heatmap format across ranks
+                     */
+                    if(!final_core->config.disable_shared_redux_flag ||
+                       (i == DARSHAN_HEATMAP_MOD))
+                    {
+                        this_mod->mod_funcs.mod_redux_func(mod_buf, final_core->mpi_comm,
+                            mod_shared_recs, mod_shared_rec_cnt);
+                    }
                 }
             }
 #endif


### PR DESCRIPTION
The shared reduction callback for the heatmap module is used to reach a consistent heatmap format across all ranks at shutdown time, which our analysis tools expect.

Furthermore, a "shared reduction" doesn't really apply to heatmap data, as it's already captured on every process (as opposed to a shared record on rank 0) -- ignoring the disable shared reduction flag is not an issue for the heatmap module, making this an easy fix.

Fixes #941 