### PR TITLE
Support for collection of backtrace memory addresses

### DIFF
--- a/darshan-runtime/lib/darshan-config.c
+++ b/darshan-runtime/lib/darshan-config.c
@@ -437,6 +437,18 @@ void darshan_parse_config_env(struct darshan_config *cfg)
             }
         }
     }
+    envstr = getenv("DXT_ENABLE_STACK_TRACE");
+    if(envstr)
+    {
+        struct dxt_trigger *trigger = malloc(sizeof(*trigger));
+        if(trigger)
+        {   
+            trigger->type = DXT_COLLECT_STACK_TRACE;
+            trigger->u.unaligned_io.thresh_pct = 0;
+            cfg->stack_trace_trigger = trigger;
+        }    
+    }
+
     if(getenv("DARSHAN_DUMP_CONFIG"))
         cfg->dump_config_flag = 1;
     if(getenv("DARSHAN_INTERNAL_TIMING"))

--- a/darshan-runtime/lib/darshan-config.h
+++ b/darshan-runtime/lib/darshan-config.h
@@ -37,6 +37,7 @@ struct darshan_config
     char *rank_inclusions;
     struct dxt_trigger *small_io_trigger;
     struct dxt_trigger *unaligned_io_trigger;
+    struct dxt_trigger *stack_trace_trigger;
     int internal_timing_flag;
     int disable_shared_redux_flag;
     int dump_config_flag;

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -394,6 +394,10 @@ void darshan_core_initialize(int argc, char **argv)
         darshan_core_fprintf(stderr, "darshan:init\t%d\t%f\n", nprocs, init_time);
     }
 
+    if(init_core->config.stack_trace_trigger){
+        dxt_enable_stack_trace();
+    }
+
     return;
 }
 
@@ -586,6 +590,7 @@ void darshan_core_shutdown(int write_log)
         dxt_posix_apply_trace_filter(final_core->config.small_io_trigger);
     if(final_core->config.unaligned_io_trigger)
         dxt_posix_apply_trace_filter(final_core->config.unaligned_io_trigger);
+
 
     /* loop over globally used darshan modules and:
      *      - get final output buffer

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -39,7 +39,7 @@
 #include <assert.h>
 #include <spawn.h>
 
-#ifdef HAVE_/global/homes/h/hather/darshan/darshan-runtime/install/libMPI
+#ifdef HAVE_MPI
 #include <mpi.h>
 #endif
 

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -54,8 +54,6 @@
 #include <lustre/lustre_user.h>
 #endif
 
-#define STACK_TRACE_BUF_SIZE       60
-
 extern char* __progname;
 extern char* __progname_full;
 struct darshan_core_runtime *__darshan_core = NULL;
@@ -675,11 +673,11 @@ void darshan_core_shutdown(int write_log)
             /* get the final output buffer */
             this_mod->mod_funcs.mod_output_func(&mod_buf, &mod_buf_sz);
         }
-
+        
+/* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
 #ifdef HAVE_MPI
         if(using_mpi)
         {
-            //if(i == DXT_POSIX_MOD && my_rank == 0 && final_core->config.stack_trace_trigger)
             if (i == DXT_POSIX_MOD) {
                 PMPI_Barrier(MPI_COMM_WORLD);
                 if (my_rank == 0 && final_core->config.stack_trace_trigger) {
@@ -715,8 +713,6 @@ void darshan_core_shutdown(int write_log)
 
                             fclose(fptr);
                             remove(stack_file_name_posix);
-                        } else {
-                            printf("unable to open POSIX file\n");
                         }
                     }
 
@@ -731,7 +727,6 @@ void darshan_core_shutdown(int write_log)
                         char *line = NULL;     
                         size_t len = 0;
 
-                        // sprintf(cmd, "addr2line -a %s -e %s", d->address, exe_name);  
                         char addr[32];
                         sprintf(addr, "%s", d->address);  
                     
@@ -760,8 +755,10 @@ void darshan_core_shutdown(int write_log)
                             // Read the output from the pipe
                             char buffer[4096];
                             ssize_t bytes_read;
+                            FILE* debug;
+                            debug = fopen("/dev/null", "w");
                             while ((bytes_read = read(pipe_fd[0], buffer, sizeof(buffer))) > 0) {
-                                fwrite(buffer, 1, bytes_read, stdout);
+                                fwrite(buffer, 1, bytes_read, debug);
                             }
 
                             char * token = strtok(buffer, "\n");
@@ -811,8 +808,6 @@ void darshan_core_shutdown(int write_log)
 
                             fclose(fptr);
                             remove(stack_file_name_mpiio);
-                        } else {
-                            printf("unable to open MPIIO file\n");
                         }
                     }
 
@@ -857,8 +852,10 @@ void darshan_core_shutdown(int write_log)
                             // Read the output from the pipe
                             char buffer[4096];
                             ssize_t bytes_read;
+                            FILE* debug;
+                            debug = fopen("/dev/null", "w");
                             while ((bytes_read = read(pipe_fd[0], buffer, sizeof(buffer))) > 0) {
-                                fwrite(buffer, 1, bytes_read, stdout);
+                                fwrite(buffer, 1, bytes_read, debug);
                             }
 
                             // Wait for the child process to complete

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -77,8 +77,6 @@ static struct darshan_core_mnt_data mnt_data_array[DARSHAN_MAX_MNTS];
 static int mnt_data_count = 0;
 
 static char *exe_name = "";
-bool processedPOSIX = false;
-bool processedMPIIO = false;
 #ifdef DARSHAN_BGQ
 extern void bgq_runtime_initialize();
 #endif
@@ -684,8 +682,7 @@ void darshan_core_shutdown(int write_log)
             //if(i == DXT_POSIX_MOD && my_rank == 0 && final_core->config.stack_trace_trigger)
             if (i == DXT_POSIX_MOD) {
                 PMPI_Barrier(MPI_COMM_WORLD);
-                if (my_rank == 0 && final_core->config.stack_trace_trigger && processedPOSIX == false) {
-                    processedPOSIX = true;
+                if (my_rank == 0 && final_core->config.stack_trace_trigger) {
                     FILE *fptr;
 
                     typedef struct {
@@ -781,8 +778,7 @@ void darshan_core_shutdown(int write_log)
             }
             else if (i == DXT_MPIIO_MOD) {
                 PMPI_Barrier(MPI_COMM_WORLD);
-                if (my_rank == 0 && final_core->config.stack_trace_trigger && processedMPIIO == false) {
-                    processedMPIIO = true;
+                if (my_rank == 0 && final_core->config.stack_trace_trigger) {
                     FILE *fptr;
 
                     typedef struct {

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -59,7 +59,7 @@ typedef int64_t off64_t;
 /* NOTE: when this size is exceeded, the buffer size is doubled */
 #define IO_TRACE_BUF_SIZE       64
 
-#define STACK_TRACE_BUF_SIZE       26
+#define STACK_TRACE_BUF_SIZE       60
 
 bool isStackTrace = false;
 
@@ -324,7 +324,7 @@ void dxt_posix_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     if (isStackTrace){
         backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
-        rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
+        rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
     }
     else
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 0;
@@ -427,7 +427,7 @@ void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     if (isStackTrace){
         backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
-        rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
+        rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
     }
     else
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 0;
@@ -859,7 +859,6 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
                 record_read_count * sizeof(segment_info));
 
     if (isStackTrace){
-
         int * unique_memory_addresses;
         int size = STACK_TRACE_BUF_SIZE;
         unique_memory_addresses = (int*)calloc(size, sizeof(int));
@@ -893,7 +892,7 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
         }
 
         j = 0;
