### PR TITLE
BUG: fixes for HDF5 module method for determining whether MPIO VFD is used

### DIFF
--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -29,14 +29,6 @@
 
 #include <hdf5.h>
 
-/* NOTE: this is a dummy definition of H5FD_mpio_init() with a weak alias.
- * It prevents "libdarshan.so: undefined symbol: H5FD_mpio_init" errors if
- * Darshan is enabled via LD_PRELOAD for non-HDF executables.  This problem
- * may occur if Darshan itself was compiled against HDF5 1.13.2.
- */
-hid_t dummy_H5FD_mpio_init(void) { return(0); }
-hid_t H5FD_mpio_init (void) __attribute__ ((weak, alias("dummy_H5FD_mpio_init")));
-
 /* H5F prototypes */
 DARSHAN_FORWARD_DECL(H5Fcreate, hid_t, (const char *filename, unsigned flags, hid_t create_plist, hid_t access_plist));
 DARSHAN_FORWARD_DECL(H5Fopen, hid_t, (const char *filename, unsigned flags, hid_t access_plist));
@@ -253,8 +245,24 @@ hid_t DARSHAN_DECL(H5Fcreate)(const char *filename, unsigned flags,
         }
 
 #ifdef DARSHAN_HDF5_PAR_BUILD
-        if(access_plist != H5P_DEFAULT && H5Pget_driver(access_plist) == H5FD_MPIO)
-            use_mpio = 1;
+        if(access_plist != H5P_DEFAULT)
+        {
+            H5E_auto_t old_func;
+            void *old_client_data;
+
+            H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
+
+            /* temporarily disable error handling to avoid errors if this isn't
+             * the MPIO VFD
+             */
+            H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+
+            if(H5Pget_fapl_mpio(access_plist, NULL, NULL) >= 0)
+                use_mpio = 1;
+
+            /* restore the default error handler */
+            H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+        }
 #endif
 
         H5F_PRE_RECORD();
@@ -329,8 +337,24 @@ hid_t DARSHAN_DECL(H5Fopen)(const char *filename, unsigned flags,
         }
 
 #ifdef DARSHAN_HDF5_PAR_BUILD
-        if(access_plist != H5P_DEFAULT && H5Pget_driver(access_plist) == H5FD_MPIO)
-            use_mpio = 1;
+        if(access_plist != H5P_DEFAULT)
+        {
+            H5E_auto_t old_func;
+            void *old_client_data;
+
+            H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
+
+            /* temporarily disable error handling to avoid errors if this isn't
+             * the MPIO VFD
+             */
+            H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+
+            if(H5Pget_fapl_mpio(access_plist, NULL, NULL) >= 0)
+                use_mpio = 1;
+
+            /* restore the default error handler */
+            H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+        }
 #endif
 
         H5F_PRE_RECORD();


### PR DESCRIPTION
* use `H5Pget_fapl_mpio` instead of `H5Pget_driver`
* this code temporarily disables HDF5 error reporting to avoid noisy error messages in the case the associated VFD is not MPIO
* remove old hack to declare `H5FD_mpio_init` as a weak symbol

Fixes #960

For some background, we added the weak symbol hack mentioned above in our last release to work around a weird issue when LD_PRELOADing Darshan with HDF5 support leading to loader issues like this:
```
symbol lookup error: /home/shane/software/darshan/darshan-dev/install/lib/libdarshan.so: undefined symbol: H5FD_mpio_init
```

While this hack works as intended for non-HDF5 apps, it does not work as intended for HDF5 apps -- the weak dummy function is being linked in rather than the real implementation of  `H5FD_mpio_init`, causing errors as seen in #960.

Rather than go down the rabbit hole to understand why our usage of `H5FD_MPIO` is causing the HDF5 library to need to be linked (this wasn't the case in HDF5 versions prior to 1.13), I've just moved away from using that macro entirely. `H5Pget_fapl_mpio` can provide the same functionality, with the caveat that we have to temporarily disable HDF5 error printing when probing, as it will print an error message if called on a file access property list that does not have the MPIO VFD enabled.