### PR TITLE
BUG: fix handling of `fscanf`/`__isoc99_fscanf`

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -740,19 +740,15 @@ if test "x$enable_darshan_runtime" = xyes ; then
    # End of MPI-only checks
    #
 
-   AC_MSG_CHECKING(for fscanf redirect)
-   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-      #define _GNU_SOURCE
-      #include <stdio.h>
-      int fscanf(FILE *stream, const char *format, ...) {return(0);}
-      int __isoc99_fscanf(FILE *stream, const char *format, ...) {return(0);}
-      ]])],
-      [AC_MSG_RESULT(no)
-       DARSHAN_STDIO_ADD_FSCANF_LD_OPTS="--wrap=__isoc99_fscanf"],
-      [AC_MSG_RESULT(yes)
-       AC_DEFINE([HAVE_FSCANF_REDIRECT], 1,
-                 [Define if fscanf is redirected to another function])
-       DARSHAN_STDIO_ADD_FSCANF_LD_OPTS=""]
+   # Newer glibc implementations will redirect fscanf calls to
+   # __isoc99_fscanf calls. To properly handle this, we detect the
+   # presence of the __isoc99_fscanf symbol and compile it's wrapper
+   # if found. Otherwise, we will use the traditional fscanf wrapper.
+   # We must only wrap one of these calls to avoid multiple definition
+   # errors when building Darshan.
+   AC_CHECK_FUNCS([__isoc99_fscanf],
+      [DARSHAN_STDIO_ADD_FSCANF_LD_OPTS="--wrap=__isoc99_fscanf"],
+      [DARSHAN_STDIO_ADD_FSCANF_LD_OPTS="--wrap=fscanf"]
    )
 
    # look for glibc-specific functions

--- a/darshan-runtime/lib/darshan-stdio.c
+++ b/darshan-runtime/lib/darshan-stdio.c
@@ -113,9 +113,10 @@ DARSHAN_FORWARD_DECL(fgetc, int, (FILE *stream));
 DARSHAN_FORWARD_DECL(getw, int, (FILE *stream));
 DARSHAN_FORWARD_DECL(_IO_getc, int, (FILE *stream));
 DARSHAN_FORWARD_DECL(_IO_putc, int, (int, FILE *stream));
-DARSHAN_FORWARD_DECL(fscanf, int, (FILE *stream, const char *format, ...));
-#ifndef HAVE_FSCANF_REDIRECT
+#ifdef HAVE___ISOC99_FSCANF
 DARSHAN_FORWARD_DECL(__isoc99_fscanf, int, (FILE *stream, const char *format, ...));
+#else
+DARSHAN_FORWARD_DECL(fscanf, int, (FILE *stream, const char *format, ...));
 #endif
 DARSHAN_FORWARD_DECL(vfscanf, int, (FILE *stream, const char *format, va_list ap));
 DARSHAN_FORWARD_DECL(fgets, char*, (char *s, int size, FILE *stream));
@@ -739,7 +740,7 @@ int DARSHAN_DECL(getw)(FILE *stream)
     return(ret);
 }
 
-#ifndef HAVE_FSCANF_REDIRECT
+#ifdef HAVE___ISOC99_FSCANF
 /* NOTE: some glibc versions use __isoc99_fscanf as the underlying symbol
  * rather than fscanf
  */
@@ -770,8 +771,7 @@ int DARSHAN_DECL(__isoc99_fscanf)(FILE *stream, const char *format, ...)
 
     return(ret);
 }
-#endif
-
+#else
 int DARSHAN_DECL(fscanf)(FILE *stream, const char *format, ...)
 {
     int ret;
@@ -799,6 +799,7 @@ int DARSHAN_DECL(fscanf)(FILE *stream, const char *format, ...)
 
     return(ret);
 }
+#endif
 
 int DARSHAN_DECL(vfscanf)(FILE *stream, const char *format, va_list ap)
 {

--- a/darshan-runtime/share/ld-opts/darshan-stdio-ld-opts.in
+++ b/darshan-runtime/share/ld-opts/darshan-stdio-ld-opts.in
@@ -9,7 +9,6 @@
 --wrap=fwrite
 --wrap=fread
 --wrap=fgetc
---wrap=fscanf
 --wrap=vfscanf
 --wrap=_IO_getc
 --wrap=_IO_putc


### PR DESCRIPTION
A long time ago we added a wrapper and an autoconf test for the `__isoc99_fscanf` function that can be found in newer glibc implementations. It doesn't appear as though this old autoconf test appropriately tests whether we should include a wrapper for the `__isoc99_fscanf` routine. Locally, this autoconf test was failing even though I have `__isoc99_fscanf`, leading to missed instrumentation of these calls.

We can't simply offer wrappers for both `fscanf` and `__isoc99_fscanf`, as this leads to symbol redefinition errors when building Darshan's shared library.

This PR tries to address the issue by detecting the presence of `__isoc99_fscanf`, and including a wrapper for that call if found. If not found, we include our traditional `fscanf` wrapper. The key is to ensure that only one of these wrappers is available in Darshan, and that we prefer `__isoc99_fscanf` if available.