-        for(int i = 0; i < record_read_count * STACK_TRACE_BUF_SIZE; i++){
+        for(int i = 0; i < record_read_count * STACK_TRACE_BUF_SIZE; i++){           
             int flag = 0;
             if (j != STACK_TRACE_BUF_SIZE){
                 for(int k = 0; k < curr_size; k++){
@@ -1042,7 +1041,6 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
                 record_read_count * sizeof(segment_info));
 
     if (isStackTrace){
-
         int * unique_memory_addresses;
         int size = STACK_TRACE_BUF_SIZE;
         unique_memory_addresses = (int*)calloc(size, sizeof(int));

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -62,7 +62,8 @@ typedef int64_t off64_t;
 #define STACK_TRACE_BUF_SIZE       60
 
 bool isStackTrace = false;
-
+char posixMappingsPath[1024];
+char mpiioMappingsPath[1024];
 /* The dxt_file_record_ref structure maintains necessary runtime metadata
  * for the DXT file record (dxt_file_record structure, defined in
  * darshan-dxt-log-format.h) pointed to by 'file_rec'. This metadata
@@ -158,8 +159,9 @@ void dxt_posix_runtime_initialize()
     };
     int ret;
 
-
-    // set_posix_line_mapping(posix_line_mapping, isStackTrace);
+    // getcwd(posixMappingsPath, sizeof(posixMappingsPath));
+    // char source[] = "/posix_mappings.txt";
+    // strcat(posixMappingsPath, source);
 
     /* register the DXT module with darshan core */
     ret = darshan_core_register_module(
@@ -203,6 +205,9 @@ void dxt_mpiio_runtime_initialize()
     };
     int ret;
 
+    // getcwd(mpiioMappingsPath, sizeof(mpiioMappingsPath));
+    // char source[] = "/mpiio_mappings.txt";
+    // strcat(mpiioMappingsPath, source);
     /* register the DXT module with darshan core */
     ret = darshan_core_register_module(
         DXT_MPIIO_MOD,
@@ -265,20 +270,37 @@ void dxt_posix_write(darshan_record_id rec_id, int64_t offset,
         DXT_UNLOCK();
         return;
     }
-    
     rec_ref->write_traces[file_rec->write_count].offset = offset;
     rec_ref->write_traces[file_rec->write_count].length = length;
     rec_ref->write_traces[file_rec->write_count].start_time = start_time;
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
     if (isStackTrace){
-        backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
+        int size = backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
+        for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
+            rec_ref->write_traces[file_rec->write_count].address_array[i] = NULL;
+        }
+
+        // FILE *fptr;
+        // fptr = fopen(posixMappingsPath, "a+");
+
+        // char **strings;;
+        // strings = backtrace_symbols (rec_ref->write_traces[file_rec->write_count].address_array, size);
+        // if (strings != NULL)
+        // {
+        //     for (int j = 0; j < size; j++){
+        //         if (strings[j] != NULL)
+        //             fprintf(fptr, "%s\n", strings[j]);
+        //     }
+        // }
+        
+        // fclose(fptr);
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
+        rec_ref->write_traces[file_rec->write_count].size = size;
     }
     else
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 0;
     
     file_rec->write_count += 1;
-
     DXT_UNLOCK();
 }
 
@@ -323,13 +345,31 @@ void dxt_posix_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].start_time = start_time;
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     if (isStackTrace){
-        backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
+        int size = backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
+        for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
+            rec_ref->read_traces[file_rec->read_count].address_array[i] = NULL;
+        }
+
+        // FILE *fptr;
+        // fptr = fopen(posixMappingsPath, "a+");
+
+        // char **strings;;
+        // strings = backtrace_symbols (rec_ref->read_traces[file_rec->read_count].address_array, size);
+        // if (strings != NULL)
+        // {
+        //     for (int j = 0; j < size; j++){
+        //         if (strings[j] != NULL)
+        //             fprintf(fptr, "%s\n", strings[j]);
+        //     }
+        // }
+        
+        // fclose(fptr);
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
+        rec_ref->read_traces[file_rec->read_count].size = size;
     }
     else
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 0;
     file_rec->read_count += 1;
-
     DXT_UNLOCK();
 }
 
@@ -374,14 +414,31 @@ void dxt_mpiio_write(darshan_record_id rec_id, int64_t offset,
     rec_ref->write_traces[file_rec->write_count].start_time = start_time;
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
     if (isStackTrace){
-        backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
+        int size = backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
+        for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
+            rec_ref->write_traces[file_rec->write_count].address_array[i] = NULL;
+        }
+        // FILE *fptr;
+        // fptr = fopen(mpiioMappingsPath, "a+");
+
+        // char **strings;;
+        // strings = backtrace_symbols (rec_ref->write_traces[file_rec->write_count].address_array, size);
+        // if (strings != NULL)
+        // {
+        //     for (int j = 0; j < size; j++){
+        //         if (strings[j] != NULL)
+        //             fprintf(fptr, "%s\n", strings[j]);
+        //     }
+        // }
+        
+        // fclose(fptr);
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
+        rec_ref->write_traces[file_rec->write_count].size = size;
     }
     else
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 0;
 
     file_rec->write_count += 1;
-
     DXT_UNLOCK();
 }
 
@@ -426,13 +483,30 @@ void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].start_time = start_time;
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     if (isStackTrace){
-        backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
+        int size = backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
+        for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
+            rec_ref->read_traces[file_rec->read_count].address_array[i] = NULL;
+        }
+        // FILE *fptr;
+        // fptr = fopen(mpiioMappingsPath, "a+");
+        
+        // char **strings;;
+        // strings = backtrace_symbols (rec_ref->read_traces[file_rec->read_count].address_array, size);
+        // if (strings != NULL)
+        // {
+        //     for (int j = 0; j < size; j++){
+        //         if (strings[j] != NULL)
+        //             fprintf(fptr, "%s\n", strings[j]);
+        //     }
+        // }
+        
+        // fclose(fptr);
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
+        rec_ref->read_traces[file_rec->read_count].size = size;
     }
     else
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 0;
     file_rec->read_count += 1;
-
     DXT_UNLOCK();
 }
 
@@ -830,7 +904,56 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
 
     if (record_write_count == 0 && record_read_count == 0)
         return;
