### PR TITLE
MAINT: 3.12 support

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest,
                    macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/darshan-util/pydarshan/RELEASE-CHECKLIST-PyDarshan.txt
+++ b/darshan-util/pydarshan/RELEASE-CHECKLIST-PyDarshan.txt
@@ -11,6 +11,7 @@ Notes on how to release a new version of PyDarshan
     - commit
  - Update version numbers in:
     setup.py
+    pyproject.toml
     setup.cfg
     darshan/__init__.py
  - Make sure documentation in docs/ is up to date

--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -677,10 +677,10 @@ def plot_with_report(report: darshan.DarshanReport,
         height = num_cats
 
     plot_data(fig,
-              file_rd_series[sort_inds],
-              file_wr_series[sort_inds],
-              bytes_rd_series[sort_inds],
-              bytes_wr_series[sort_inds],
+              file_rd_series.iloc[sort_inds],
+              file_wr_series.iloc[sort_inds],
+              bytes_rd_series.iloc[sort_inds],
+              bytes_wr_series.iloc[sort_inds],
               filesystem_roots,
               num_cats=num_cats)
 

--- a/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/plot_io_cost.py
@@ -177,7 +177,7 @@ def plot_io_cost(report: darshan.DarshanReport) -> Any:
     # add the legend and appropriate labels
     ax_raw.set_ylabel("Runtime (s)")
     handles, labels = ax_raw.get_legend_handles_labels()
-    ax_norm.legend(handles[::-1], labels[::-1], loc="upper left", bbox_to_anchor=(1.22, 1.02))
+    ax_raw.legend(handles[::-1], labels[::-1], loc="upper left", bbox_to_anchor=(1.22, 1.02))
     ax_norm.set_ylabel("Runtime (%)")
     # rotate the xticklabels so they don't overlap
     for ax in [ax_raw, ax_norm]:

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -1,3 +1,4 @@
+import io
 import re
 import os
 import pytest
@@ -389,7 +390,7 @@ class TestReportData:
         # generate the report data
         R = summary.ReportData(log_path=log_path)
         # convert the metadata table back to a pandas dataframe
-        actual_metadata_df = pd.read_html(R.metadata_table, index_col=0)[0]
+        actual_metadata_df = pd.read_html(io.StringIO(R.metadata_table), index_col=0)[0]
         # correct index and columns attributes after
         # `index_col` removed the first column
         actual_metadata_df.index.names = [None]
@@ -503,7 +504,7 @@ class TestReportData:
         # check that number of unicode warning symbols matches expected partial flag count
         assert R.module_table.count("&#x26A0;") == expected_partial_flags
         # convert the module table back to a pandas dataframe
-        actual_mod_df = pd.read_html(R.module_table, index_col=0)[0]
+        actual_mod_df = pd.read_html(io.StringIO(R.module_table), index_col=0)[0]
         # correct index and columns attributes after
         # `index_col` removed the first column
         actual_mod_df.index.names = [None]
@@ -521,8 +522,10 @@ class TestReportData:
         expected_df[1] = np.nan
         flag = "\u26A0 Module data incomplete due to runtime memory or record count limits"
         if "partial_data_stdio.darshan" in log_path:
+            expected_df[[1]] = expected_df[[1]].astype(object)
             expected_df.iloc[5, 1] = flag
         if "partial_data_dxt.darshan" in log_path:
+            expected_df[[1]] = expected_df[[1]].astype(object)
             expected_df.iloc[6:, 1] = flag
 
         # check the module dataframes

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -1,11 +1,13 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools<64.0.0",
+    "setuptools>=65.0.0",
 ]
 
 [project]
+name = "darshan"
 requires-python = ">=3.7"
+version = "3.4.4.0"
 
 [tool.cibuildwheel]
 environment = "PYDARSHAN_BUILD_EXT=1"

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     description="Python tools to interact with darshan log records of HPC applications.",
     long_description=readme,


### PR DESCRIPTION
* a few adjustments to `pyproject.toml` to allow for `pip install -v .` followed by `python -m pytest --pyargs darshan -n 32` to pass the full suite locally on x86_64 Linux with Python `3.12.0rc3`, given that the final release of Python `3.12.0` is about a week away I think

* changing the version of `setuptools` may break the developer experience with "editable" installs, since I recall pinning it a while back for that reason, but I think supporting isolated wheel builds/install with `3.12.0` should likely take priority

* some of the metadata updates to `pyproject.toml` are apparently newly-required fields that must be present (`pip install -v .` fails otherwise)

* perhaps we can delay adding `3.12` to the CI testing until the final release, though GHA does have the RC available if we want it

[skip cirrus]