### PR TITLE
ENH: wrap _exit in Darshan's shared library

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -754,6 +754,18 @@ if test "x$enable_darshan_runtime" = xyes ; then
    # look for glibc-specific functions
    AC_CHECK_FUNCS([pwritev preadv pwritev2 preadv2])
 
+   # allow users to opt out of wrapping of _exit as a shutdown hook in
+   # Darshan's non-MPI mode, in case this functionality is problematic
+   AC_ARG_ENABLE([exit-wrapper],
+      [AS_HELP_STRING([--disable-exit-wrapper],
+                      [Disables wrapping of _exit() calls as last ditch shutdown
+                       hook for the Darshan library when used in non-MPI mode.])],
+      [], [enable_exit_wrapper=yes])
+   if test "x$enable_exit_wrapper" = "xyes" ; then
+      AC_DEFINE([__DARSHAN_ENABLE_EXIT_WRAPPER], 1,
+                [Define if the Darshan runtime library should wrap _exit() calls])
+   fi
+
    DARSHAN_VERSION="AC_PACKAGE_VERSION"
    AC_SUBST(LDFLAGS)
    AC_SUBST(__DARSHAN_LOG_PATH)

--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -120,6 +120,8 @@ make install
 * `--disable-ld-preload`: disables building of the Darshan LD_PRELOAD library
 * `--enable-group-readable-logs`: sets Darshan log file permissions to allow
   group read access.
+* `--disable-exit-wrapper`: disables wrapping of `_exit()` calls as last ditch
+  shutdown hook for the Darshan library when used in non-MPI mode.
 * `CC=`: specifies the C compiler to use for compilation.
 
 .Configure arguments for controlling which Darshan modules to use:

--- a/darshan-runtime/lib/darshan-core-init-finalize.c
+++ b/darshan-runtime/lib/darshan-core-init-finalize.c
@@ -115,7 +115,7 @@ __attribute__((destructor)) void serial_finalize(void)
 }
 #endif
 
-#ifdef DARSHAN_PRELOAD
+#if defined(DARSHAN_PRELOAD) && defined(__DARSHAN_ENABLE_EXIT_WRAPPER)
 void (*__real__exit)(int status) __attribute__ ((noreturn)) = NULL;
 void _exit(int status)
 {

--- a/darshan-runtime/lib/darshan-core-init-finalize.c
+++ b/darshan-runtime/lib/darshan-core-init-finalize.c
@@ -115,6 +115,21 @@ __attribute__((destructor)) void serial_finalize(void)
 }
 #endif
 
+#ifdef DARSHAN_PRELOAD
+void (*__real__exit)(int status) __attribute__ ((noreturn)) = NULL;
+void _exit(int status)
+{
+    MAP_OR_FAIL(_exit);
+    (void)__darshan_disabled;
+
+    char *no_mpi = getenv("DARSHAN_ENABLE_NONMPI");
+    if (no_mpi)
+        darshan_core_shutdown(1);
+
+    __real__exit(status);
+}
+#endif
+
 /*
  * Local variables:
  *  c-indent-level: 4


### PR DESCRIPTION
Python apps using the `multiprocessing` package can invoke the `_exit()` call directly. E.g., see [this code](https://hg.python.org/cpython/file/e04cd497aa41/Lib/multiprocessing/popen_fork.py#l76).

Invoking `_exit()` directly bypasses Darshan's shared library destructor, which is what is used to write out its log file. So, these processes spawned by `multiprocessing` are properly instrumenting I/O calls, but never get an opportunity to write the instrumentation data to log file. 

This PR adds a function wrapper for `_exit()`, which Darshan uses to intercept `_exit()` calls, invoking the Darshan shutdown procedure before calling the real _exit implementation. This modification to Darshan seems to fix some issues reported by users related to this issue (e.g., #872). Let's see if it can get through our CI without causing other issues.

Note that this code is only included in our shared library, since it's intended for Darshan's non-MPI mode (which only works when dynamically linking).

Keeping this PR as a WIP at least until I add some autoconf support to disable this functionality entirely, in case it becomes problematic in some scenarios.