+    
+    if (isStackTrace){
+        // clock_t start, end;
+        // double cpu_time_used;
+        // start = clock();
 
+        // char *path = malloc(4096);
+        // get_log_file_path(path);
+        // char substr[256] = "posix_mappings.txt";
+        // char * pch;
+        // pch=strchr(path,'.');
+     
+        // int ind = strlen(path) - strlen(pch) + 1;
+        // for (int i = 0; i < strlen(substr); i++){
+        //     path[ind] = substr[i];
+        //     ind = ind + 1;
+        // }
+        // path[ind] ='\0';
+        
+    
+        FILE *fptr;
+        fptr = fopen("/tmp/posix_mappings.txt", "a");
+       
+        for(int i = 0; i < record_write_count; i++){
+            char **strings;
+            int size = rec_ref->write_traces[i].size;
+            strings = backtrace_symbols (rec_ref->write_traces[i].address_array, size);
+            if (strings != NULL)
+            {
+                for (int j = 0; j < size; j++){
+                    // printf("%s\n", strings[i]);
+                     fprintf(fptr, "%s\n", strings[j]);
+                }
+            }
+        }
+
+        for(int i = 0; i < record_read_count; i++){           
+            char **strings;
+            int size = rec_ref->read_traces[i].size;
+            strings = backtrace_symbols (rec_ref->read_traces[i].address_array, size);
+            if (strings != NULL)
+            {
+                for (int j = 0; j < size; j++){
+                    // printf("%s\n", strings[i]);
+                    fprintf(fptr, "%s\n", strings[j]);
+                }
+            }
+        }
+        fclose(fptr);
+    }
     /*
      * Buffer format:
      * dxt_file_record + write_traces + read_traces
@@ -858,97 +981,7 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
     tmp_buf_ptr = (void *)(tmp_buf_ptr +
                 record_read_count * sizeof(segment_info));
 
-    if (isStackTrace){
-        int * unique_memory_addresses;
-        int size = STACK_TRACE_BUF_SIZE;
-        unique_memory_addresses = (int*)calloc(size, sizeof(int));
-
-        int j = 0;
-        int curr_size = 0;
-
-        for(int i = 0; i < record_write_count * STACK_TRACE_BUF_SIZE; i++){
-            int flag = 0;
-            if (j != STACK_TRACE_BUF_SIZE){
-                for(int k = 0; k < curr_size; k++){
-                    if (unique_memory_addresses[k] == (int )(rec_ref->write_traces->address_array[i])){
-                        flag = 1;
-                        break;
-                    }
-                }
-                if (flag == 0){
-                    if (curr_size == size){
-                        size = size * 2;
-                        unique_memory_addresses = realloc(unique_memory_addresses, size * sizeof(int));
-                    }
-                    unique_memory_addresses[curr_size] = (int )(rec_ref->write_traces->address_array[i]);
-                    curr_size = curr_size + 1;
-                }
-                j = j + 1;
-            }
-            else{
-                j = 0;
-                i = i + 4;
-            }
-        }
-
-        j = 0;
-        for(int i = 0; i < record_read_count * STACK_TRACE_BUF_SIZE; i++){           
-            int flag = 0;
-            if (j != STACK_TRACE_BUF_SIZE){
-                for(int k = 0; k < curr_size; k++){
-                    if (unique_memory_addresses[k] == (int )(rec_ref->read_traces->address_array[i])){
-                        flag = 1;
-                        break;
-                    }
-                }
-                if (flag == 0){
-                    if (curr_size == size){
-                        size = size * 2;
-                        unique_memory_addresses = realloc(unique_memory_addresses, size * sizeof(int));
-                    }
-                    unique_memory_addresses[curr_size] = (int )(rec_ref->read_traces->address_array[i]);
-                    curr_size = curr_size + 1;
-                }
-                j = j + 1;
-            }
-            else{
-                j = 0;
-                i = i + 4;
-            }
-        }
-        
-        char * address_line_mapping;
-        char * address_line_mapping_cur = "";
-
-        char * exe_name = darshan_exe();
-
-        for(int i = 0; i < curr_size; i++){
-            FILE *FileOpen;
-            char syscom[256]; 
-            char line[100];      
-
-            if (unique_memory_addresses[i]){
-                sprintf(syscom, "addr2line -a %p -e %s", unique_memory_addresses[i], exe_name);                
-                FileOpen = popen(syscom, "r");                                                                            
-
-                while (fgets(line, sizeof line, FileOpen))
-                {
-                    if (strstr(line, "0x") == NULL && strstr(line, "(nil)") == NULL){
-                        if (strstr(line, "??") == NULL){
-                            sprintf(syscom,"%p, %s", unique_memory_addresses[i], line);   
-                            address_line_mapping = (char *)calloc(strlen(address_line_mapping_cur) + strlen(syscom) + 1, sizeof(char));
-                            strcat(address_line_mapping, address_line_mapping_cur);
-                            strcat(address_line_mapping, syscom);
-                            address_line_mapping_cur = address_line_mapping;
-                        }
-                    }
-                }
-            }
-        }
-        
-        set_posix_line_mapping(address_line_mapping, isStackTrace);
-        free(address_line_mapping);
-    }
+    printf("%i\n", file_rec->base_rec.rank);
     dxt_posix_runtime->record_buf_size += record_size;
 }
 
@@ -1013,7 +1046,53 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
     record_read_count = file_rec->read_count;
     if (record_write_count == 0 && record_read_count == 0)
         return;
+    
+    if (isStackTrace){
+        // clock_t start, end;
+        // double cpu_time_used;
+        // start = clock();
 
+        // char *path = malloc(4096);
+        // get_log_file_path(path);
+        // char substr[256] = "/tmp/mpiio_mappings.txt";
+        // char * pch;
+        // pch=strchr(path,'.');
+     
+        // int ind = strlen(path) - strlen(pch) + 1;
+        // for (int i = 0; i < strlen(substr); i++){
+        //     path[ind] = substr[i];
+        //     ind = ind + 1;
+        // }
+        // path[ind] ='\0';
+
+        FILE *fptr;
+        fptr = fopen("/tmp/mpiio_mappings.txt", "a");
+
+        for(int i = 0; i < record_write_count; i++){
+            char **strings;
+            int size = rec_ref->write_traces[i].size;
+            strings = backtrace_symbols (rec_ref->write_traces[i].address_array, size);
+            if (strings != NULL)
+            {
+                for (int j = 0; j < size; j++){
+                    fprintf(fptr, "%s\n", strings[j]);
+                }
+            }
+        }
+
+        for(int i = 0; i < record_read_count; i++){
+            char **strings;
+            int size = rec_ref->read_traces[i].size;
+            strings = backtrace_symbols (rec_ref->read_traces[i].address_array, size);
+            if (strings != NULL)
+            {
+                for (int j = 0; j < size; j++){
+                    fprintf(fptr, "%s\n", strings[j]);
+                }
+            }
+        }
+        fclose(fptr);
+    }
     /*
      * Buffer format:
      * dxt_file_record + write_traces + read_traces
@@ -1039,99 +1118,6 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
             record_read_count * sizeof(segment_info));
     tmp_buf_ptr = (void *)(tmp_buf_ptr +
                 record_read_count * sizeof(segment_info));
-
-    if (isStackTrace){
-        int * unique_memory_addresses;
-        int size = STACK_TRACE_BUF_SIZE;
-        unique_memory_addresses = (int*)calloc(size, sizeof(int));
-
-        int j = 0;
-        int curr_size = 0;
-
-        for(int i = 0; i < record_write_count * STACK_TRACE_BUF_SIZE; i++){
-            int flag = 0;
-            if (j != STACK_TRACE_BUF_SIZE){
-                for(int k = 0; k < curr_size; k++){
-                    if (unique_memory_addresses[k] == (int )(rec_ref->write_traces->address_array[i])){
-                        flag = 1;
-                        break;
-                    }
-                }
-                if (flag == 0){
-                    if (curr_size == size){
-                        size = size * 2;
-                        unique_memory_addresses = realloc(unique_memory_addresses, size * sizeof(int));
-                    }
-                    unique_memory_addresses[curr_size] = (int )(rec_ref->write_traces->address_array[i]);
-                    curr_size = curr_size + 1;
-                }
-                j = j + 1;
-            }
-            else{
-                j = 0;
-                i = i + 4;
-            }
-        }
-
-        j = 0;
-        for(int i = 0; i < record_read_count * STACK_TRACE_BUF_SIZE; i++){
-            int flag = 0;
-            if (j != STACK_TRACE_BUF_SIZE){
-                for(int k = 0; k < curr_size; k++){
-                    if (unique_memory_addresses[k] == (int )(rec_ref->read_traces->address_array[i])){
-                        flag = 1;
-                        break;
-                    }
-                }
-                if (flag == 0){
-                    if (curr_size == size){
-                        size = size * 2;
-                        unique_memory_addresses = realloc(unique_memory_addresses, size * sizeof(int));
-                    }
-                    unique_memory_addresses[curr_size] = (int )(rec_ref->read_traces->address_array[i]);
-                    curr_size = curr_size + 1;
-                }
-                j = j + 1;
-            }
-            else{
-                j = 0;
-                i = i + 4;
-            }
-        }
-        
-        char * mpiio_address_line_mapping;
-        char * mpiio_address_line_mapping_cur = "";
-
-        char * exe_name = darshan_exe();
-
-        for(int i = 0; i < curr_size; i++){
-            FILE *FileOpen;
-            char syscom[256]; 
-            char line[100];      
-            
-            if (unique_memory_addresses[i]){
-                sprintf(syscom, "addr2line -a %p -e %s", unique_memory_addresses[i], exe_name);                
-                FileOpen = popen(syscom, "r");                                                                            
-
-                while (fgets(line, sizeof line, FileOpen))
-                {   
-
-                    if (strstr(line, "0x") == NULL && strstr(line, "(nil)") == NULL) {
-                        if (strstr(line, "??") == NULL){
-                            sprintf(syscom,"%p, %s", unique_memory_addresses[i], line);   
-                            mpiio_address_line_mapping = (char *)calloc(strlen(mpiio_address_line_mapping_cur) + strlen(syscom) + 1, sizeof(char));
-                            strcat(mpiio_address_line_mapping, mpiio_address_line_mapping_cur);
-                            strcat(mpiio_address_line_mapping, syscom);
-                            mpiio_address_line_mapping_cur = mpiio_address_line_mapping;
-                        }
-                    }
-                }
-            }
-        }
-
-        set_mpiio_line_mapping(mpiio_address_line_mapping, isStackTrace);
-        free(mpiio_address_line_mapping);
-    }
     dxt_mpiio_runtime->record_buf_size += record_size;
 }
 

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -62,6 +62,8 @@ typedef int64_t off64_t;
 #define STACK_TRACE_BUF_SIZE       60
 
 bool isStackTrace = false;
+bool processedBeforePOSIX = false;
+bool processedBeforeMPIIO = false;
 
 /* The dxt_file_record_ref structure maintains necessary runtime metadata
  * for the DXT file record (dxt_file_record structure, defined in
@@ -827,12 +829,13 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
-    if (isStackTrace){        
+    if (isStackTrace && processedBeforePOSIX == false){    
+        processedBeforePOSIX = true;    
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-posix", dxt_my_rank);
 
         FILE *fptr;
-        fptr = fopen(stack_file_name, "w");
+        fptr = fopen(stack_file_name, "a+");
 
         typedef struct {
             void *address;             /* key */
@@ -897,6 +900,7 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
         }
 
         stack_struct *d = NULL;
