### PR TITLE
ENH: add runtime library support for MODMEM_USAGE config setting

### DIFF
--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -503,6 +503,8 @@ The Darshan library honors the following settings to modify behavior at runtime:
 | DARSHAN_INTERNAL_TIMING=1 | INTERNAL_TIMING
  | Enables internal instrumentation that will print the time required
 to startup and shutdown Darshan to stderr at runtime.
+| DARSHAN_MODMEM_USAGE=1 | MODMEM_USAGE
+ | Prints details on memory usage of Darshan's instrumentation modules.
 | DARSHAN_MODMEM=<val> | MODMEM <val>
  | Specifies the amount of memory (in MiB) Darshan instrumentation
  modules can collectively consume (if not specified, a default 4 MiB

--- a/darshan-runtime/lib/darshan-config.c
+++ b/darshan-runtime/lib/darshan-config.c
@@ -441,6 +441,8 @@ void darshan_parse_config_env(struct darshan_config *cfg)
         cfg->dump_config_flag = 1;
     if(getenv("DARSHAN_INTERNAL_TIMING"))
         cfg->internal_timing_flag = 1;
+    if(getenv("DARSHAN_MODMEM_USAGE"))
+        cfg->mod_mem_usage_flag = 1;
     if(getenv("DARSHAN_DISABLE_SHARED_REDUCTION"))
         cfg->disable_shared_redux_flag = 1;
 
@@ -814,6 +816,8 @@ void darshan_parse_config_file(struct darshan_config *cfg)
                 cfg->dump_config_flag = 1;
             else if(strcmp(key, "INTERNAL_TIMING") == 0)
                 cfg->internal_timing_flag = 1;
+            else if(strcmp(key, "MODMEM_USAGE") == 0)
+                cfg->mod_mem_usage_flag = 1;
             else if(strcmp(key, "DISABLE_SHARED_REDUCTION") == 0)
                 cfg->disable_shared_redux_flag = 1;
             else

--- a/darshan-runtime/lib/darshan-config.h
+++ b/darshan-runtime/lib/darshan-config.h
@@ -38,6 +38,7 @@ struct darshan_config
     struct dxt_trigger *small_io_trigger;
     struct dxt_trigger *unaligned_io_trigger;
     int internal_timing_flag;
+    int mod_mem_usage_flag;
     int disable_shared_redux_flag;
     int dump_config_flag;
 };

--- a/darshan-runtime/lib/darshan.h
+++ b/darshan-runtime/lib/darshan.h
@@ -277,6 +277,8 @@ struct darshan_core_module
 {
     void *rec_buf_start;
     void *rec_buf_p;
+    size_t bytes_allocated;
+    size_t bytes_registered;
     size_t rec_mem_avail;
     darshan_module_funcs mod_funcs;
 };


### PR DESCRIPTION
prints details on amount of memory allocated for each module, as well as the total amount of memory registered for each module. this information can be used to help sanity check that user memory configuration settings are working as expected

produces output like: 

```
# Darshan POSIX module: bytes_registered=704 bytes_allocated=720896
# Darshan DXT_POSIX module: bytes_registered=4194280 bytes_allocated=4194304
# Darshan HEATMAP module: bytes_registered=3248 bytes_allocated=25984

```