### PR TITLE
Fix cibuildwheel process failing due to undeclared dynamic pyproject.toml metadata and missing test dependencies 

### DIFF
--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
 name = "darshan"
 requires-python = ">=3.7"
 version = "3.4.4.0"
+dynamic = ["description", "readme", "keywords", "classifiers"]
 
 [tool.cibuildwheel]
 environment = "PYDARSHAN_BUILD_EXT=1"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -23,6 +23,10 @@ skip = [
 test-requires = [
     "packaging",
     "pytest",
+    "cffi",
+    "pandas",
+    "seaborn",
+    "mako",
     "lxml",
     "matplotlib",
     "importlib_resources;python_version<'3.9'",


### PR DESCRIPTION
cibuildwheel builds fail complaining about a missing test dependencies (pytest) and dynamic properties in pyproject.toml not declared explicitly raising the following error:

`/tmp/pip-build-env-9ywkt6zf/overlay/lib/python3.8/site-packages/setuptools/config/_apply_pyprojecttoml.py:75: _MissingDynamic: `description` defined outside of `pyproject.toml` is ignored`

This pull request updates pyproject.toml and marks the affected fields as dynamic and adds missing test dependencies to resolve the issues.