### PR TITLE
Fix #946, Append mode in mod_agg_iohist doesn't work 

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/aggregators/mod_agg_iohist.py
+++ b/darshan-util/pydarshan/darshan/experimental/aggregators/mod_agg_iohist.py
@@ -58,7 +58,7 @@ def mod_agg_iohist(self, mod, mode='append'):
 
 
     if mode == 'append':
-        if 'agg_iohist' not in self.data:
+        if 'agg_iohist' not in self.summary:
             self.summary['agg_iohist'] = {}
         self.summary['agg_iohist'][mod] = ctx
     


### PR DESCRIPTION
Fixes #946 - Caching of aggregators was supposed to be stored to `report.summary['<name-of-aggregator>']` and not `report.data`.

We might want to consider dropping this behavior at this level altogether in favor of other facilities, but the feature was originally motivated by an interactive analysis that would keep reports in memory without needing to recalculate users would interact with the same log repetitively.