### PR TITLE
CI: fix mypy errors

### DIFF
--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -29,8 +29,6 @@ def response():
     pass
 
 
-@pytest.mark.skipif(not pytest.has_log_repo,
-                    reason="missing darshan_logs")
 @pytest.mark.parametrize("log_filepath",
         _provide_logs_repo_filepaths()
         )

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -177,8 +177,6 @@ def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_coun
                 summary.main()
 
 
-@pytest.mark.skipif(not pytest.has_log_repo,
-                    reason="missing darshan_logs")
 @pytest.mark.parametrize("log_filepath",
         _provide_logs_repo_filepaths()
         )


### PR DESCRIPTION
We're getting errors like this in the PyDarshan CI now related to the mypy step:

```
darshan/tests/test_summary.py:180: error: Module has no attribute "has_log_repo"  [attr-defined]
darshan/tests/test_report.py:32: error: Module has no attribute "has_log_repo"  [attr-defined]
```

which I think is caused by injecting variables into pytest (and later referencing them in tests), like in `conftest.py`:

```
def pytest_configure():
    pytest.has_log_repo = has_log_repo
```

As a temporary workaround, just remove offending pytest `skipif` decorators -- it looks like this modification just works and still properly skips tests due to not having the log file repo. The only downside is the skip reason is less helpful now, e.g. instead of:

```
SKIPPED [1] darshan/tests/test_report.py:32: missing darshan_logs
```

we now get:

```
SKIPPED [1] darshan/tests/test_report.py:32: got empty parameter set ['log_filepath'], function test_jobid_type_all_logs_repo_files at /home/shane/software/darshan/darshan-python/darshan-util/pydarshan/darshan/tests/test_report.py:31
```

I'm open to alternative solutions. I couldn't come up with anything that allows us to detect the presence of the log repo from inside a decorator like that.