### PR TITLE
logutils workaround for heatmap time skew

### DIFF
--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -43,6 +43,12 @@ struct darshan_fd_s
 
     /* KEEP OUT -- remaining state hidden in logutils source */
     struct darshan_fd_int_state *state;
+
+    /* workaround to parse logs with slightly inconsistent heatmap bin
+     * counts as described in https://github.com/darshan-hpc/darshan/issues/941
+     */
+    int64_t first_heatmap_record_nbins;
+    double first_heatmap_record_bin_width_seconds;
 };
 typedef struct darshan_fd_s* darshan_fd;
 


### PR DESCRIPTION
This is the utility side counter part to #942.

This will "repair" logs on the fly that were generated under the conditions described in https://github.com/darshan-hpc/darshan/issues/941 so that the heatmap bin count stays uniform/rectangular despite slight timing skew across ranks.  This condition is only possible for logs generated with Darshan 3.4.3   with shared record reduction explicitly disabled.

@nafi3 are you able to confirm if you can parse existing logs that have mismatched heatmap bin problems?  (not the negative value problem; that is something different).

Fixes #941 