+
 
         for (d = unique_mem_addr; d != NULL; d = (stack_struct *)(d->hh.next)) {
             fprintf(fptr, "%p\n", d->address);
@@ -1000,12 +1004,13 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
-    if (isStackTrace){ 
+    if (isStackTrace && processedBeforeMPIIO == false){ 
+        processedBeforeMPIIO = true;
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-mpiio", dxt_my_rank);
 
         FILE *fptr;
-        fptr = fopen(stack_file_name, "w");
+        fptr = fopen(stack_file_name, "a+");
 
         typedef struct {
             void *address;             /* key */

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -62,8 +62,7 @@ typedef int64_t off64_t;
 #define STACK_TRACE_BUF_SIZE       60
 
 bool isStackTrace = false;
-char posixMappingsPath[1024];
-char mpiioMappingsPath[1024];
+
 /* The dxt_file_record_ref structure maintains necessary runtime metadata
  * for the DXT file record (dxt_file_record structure, defined in
  * darshan-dxt-log-format.h) pointed to by 'file_rec'. This metadata
@@ -159,10 +158,6 @@ void dxt_posix_runtime_initialize()
     };
     int ret;
 
-    // getcwd(posixMappingsPath, sizeof(posixMappingsPath));
-    // char source[] = "/posix_mappings.txt";
-    // strcat(posixMappingsPath, source);
-
     /* register the DXT module with darshan core */
     ret = darshan_core_register_module(
         DXT_POSIX_MOD,
@@ -205,9 +200,6 @@ void dxt_mpiio_runtime_initialize()
     };
     int ret;
 
-    // getcwd(mpiioMappingsPath, sizeof(mpiioMappingsPath));
-    // char source[] = "/mpiio_mappings.txt";
-    // strcat(mpiioMappingsPath, source);
     /* register the DXT module with darshan core */
     ret = darshan_core_register_module(
         DXT_MPIIO_MOD,
@@ -276,37 +268,6 @@ void dxt_posix_write(darshan_record_id rec_id, int64_t offset,
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
     if (isStackTrace){
         int size = backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
-        // JL I believe we can remove this since the symbols will help remove whatever is not from the application
-        //for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
-        //    rec_ref->write_traces[file_rec->write_count].address_array[i] = NULL;
-        //}
-
-        /*char **strings;
-        strings = backtrace_symbols(rec_ref->write_traces[file_rec->write_count].address_array, size);
-
-        if (strings != NULL)
-            for(int i = 0; i < size; i++) {
-                printf("%d: %p %s\n",
-                    i,
-                    (int)rec_ref->write_traces[file_rec->write_count].address_array[i],
-                    strings[i]
-                );
-            }
-        */
-        // FILE *fptr;
-        // fptr = fopen(posixMappingsPath, "a+");
-
-        // char **strings;;
-        // strings = backtrace_symbols (rec_ref->write_traces[file_rec->write_count].address_array, size);
-        // if (strings != NULL)
-        // {
-        //     for (int j = 0; j < size; j++){
-        //         if (strings[j] != NULL)
-        //             fprintf(fptr, "%s\n", strings[j]);
-        //     }
-        // }
-        
-        // fclose(fptr);
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
         rec_ref->write_traces[file_rec->write_count].size = size;
     }
@@ -359,25 +320,6 @@ void dxt_posix_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     if (isStackTrace){
         int size = backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
-        // JL removed as we can have the symbols do this for us
-        //for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
-        //    rec_ref->read_traces[file_rec->read_count].address_array[i] = NULL;
-        //}
-
-        // FILE *fptr;
-        // fptr = fopen(posixMappingsPath, "a+");
-
-        // char **strings;;
-        // strings = backtrace_symbols (rec_ref->read_traces[file_rec->read_count].address_array, size);
-        // if (strings != NULL)
-        // {
-        //     for (int j = 0; j < size; j++){
-        //         if (strings[j] != NULL)
-        //             fprintf(fptr, "%s\n", strings[j]);
-        //     }
-        // }
-        
-        // fclose(fptr);
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
         rec_ref->read_traces[file_rec->read_count].size = size;
     }
@@ -429,23 +371,6 @@ void dxt_mpiio_write(darshan_record_id rec_id, int64_t offset,
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
     if (isStackTrace){
         int size = backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
-        //for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
-        //    rec_ref->write_traces[file_rec->write_count].address_array[i] = NULL;
-        //}
-        // FILE *fptr;
-        // fptr = fopen(mpiioMappingsPath, "a+");
-
-        // char **strings;;
-        // strings = backtrace_symbols (rec_ref->write_traces[file_rec->write_count].address_array, size);
-        // if (strings != NULL)
-        // {
-        //     for (int j = 0; j < size; j++){
-        //         if (strings[j] != NULL)
-        //             fprintf(fptr, "%s\n", strings[j]);
-        //     }
-        // }
-        
-        // fclose(fptr);
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
         rec_ref->write_traces[file_rec->write_count].size = size;
     }
@@ -498,23 +423,6 @@ void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
     if (isStackTrace){
         int size = backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
-        //for (int i = size; i < STACK_TRACE_BUF_SIZE; i++){
-        //  rec_ref->read_traces[file_rec->read_count].address_array[i] = NULL;
-        //}
-        // FILE *fptr;
-        // fptr = fopen(mpiioMappingsPath, "a+");
-        
-        // char **strings;;
-        // strings = backtrace_symbols (rec_ref->read_traces[file_rec->read_count].address_array, size);
-        // if (strings != NULL)
-        // {
-        //     for (int j = 0; j < size; j++){
-        //         if (strings[j] != NULL)
-        //             fprintf(fptr, "%s\n", strings[j]);
-        //     }
-        // }
-        
-        // fclose(fptr);
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
         rec_ref->read_traces[file_rec->read_count].size = size;
     }
@@ -919,41 +827,46 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
-    if (isStackTrace){
-        // clock_t start, end;
-        // double cpu_time_used;
-        // start = clock();
-
-        // char *path = malloc(4096);
-        // get_log_file_path(path);
-        // char substr[256] = "posix_mappings.txt";
-        // char * pch;
-        // pch=strchr(path,'.');
-     
-        // int ind = strlen(path) - strlen(pch) + 1;
-        // for (int i = 0; i < strlen(substr); i++){
-        //     path[ind] = substr[i];
-        //     ind = ind + 1;
-        // }
-        // path[ind] ='\0';
-        
+    if (isStackTrace){        
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-posix", dxt_my_rank);
 
         FILE *fptr;
         fptr = fopen(stack_file_name, "w");
 
-        /*for(int i = 0; i < record_write_count; i++){
+        typedef struct {
+            void *address;             /* key */
+            UT_hash_handle hh;         /* makes this structure hashable */
+        } stack_struct;
+
+        stack_struct *unique_mem_addr = NULL;
+
+        char * exe_name = darshan_exe();
+        for(int i = 0; i < record_write_count; i++){
             char **strings;
             int size = rec_ref->write_traces[i].size;
             strings = backtrace_symbols (rec_ref->write_traces[i].address_array, size);
             if (strings != NULL)
             {
                 for (int j = 0; j < size; j++){
-                    fwrite(fptr, "%s\n", strings[j]);
+                    if (strstr(strings[j], exe_name) != NULL) {
+                        stack_struct *d = NULL;
+                        char * token = strtok(strings[j], "[");
+                        token = strtok(NULL, "[");
+                        token = strtok(token, "]");
+                        int number = (int)strtol(token, NULL, 16);
+                        void *addr = number;
+                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
+
+                        if (!d) {
+                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
+                            e->address = addr;
+                            HASH_ADD_PTR(unique_mem_addr, address, e);
+                        }
+                    }
                 }
+                free(strings);
             }
-	        free(strings);
         }
 
         for(int i = 0; i < record_read_count; i++){           
@@ -963,53 +876,37 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
             if (strings != NULL)
             {
                 for (int j = 0; j < size; j++){
-                    // printf("%s\n", strings[i]);
-                    fprintf(fptr, "%s\n", strings[j]);
+                    if (strstr(strings[j], exe_name) != NULL) {
+                        stack_struct *d = NULL;
+                        char * token = strtok(strings[j], "[");
+                        token = strtok(NULL, "[");
+                        token = strtok(token, "]");
+                        int number = (int)strtol(token, NULL, 16);
+                        void *addr = number;
+                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
+
+                        if (!d) {
+                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
+                            e->address = addr;
+                            HASH_ADD_PTR(unique_mem_addr, address, e);
+                        }
+                    }
                 }
-            }
-            free(strings);
-        }*/
-
-        typedef struct {
-            void *address;             /* key */
-            UT_hash_handle hh;         /* makes this structure hashable */
-        } stack_struct;
-
-        stack_struct *unique_mem_addr = NULL;
-
-        for(int i = 0; i < record_write_count; i++){
-            int size = rec_ref->write_traces[i].size;
-            
-            for (int j = 0; j < size; j++) {
-                stack_struct *d = NULL;
-
-                void *addr = rec_ref->write_traces[i].address_array[j];
-                // printf("looking for %p\n", addr);
-                HASH_FIND_PTR(unique_mem_addr, &addr, d);
-
-                if (!d) {
-                    //printf("not found\n");
-                    stack_struct *e = (stack_struct *) malloc(sizeof *e);
-
-                    e->address = addr;
-
-                    HASH_ADD_PTR(unique_mem_addr, address, e);
-                }
+                free(strings);
             }
         }
 
         stack_struct *d = NULL;
 
         for (d = unique_mem_addr; d != NULL; d = (stack_struct *)(d->hh.next)) {
-            //printf("unique-> %p\n", d->address);
             fprintf(fptr, "%p\n", d->address);
-
             HASH_DEL(unique_mem_addr, d);
         }
 
         //fflush(fptr);
         fclose(fptr);
     }
+    
     /*
      * Buffer format:
      * dxt_file_record + write_traces + read_traces
@@ -1103,26 +1000,21 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
-    if (isStackTrace){
-        // clock_t start, end;
-        // double cpu_time_used;
-        // start = clock();
+    if (isStackTrace){ 
+        char stack_file_name[50];
+        sprintf(stack_file_name, ".%d.darshan-mpiio", dxt_my_rank);
 
-        // char *path = malloc(4096);
-        // get_log_file_path(path);
-        // char substr[256] = "/tmp/mpiio_mappings.txt";
-        // char * pch;
-        // pch=strchr(path,'.');
-     
-        // int ind = strlen(path) - strlen(pch) + 1;
-        // for (int i = 0; i < strlen(substr); i++){
-        //     path[ind] = substr[i];
-        //     ind = ind + 1;
-        // }
-        // path[ind] ='\0';
+        FILE *fptr;
+        fptr = fopen(stack_file_name, "w");
 
-        /*FILE *fptr;
-        fptr = fopen("/tmp/mpiio_mappings.txt", "a");
+        typedef struct {
+            void *address;             /* key */
+            UT_hash_handle hh;         /* makes this structure hashable */
+        } stack_struct;
+
+        stack_struct *unique_mem_addr = NULL;
+
+        char * exe_name = darshan_exe();
 
         for(int i = 0; i < record_write_count; i++){
             char **strings;
@@ -1131,23 +1023,62 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
             if (strings != NULL)
             {
                 for (int j = 0; j < size; j++){
-                    fprintf(fptr, "%s\n", strings[j]);
+                    if (strstr(strings[j], exe_name) != NULL) {
+                        stack_struct *d = NULL;
+                        char * token = strtok(strings[j], "[");
+                        token = strtok(NULL, "[");
+                        token = strtok(token, "]");
+                        int number = (int)strtol(token, NULL, 16);
+                        void *addr = number;
+                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
+
+                        if (!d) {
+                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
+                            e->address = addr;
+                            HASH_ADD_PTR(unique_mem_addr, address, e);
+                        }
+                    }
                 }
+                free(strings);
             }
         }
 
-        for(int i = 0; i < record_read_count; i++){
+        for(int i = 0; i < record_read_count; i++){           
             char **strings;
             int size = rec_ref->read_traces[i].size;
             strings = backtrace_symbols (rec_ref->read_traces[i].address_array, size);
             if (strings != NULL)
             {
                 for (int j = 0; j < size; j++){
-                    fprintf(fptr, "%s\n", strings[j]);
+                    if (strstr(strings[j], exe_name) != NULL) {
+                        stack_struct *d = NULL;
+                        char * token = strtok(strings[j], "[");
+                        token = strtok(NULL, "[");
+                        token = strtok(token, "]");
+                        int number = (int)strtol(token, NULL, 16);
+                        void *addr = number;
+                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
+
+                        if (!d) {
+                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
+                            e->address = addr;
+                            HASH_ADD_PTR(unique_mem_addr, address, e);
+                        }
+                    }
                 }
+                free(strings);
             }
-        }*/
-        //fclose(fptr);
+        }
+
+        stack_struct *d = NULL;
+
+        for (d = unique_mem_addr; d != NULL; d = (stack_struct *)(d->hh.next)) {
+            fprintf(fptr, "%p\n", d->address);
+            HASH_DEL(unique_mem_addr, d);
+        }
+
+        //fflush(fptr);
+        fclose(fptr);
     }
     /*
      * Buffer format:

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -265,6 +265,8 @@ void dxt_posix_write(darshan_record_id rec_id, int64_t offset,
     rec_ref->write_traces[file_rec->write_count].length = length;
     rec_ref->write_traces[file_rec->write_count].start_time = start_time;
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
+
+    /* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
     if (isStackTrace){
         int size = backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
@@ -317,6 +319,7 @@ void dxt_posix_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].length = length;
     rec_ref->read_traces[file_rec->read_count].start_time = start_time;
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
+    /* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
     if (isStackTrace){
         int size = backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
@@ -368,6 +371,7 @@ void dxt_mpiio_write(darshan_record_id rec_id, int64_t offset,
     rec_ref->write_traces[file_rec->write_count].offset = offset;
     rec_ref->write_traces[file_rec->write_count].start_time = start_time;
     rec_ref->write_traces[file_rec->write_count].end_time = end_time;
+    /* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
     if (isStackTrace){
         int size = backtrace (rec_ref->write_traces[file_rec->write_count].address_array, STACK_TRACE_BUF_SIZE);
         rec_ref->write_traces[file_rec->write_count].noStackTrace = 1;
@@ -420,6 +424,7 @@ void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
     rec_ref->read_traces[file_rec->read_count].offset = offset;
     rec_ref->read_traces[file_rec->read_count].start_time = start_time;
     rec_ref->read_traces[file_rec->read_count].end_time = end_time;
+    /* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
     if (isStackTrace){
         int size = backtrace (rec_ref->read_traces[file_rec->read_count].address_array , STACK_TRACE_BUF_SIZE);
         rec_ref->read_traces[file_rec->read_count].noStackTrace = 1;
@@ -826,6 +831,7 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
+    /* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
     if (isStackTrace){    
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-posix", dxt_my_rank);
@@ -974,6 +980,7 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
+    /* Code added by Hammad Ather (hather@lbl.gov) and Jean Luca Bez (jlbez@lbl.gov) */
     if (isStackTrace){ 
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-mpiio", dxt_my_rank);

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -838,7 +838,6 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
             UT_hash_handle hh;         /* makes this structure hashable */
         } stack_struct;
 
-        stack_struct *unique_mem_addr = NULL;
 
         char * exe_name = darshan_exe();
         for(int i = 0; i < record_write_count; i++){
@@ -849,19 +848,11 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
             {
                 for (int j = 0; j < size; j++){
                     if (strstr(strings[j], exe_name) != NULL) {
-                        stack_struct *d = NULL;
                         char * token = strtok(strings[j], "[");
                         token = strtok(NULL, "[");
                         token = strtok(token, "]");
                         int number = (int)strtol(token, NULL, 16);
-                        void *addr = number;
-                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
-
-                        if (!d) {
-                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
-                            e->address = addr;
-                            HASH_ADD_PTR(unique_mem_addr, address, e);
-                        }
+                        fprintf(fptr, "%p\n", number);
                     }
                 }
                 free(strings);
@@ -876,34 +867,17 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
             {
                 for (int j = 0; j < size; j++){
                     if (strstr(strings[j], exe_name) != NULL) {
-                        stack_struct *d = NULL;
                         char * token = strtok(strings[j], "[");
                         token = strtok(NULL, "[");
                         token = strtok(token, "]");
                         int number = (int)strtol(token, NULL, 16);
-                        void *addr = number;
-                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
-
-                        if (!d) {
-                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
-                            e->address = addr;
-                            HASH_ADD_PTR(unique_mem_addr, address, e);
-                        }
+                        fprintf(fptr, "%p\n", number);
                     }
                 }
                 free(strings);
             }
         }
 
-        stack_struct *d = NULL;
-
-
-        for (d = unique_mem_addr; d != NULL; d = (stack_struct *)(d->hh.next)) {
-            fprintf(fptr, "%p\n", d->address);
-            HASH_DEL(unique_mem_addr, d);
-        }
-
-        //fflush(fptr);
         fclose(fptr);
     }
     
@@ -1012,7 +986,6 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
             UT_hash_handle hh;         /* makes this structure hashable */
         } stack_struct;
 
-        stack_struct *unique_mem_addr = NULL;
 
         char * exe_name = darshan_exe();
 
@@ -1024,19 +997,11 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
             {
                 for (int j = 0; j < size; j++){
                     if (strstr(strings[j], exe_name) != NULL) {
-                        stack_struct *d = NULL;
                         char * token = strtok(strings[j], "[");
                         token = strtok(NULL, "[");
                         token = strtok(token, "]");
                         int number = (int)strtol(token, NULL, 16);
-                        void *addr = number;
-                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
-
-                        if (!d) {
-                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
-                            e->address = addr;
-                            HASH_ADD_PTR(unique_mem_addr, address, e);
-                        }
+                        fprintf(fptr, "%p\n", number);
                     }
                 }
                 free(strings);
@@ -1051,33 +1016,17 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
             {
                 for (int j = 0; j < size; j++){
                     if (strstr(strings[j], exe_name) != NULL) {
-                        stack_struct *d = NULL;
                         char * token = strtok(strings[j], "[");
                         token = strtok(NULL, "[");
                         token = strtok(token, "]");
                         int number = (int)strtol(token, NULL, 16);
-                        void *addr = number;
-                        HASH_FIND_PTR(unique_mem_addr, &addr, d);
-
-                        if (!d) {
-                            stack_struct *e = (stack_struct *) malloc(sizeof *e);
-                            e->address = addr;
-                            HASH_ADD_PTR(unique_mem_addr, address, e);
-                        }
+                        fprintf(fptr, "%p\n", number);
                     }
                 }
                 free(strings);
             }
         }
 
-        stack_struct *d = NULL;
-
-        for (d = unique_mem_addr; d != NULL; d = (stack_struct *)(d->hh.next)) {
-            fprintf(fptr, "%p\n", d->address);
-            HASH_DEL(unique_mem_addr, d);
-        }
-
-        //fflush(fptr);
         fclose(fptr);
     }
     /*

--- a/darshan-runtime/lib/darshan-dxt.c
+++ b/darshan-runtime/lib/darshan-dxt.c
@@ -62,9 +62,6 @@ typedef int64_t off64_t;
 #define STACK_TRACE_BUF_SIZE       60
 
 bool isStackTrace = false;
-bool processedBeforePOSIX = false;
-bool processedBeforeMPIIO = false;
-
 /* The dxt_file_record_ref structure maintains necessary runtime metadata
  * for the DXT file record (dxt_file_record structure, defined in
  * darshan-dxt-log-format.h) pointed to by 'file_rec'. This metadata
@@ -829,8 +826,7 @@ static void dxt_serialize_posix_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
-    if (isStackTrace && processedBeforePOSIX == false){    
-        processedBeforePOSIX = true;    
+    if (isStackTrace){    
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-posix", dxt_my_rank);
 
@@ -1004,8 +1000,7 @@ static void dxt_serialize_mpiio_records(void *rec_ref_p, void *user_ptr)
     if (record_write_count == 0 && record_read_count == 0)
         return;
     
-    if (isStackTrace && processedBeforeMPIIO == false){ 
-        processedBeforeMPIIO = true;
+    if (isStackTrace){ 
         char stack_file_name[50];
         sprintf(stack_file_name, ".%d.darshan-mpiio", dxt_my_rank);
 

--- a/darshan-runtime/lib/darshan-dxt.h
+++ b/darshan-runtime/lib/darshan-dxt.h
@@ -19,7 +19,8 @@
 enum dxt_trigger_type
 {
     DXT_SMALL_IO_TRIGGER,
-    DXT_UNALIGNED_IO_TRIGGER
+    DXT_UNALIGNED_IO_TRIGGER,
+    DXT_COLLECT_STACK_TRACE
 };
 struct dxt_trigger
 {
@@ -35,6 +36,7 @@ struct dxt_trigger
         } unaligned_io;
     } u;
 };
+
 
 /* dxt_posix_runtime_initialize()
  *
@@ -71,5 +73,7 @@ void dxt_mpiio_read(darshan_record_id rec_id, int64_t offset,
         int64_t length, double start_time, double end_time);
 
 void dxt_posix_apply_trace_filter(struct dxt_trigger *trigger);
+
+void dxt_enable_stack_trace();
 
 #endif /* __DARSHAN_DXT_H */

--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -57,6 +57,7 @@ DARSHAN_FORWARD_DECL(H5Oopen_by_token, hid_t, (hid_t loc_id, H5O_token_t token))
 #endif
 DARSHAN_FORWARD_DECL(H5Oclose, herr_t, (hid_t object_id));
 
+
 /* structure that can track i/o stats for a given HDF5 file record at runtime */
 struct hdf5_file_record_ref
 {

--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -57,7 +57,6 @@ DARSHAN_FORWARD_DECL(H5Oopen_by_token, hid_t, (hid_t loc_id, H5O_token_t token))
 #endif
 DARSHAN_FORWARD_DECL(H5Oclose, herr_t, (hid_t object_id));
 
-
 /* structure that can track i/o stats for a given HDF5 file record at runtime */
 struct hdf5_file_record_ref
 {

--- a/darshan-runtime/lib/darshan.h
+++ b/darshan-runtime/lib/darshan.h
@@ -314,6 +314,15 @@ int darshan_core_register_module(
 void darshan_core_unregister_module(
     darshan_module_id mod_id);
 
+
+char *darshan_exe();
+
+void set_posix_line_mapping(
+    char *mapping_array, bool isStackTrace);
+
+void set_mpiio_line_mapping(
+    char *mapping_array, bool isStackTrace);
+
 /* darshan_instrument_fs_data()
  *
  * Allow file system-specific modules to instrument data for the file

--- a/darshan-util/darshan-dxt-logutils.c
+++ b/darshan-util/darshan-dxt-logutils.c
@@ -23,7 +23,7 @@
 
 #include "darshan-logutils.h"
 
-#define STACK_TRACE_BUF_SIZE       26
+#define STACK_TRACE_BUF_SIZE       60
 
 static int dxt_log_get_posix_file(darshan_fd fd, void** dxt_posix_buf_p);
 static int dxt_log_put_posix_file(darshan_fd fd, void* dxt_posix_buf);
@@ -354,7 +354,7 @@ void dxt_log_print_posix_file(void *posix_file_rec, char *file_name,
     }
 
     if (isStackTrace)
-        printf("    Memory Offsets");
+        printf("    Stack Memory Addresses");
     printf("\n");
 
     /* Print IO Traces information */
@@ -384,11 +384,15 @@ void dxt_log_print_posix_file(void *posix_file_rec, char *file_name,
         }
 
         if (isStackTrace){
+            bool first = true;
             printf("    [");
             for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
-                printf("%p",  io_trace[i].address_array[j]);
-                if (j != STACK_TRACE_BUF_SIZE - 1)
-                    printf(", ");
+                if (io_trace[i].address_array[j]){
+                    if (j != STACK_TRACE_BUF_SIZE - 1 && first == false)
+                        printf(", ");
+                    printf("%p",  io_trace[i].address_array[j]);
+                    first = false;
+                }
             }
             printf("]");
         }
@@ -421,11 +425,15 @@ void dxt_log_print_posix_file(void *posix_file_rec, char *file_name,
         }
 
         if (isStackTrace){
+            bool first = true;
             printf("    [");
             for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
-                printf("%p",  io_trace[i].address_array[j]);
-                if (j != STACK_TRACE_BUF_SIZE - 1)
-                    printf(", ");
+                if (io_trace[i].address_array[j]){
+                    if (j != STACK_TRACE_BUF_SIZE - 1 && first == false)
+                        printf(", ");
+                    printf("%p",  io_trace[i].address_array[j]);
+                    first = false;
+                }
             }
             printf("]");
         }
@@ -470,7 +478,7 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
 
     /* Print header */
     if (isStackTrace)
-        printf("# Module    Rank  Wt/Rd  Segment          Offset        Length         Start(s)    End(s)     Memory Offsets\n");
+        printf("# Module    Rank  Wt/Rd  Segment          Offset        Length        Start(s)    End(s)     Stack Memory Addresses\n");
     else
         printf("# Module    Rank  Wt/Rd  Segment          Offset        Length         Start(s)    End(s)\n");
 
@@ -484,11 +492,15 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
         printf("%8s%8" PRId64 "%7s%9d%16" PRId64 "%16" PRId64 "%12.4f%12.4f", "X_MPIIO", rank, "write", i, offset, length, start_time, end_time);
 
         if (isStackTrace){
+            bool first = true;
             printf("     [");
             for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
-                printf("%p",  io_trace[i].address_array[j]);
-                if (j != STACK_TRACE_BUF_SIZE - 1)
-                    printf(", ");
+                if (io_trace[i].address_array[j]){
+                    if (j != STACK_TRACE_BUF_SIZE - 1 && first == false)
+                        printf(", ");
+                    printf("%p",  io_trace[i].address_array[j]);    
+                    first = false;
+                }
             }
             printf("]");
         }
@@ -504,11 +516,15 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
         printf("%8s%8" PRId64 "%7s%9d%16" PRId64 "%16" PRId64 "%12.4f%12.4f", "X_MPIIO", rank, "read", (int)(i - write_count), offset, length, start_time, end_time);
         
         if (isStackTrace){
+            bool first = true;
             printf("     [");
             for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
-                printf("%p",  io_trace[i].address_array[j]);
-                if (j != STACK_TRACE_BUF_SIZE - 1)
-                    printf(", ");
+                if (io_trace[i].address_array[j]){
+                    if (j != STACK_TRACE_BUF_SIZE - 1 && first == false)
+                        printf(", ");
+                    printf("%p",  io_trace[i].address_array[j]);
+                    first = false;
+                }
             }
             printf("]");
         }

--- a/darshan-util/darshan-dxt-logutils.c
+++ b/darshan-util/darshan-dxt-logutils.c
@@ -23,6 +23,8 @@
 
 #include "darshan-logutils.h"
 
+#define STACK_TRACE_BUF_SIZE       26
+
 static int dxt_log_get_posix_file(darshan_fd fd, void** dxt_posix_buf_p);
 static int dxt_log_put_posix_file(darshan_fd fd, void* dxt_posix_buf);
 
@@ -321,7 +323,7 @@ void dxt_log_print_posix_file(void *posix_file_rec, char *file_name,
         lustreFS = 0;
     }
 
-    if (io_trace->stack_trace.noStackTrace==0)
+    if (io_trace->noStackTrace==0)
         isStackTrace = false;
 
     printf("\n# DXT, file_id: %" PRIu64 ", file_name: %s\n", f_id, file_name);
@@ -383,9 +385,9 @@ void dxt_log_print_posix_file(void *posix_file_rec, char *file_name,
 
         if (isStackTrace){
             printf("    [");
-            for (int j = 0; j < 10; j++) {
-                printf("%p",  io_trace[i].stack_trace.address_array[j]);
-                if (j != 9)
+            for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
+                printf("%p",  io_trace[i].address_array[j]);
+                if (j != STACK_TRACE_BUF_SIZE - 1)
                     printf(", ");
             }
             printf("]");
@@ -420,9 +422,9 @@ void dxt_log_print_posix_file(void *posix_file_rec, char *file_name,
 
         if (isStackTrace){
             printf("    [");
-            for (int j = 0; j < 10; j++) {
-                printf("%p",  io_trace[i].stack_trace.address_array[j]);
-                if (j != 9)
+            for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
+                printf("%p",  io_trace[i].address_array[j]);
+                if (j != STACK_TRACE_BUF_SIZE - 1)
                     printf(", ");
             }
             printf("]");
@@ -456,7 +458,7 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
         ((void *)file_rec + sizeof(struct dxt_file_record));
     
     bool isStackTrace = true;
-    if (io_trace[0].stack_trace.noStackTrace == 0)
+    if (io_trace[0].noStackTrace == 0)
         isStackTrace = false;
 
     printf("\n# DXT, file_id: %" PRIu64 ", file_name: %s\n", f_id, file_name);
@@ -483,9 +485,9 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
 
         if (isStackTrace){
             printf("     [");
-            for (int j = 0; j < 10; j++) {
-                printf("%p",  io_trace[i].stack_trace.address_array[j]);
-                if (j != 9)
+            for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
+                printf("%p",  io_trace[i].address_array[j]);
+                if (j != STACK_TRACE_BUF_SIZE - 1)
                     printf(", ");
             }
             printf("]");
@@ -503,9 +505,9 @@ void dxt_log_print_mpiio_file(void *mpiio_file_rec, char *file_name,
         
         if (isStackTrace){
             printf("     [");
-            for (int j = 0; j < 10; j++) {
-                printf("%p",  io_trace[i].stack_trace.address_array[j]);
-                if (j != 9)
+            for (int j = 0; j < STACK_TRACE_BUF_SIZE; j++) {
+                printf("%p",  io_trace[i].address_array[j]);
+                if (j != STACK_TRACE_BUF_SIZE - 1)
                     printf(", ");
             }
             printf("]");

--- a/darshan-util/darshan-dxt-parser.c
+++ b/darshan-util/darshan-dxt-parser.c
@@ -138,6 +138,18 @@ int main(int argc, char **argv)
         printf("# metadata: %s = %s\n", key, value);
     }
 
+    if (strlen(fd->posix_line_mapping) != 0){
+        printf("\n# DXT-POSIX address to line mapping\n");
+        printf("# -------------------------------------------------------\n");
+        printf("%s", fd->posix_line_mapping);
+    }
+
+    if (strlen(fd->mpiio_line_mapping) != 0){
+        printf("\n# DXT-MPIIO address to line mapping\n");
+        printf("# -------------------------------------------------------\n");
+        printf("%s", fd->mpiio_line_mapping);
+    }
+
     /* print breakdown of each log file region's contribution to file size */
     printf("\n# log file regions\n");
     printf("# -------------------------------------------------------\n");

--- a/darshan-util/darshan-logutils.c
+++ b/darshan-util/darshan-logutils.c
@@ -432,12 +432,14 @@ int darshan_log_get_exe(darshan_fd fd, char *buf)
     }
 
     /* exe string is located before the first line break */
+    // printf("%s", state->exe_mnt_data);
     newline = strchr(state->exe_mnt_data, '\n');
 
     /* copy over the exe string */
     if(newline)
         memcpy(buf, state->exe_mnt_data, (newline - state->exe_mnt_data));
-
+    else
+        memcpy(buf, state->exe_mnt_data, strlen(state->exe_mnt_data));
     return (0);
 }
 

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -40,7 +40,8 @@ struct darshan_fd_s
     struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
     /* module-specific log-format versions contained in log */
     uint32_t mod_ver[DARSHAN_MAX_MODS];
-
+    char posix_line_mapping[1024];
+    char mpiio_line_mapping[1024];
     /* KEEP OUT -- remaining state hidden in logutils source */
     struct darshan_fd_int_state *state;
 

--- a/darshan-util/darshan-logutils.h
+++ b/darshan-util/darshan-logutils.h
@@ -40,8 +40,8 @@ struct darshan_fd_s
     struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
     /* module-specific log-format versions contained in log */
     uint32_t mod_ver[DARSHAN_MAX_MODS];
-    char posix_line_mapping[1024];
-    char mpiio_line_mapping[1024];
+    char posix_line_mapping[4096];
+    char mpiio_line_mapping[4096];
     /* KEEP OUT -- remaining state hidden in logutils source */
     struct darshan_fd_int_state *state;
 

--- a/darshan-util/darshan-parser.c
+++ b/darshan-util/darshan-parser.c
@@ -236,7 +236,6 @@ int main(int argc, char **argv)
         value++;
         printf("# metadata: %s = %s\n", key, value);
     }
-
     /* print breakdown of each log file region's contribution to file size */
     printf("\n# log file regions\n");
     printf("# -------------------------------------------------------\n");

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -177,6 +177,10 @@ typedef struct segment_info {
     int64_t length;
     double start_time;
     double end_time;
+    union {
+        void *address_array[10];
+        int noStackTrace;
+    } stack_trace;
 } segment_info;
 
 /* counter names */

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -32,6 +32,47 @@ struct darshan_derived_metrics {
     struct darshan_file_category_counters category_counters[7];
 };
 
+#define DARSHAN_MAX_MODS 64
+
+struct darshan_log_map
+{
+    uint64_t off;
+    uint64_t len;
+};
+
+struct darshan_fd_int_state;
+
+/* darshan file descriptor definition */
+struct darshan_fd_s
+{
+    /* log file version */
+    char version[8];
+    /* flag indicating whether byte swapping needs to be
+     * performed on log file data
+     */
+    int swap_flag;
+    /* bit-field indicating whether modules contain incomplete data */
+    uint64_t partial_flag;
+    /* compression type used on log file */
+    enum darshan_comp_type comp_type;
+    /* log file offset/length maps for each log file region */
+    struct darshan_log_map job_map;
+    struct darshan_log_map name_map;
+    struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
+    /* module-specific log-format versions contained in log */
+    uint32_t mod_ver[DARSHAN_MAX_MODS];
+    char posix_line_mapping[1024];
+    char mpiio_line_mapping[1024];
+    /* KEEP OUT -- remaining state hidden in logutils source */
+    struct darshan_fd_int_state *state;
+
+    /* workaround to parse logs with slightly inconsistent heatmap bin
+     * counts as described in https://github.com/darshan-hpc/darshan/issues/941
+     */
+    int64_t first_heatmap_record_nbins;
+    double first_heatmap_record_bin_width_seconds;
+};
+
 struct darshan_mnt_info
 {
     char mnt_type[3015];
@@ -63,7 +104,7 @@ int darshan_accumulator_destroy(darshan_accumulator);
 
 /* from darshan-log-format.h */
 typedef uint64_t darshan_record_id;
-#define STACK_TRACE_BUF_SIZE       26
+#define STACK_TRACE_BUF_SIZE       60
 
 struct darshan_job
 {

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -63,6 +63,7 @@ int darshan_accumulator_destroy(darshan_accumulator);
 
 /* from darshan-log-format.h */
 typedef uint64_t darshan_record_id;
+#define STACK_TRACE_BUF_SIZE       26
 
 struct darshan_job
 {
@@ -177,10 +178,8 @@ typedef struct segment_info {
     int64_t length;
     double start_time;
     double end_time;
-    union {
-        void *address_array[10];
-        int noStackTrace;
-    } stack_trace;
+    void *address_array[STACK_TRACE_BUF_SIZE];
+    int noStackTrace;
 } segment_info;
 
 /* counter names */

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -61,8 +61,8 @@ struct darshan_fd_s
     struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
     /* module-specific log-format versions contained in log */
     uint32_t mod_ver[DARSHAN_MAX_MODS];
-    char posix_line_mapping[1024];
-    char mpiio_line_mapping[1024];
+    char posix_line_mapping[4096];
+    char mpiio_line_mapping[4096];
     /* KEEP OUT -- remaining state hidden in logutils source */
     struct darshan_fd_int_state *state;
 

--- a/darshan-util/pydarshan/darshan/backend/api_def_c.py
+++ b/darshan-util/pydarshan/darshan/backend/api_def_c.py
@@ -221,6 +221,7 @@ typedef struct segment_info {
     double end_time;
     void *address_array[STACK_TRACE_BUF_SIZE];
     int noStackTrace;
+    int size;
 } segment_info;
 
 /* counter names */

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -92,7 +92,7 @@ _structdefs = {
     "APMPI-PERF": "struct darshan_apmpi_perf_record **",
 }
 
-
+STACK_TRACE_BUF_SIZE = 26
 
 def get_lib_version():
     """
@@ -617,9 +617,9 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
             "end_time": segments[i].end_time
         }
         seg_array = []
-        if not segments[i].stack_trace.noStackTrace == 0:
-            for j in range(10):
-                addr = str(segments[i].stack_trace.address_array[j])
+        if not segments[i].noStackTrace == 0:
+            for j in range(STACK_TRACE_BUF_SIZE):
+                addr = str(segments[i].address_array[j])
                 addr = addr.split("'void *' ")
                 addr = addr[1].split(">")
                 seg_array.append(addr[0])
@@ -637,9 +637,9 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
             "end_time": segments[i].end_time
         }
         seg_array = []
-        if not segments[i].stack_trace.noStackTrace == 0:
-            for j in range(10):
-                addr = str(segments[i].stack_trace.address_array[j])
+        if not segments[i].noStackTrace == 0:
+            for j in range(STACK_TRACE_BUF_SIZE):
+                addr = str(segments[i].address_array[j])
                 addr = addr.split("'void *' ")
                 addr = addr[1].split(">")
                 seg_array.append(addr[0])

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -92,7 +92,7 @@ _structdefs = {
     "APMPI-PERF": "struct darshan_apmpi_perf_record **",
 }
 
-STACK_TRACE_BUF_SIZE = 26
+STACK_TRACE_BUF_SIZE = 30
 
 def get_lib_version():
     """
@@ -583,7 +583,6 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
         return None
     mod_type = _structdefs[mod_name]
     #name_records = log_get_name_records(log)
-
     rec = {}
     buf = ffi.new("void **")
     r = libdutil.darshan_log_get_record(log['handle'], modules[mod_name]['idx'], buf)
@@ -605,7 +604,6 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
     rec['write_segments'] = []
     rec['read_segments'] = []
 
-
     size_of = ffi.sizeof("struct dxt_file_record")
     segments = ffi.cast("struct segment_info *", buf[0] + size_of  )
 
@@ -619,12 +617,13 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
         seg_array = []
         if not segments[i].noStackTrace == 0:
             for j in range(STACK_TRACE_BUF_SIZE):
-                addr = str(segments[i].address_array[j])
-                addr = addr.split("'void *' ")
-                addr = addr[1].split(">")
-                seg_array.append(addr[0])
+                if (segments[i].address_array[j]):
+                    addr = str(segments[i].address_array[j])
+                    addr = addr.split("'void *' ")
+                    addr = addr[1].split(">")
+                    seg_array.append(addr[0])
             seg["stack_memory_addresses"] = seg_array
-     
+
         rec['write_segments'].append(seg)
 
 
@@ -639,10 +638,11 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
         seg_array = []
         if not segments[i].noStackTrace == 0:
             for j in range(STACK_TRACE_BUF_SIZE):
-                addr = str(segments[i].address_array[j])
-                addr = addr.split("'void *' ")
-                addr = addr[1].split(">")
-                seg_array.append(addr[0])
+                if (segments[i].address_array[j]):
+                    addr = str(segments[i].address_array[j])
+                    addr = addr.split("'void *' ")
+                    addr = addr[1].split(">")
+                    seg_array.append(addr[0])
             seg["stack_memory_addresses"] = seg_array
 
         rec['read_segments'].append(seg)
@@ -651,6 +651,54 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
     if dtype == "pandas":
         rec['read_segments'] = pd.DataFrame(rec['read_segments'])
         rec['write_segments'] = pd.DataFrame(rec['write_segments'])
+
+    size_of = ffi.sizeof("struct darshan_fd_s")
+    address_line_mapping = ffi.cast("struct darshan_fd_s *", log['handle'])
+
+    if mod_name == 'DXT_POSIX':
+        rec['posix_address_line_mapping'] = []
+        data = ffi.string(address_line_mapping.posix_line_mapping)
+        data = data.decode('utf-8')
+        data = data.split('\n')
+        for item in data:
+            if item:
+                item = item.split(",")
+                address = item[0]
+
+                func_line = item[1]
+                func_line = func_line.split(":")
+                function_name = func_line[0]
+                line_number = func_line[1]
+
+                mapping = {
+                    "address": address,
+                    "function_name": function_name,
+                    "line_number": line_number
+                }
+
+                rec['posix_address_line_mapping'].append(mapping)
+    elif mod_name == 'DXT_MPIIO':
+        rec['mpiio_address_line_mapping'] = []
+        data = ffi.string(address_line_mapping.mpiio_line_mapping)
+        data = data.decode('utf-8')
+        data = data.split('\n')
+        for item in data:
+            if item:
+                item = item.split(",")
+                address = item[0]
+
+                func_line = item[1]
+                func_line = func_line.split(":")
+                function_name = func_line[0]
+                line_number = func_line[1]
+
+                mapping = {
+                    "address": address,
+                    "function_name": function_name,
+                    "line_number": line_number
+                }
+
+                rec['mpiio_address_line_mapping'].append(mapping)
 
     libdutil.darshan_free(buf[0])
     return rec

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -52,7 +52,6 @@ libdutil = find_utils(ffi, libdutil)
 
 check_version(ffi, libdutil)
 
-
 _mod_names = [
     "NULL",
     "POSIX",
@@ -121,6 +120,7 @@ def log_open(filename):
     Return:
         log handle
     """
+
     b_fname = filename.encode()
     handle = libdutil.darshan_log_open(b_fname)
     log = {"handle": handle, 'modules': None, 'name_records': None}
@@ -609,7 +609,6 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
     size_of = ffi.sizeof("struct dxt_file_record")
     segments = ffi.cast("struct segment_info *", buf[0] + size_of  )
 
-
     for i in range(wcnt):
         seg = {
             "offset": segments[i].offset,
@@ -617,6 +616,15 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
             "start_time": segments[i].start_time,
             "end_time": segments[i].end_time
         }
+        seg_array = []
+        if not segments[i].stack_trace.noStackTrace == 0:
+            for j in range(10):
+                addr = str(segments[i].stack_trace.address_array[j])
+                addr = addr.split("'void *' ")
+                addr = addr[1].split(">")
+                seg_array.append(addr[0])
+            seg["stack_memory_addresses"] = seg_array
+     
         rec['write_segments'].append(seg)
 
 
@@ -628,6 +636,15 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
             "start_time": segments[i].start_time,
             "end_time": segments[i].end_time
         }
+        seg_array = []
+        if not segments[i].stack_trace.noStackTrace == 0:
+            for j in range(10):
+                addr = str(segments[i].stack_trace.address_array[j])
+                addr = addr.split("'void *' ")
+                addr = addr[1].split(">")
+                seg_array.append(addr[0])
+            seg["stack_memory_addresses"] = seg_array
+
         rec['read_segments'].append(seg)
 
 

--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -97,7 +97,7 @@ _structdefs = {
     "APMPI-PERF": "struct darshan_apmpi_perf_record **",
 }
 
-STACK_TRACE_BUF_SIZE = 30
+STACK_TRACE_BUF_SIZE = 60
 
 def get_lib_version():
     """
@@ -626,7 +626,7 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
                     addr = str(segments[i].address_array[j])
                     addr = addr.split("'void *' ")
                     addr = addr[1].split(">")
-                    seg_array.append(addr[0])
+                    seg_array.append(str(addr[0]))
             seg["stack_memory_addresses"] = seg_array
 
         rec['write_segments'].append(seg)
@@ -647,7 +647,7 @@ def log_get_dxt_record(log, mod_name, reads=True, writes=True, dtype='dict'):
                     addr = str(segments[i].address_array[j])
                     addr = addr.split("'void *' ")
                     addr = addr[1].split(">")
-                    seg_array.append(addr[0])
+                    seg_array.append(str(addr[0]))
             seg["stack_memory_addresses"] = seg_array
 
         rec['read_segments'].append(seg)

--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -268,6 +268,10 @@ class DarshanRecordCollection(collections.abc.MutableSequence):
             for rec in records:
                 rec['read_segments'] = pd.DataFrame(rec['read_segments'])
                 rec['write_segments'] = pd.DataFrame(rec['write_segments'])
+                if mod == 'DXT_POSIX':
+                    rec['posix_address_line_mapping'] = pd.DataFrame(rec['posix_address_line_mapping'])
+                elif mod == 'DXT_MPIIO':
+                    rec['mpiio_address_line_mapping'] = pd.DataFrame(rec['mpiio_address_line_mapping'])
         else:
             df_recs = pd.DataFrame.from_records(records)
             # generic records have counter and fcounter arrays to collect

--- a/darshan-util/pydarshan/darshan/report.py
+++ b/darshan-util/pydarshan/darshan/report.py
@@ -269,9 +269,9 @@ class DarshanRecordCollection(collections.abc.MutableSequence):
                 rec['read_segments'] = pd.DataFrame(rec['read_segments'])
                 rec['write_segments'] = pd.DataFrame(rec['write_segments'])
                 if mod == 'DXT_POSIX':
-                    rec['posix_address_line_mapping'] = pd.DataFrame(rec['posix_address_line_mapping'])
+                    rec['address_line_mapping'] = pd.DataFrame(rec['address_line_mapping'])
                 elif mod == 'DXT_MPIIO':
-                    rec['mpiio_address_line_mapping'] = pd.DataFrame(rec['mpiio_address_line_mapping'])
+                    rec['address_line_mapping'] = pd.DataFrame(rec['address_line_mapping'])
         else:
             df_recs = pd.DataFrame.from_records(records)
             # generic records have counter and fcounter arrays to collect

--- a/include/darshan-dxt-log-format.h
+++ b/include/darshan-dxt-log-format.h
@@ -26,6 +26,8 @@ typedef struct segment_info {
     double end_time;
     void *address_array[STACK_TRACE_BUF_SIZE];
     int noStackTrace;
+    int size;
+    void *address_symbols_array[STACK_TRACE_BUF_SIZE];
 } segment_info;
 
 #define X(a) a,

--- a/include/darshan-dxt-log-format.h
+++ b/include/darshan-dxt-log-format.h
@@ -12,7 +12,7 @@
 
 #define HOSTNAME_SIZE 64
 
-#define STACK_TRACE_BUF_SIZE       26
+#define STACK_TRACE_BUF_SIZE       60
 
 #include <stdbool.h>
 /*

--- a/include/darshan-dxt-log-format.h
+++ b/include/darshan-dxt-log-format.h
@@ -11,7 +11,7 @@
 #define DXT_MPIIO_VER 2
 
 #define HOSTNAME_SIZE 64
-
+#include <stdbool.h>
 /*
  * DXT, the segment_info structure maintains detailed Segment IO tracing
  * information
@@ -21,6 +21,10 @@ typedef struct segment_info {
     int64_t length;
     double start_time;
     double end_time;
+    union {
+        void *address_array[10];
+        int noStackTrace;
+    } stack_trace;
 } segment_info;
 
 #define X(a) a,

--- a/include/darshan-dxt-log-format.h
+++ b/include/darshan-dxt-log-format.h
@@ -11,6 +11,9 @@
 #define DXT_MPIIO_VER 2
 
 #define HOSTNAME_SIZE 64
+
+#define STACK_TRACE_BUF_SIZE       26
+
 #include <stdbool.h>
 /*
  * DXT, the segment_info structure maintains detailed Segment IO tracing
@@ -21,10 +24,8 @@ typedef struct segment_info {
     int64_t length;
     double start_time;
     double end_time;
-    union {
-        void *address_array[10];
-        int noStackTrace;
-    } stack_trace;
+    void *address_array[STACK_TRACE_BUF_SIZE];
+    int noStackTrace;
 } segment_info;
 
 #define X(a) a,

--- a/include/darshan-dxt-log-format.h
+++ b/include/darshan-dxt-log-format.h
@@ -27,7 +27,6 @@ typedef struct segment_info {
     void *address_array[STACK_TRACE_BUF_SIZE];
     int noStackTrace;
     int size;
-    void *address_symbols_array[STACK_TRACE_BUF_SIZE];
 } segment_info;
 
 #define X(a) a,

--- a/include/darshan-log-format.h
+++ b/include/darshan-log-format.h
@@ -76,6 +76,8 @@ struct darshan_header
     struct darshan_log_map name_map;
     struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
     uint32_t mod_ver[DARSHAN_MAX_MODS];
+    char posix_line_mapping[1024];
+    char mpiio_line_mapping[1024];
 };
 
 /* job-level metadata stored for this application */

--- a/include/darshan-log-format.h
+++ b/include/darshan-log-format.h
@@ -76,8 +76,8 @@ struct darshan_header
     struct darshan_log_map name_map;
     struct darshan_log_map mod_map[DARSHAN_MAX_MODS];
     uint32_t mod_ver[DARSHAN_MAX_MODS];
-    char posix_line_mapping[1024];
-    char mpiio_line_mapping[1024];
+    char posix_line_mapping[4096];
+    char mpiio_line_mapping[4096];
 };
 
 /* job-level metadata stored for this application */


### PR DESCRIPTION
- Added support for collecting backtrace memory addresses using backtrace () and backtrace_symbols ()
- Get address-to-line mappings using addr2line for the unique memory addresses corresponding to the binary
- Modified Darshan logs to include the address-to-line mappings as part of the Darshan header and the complete memory addresses stack as part of the DXT trace data