### PR TITLE
BUG: fix darshan-runtime config parsing leading to infinite loops

### DIFF
--- a/darshan-runtime/lib/darshan-config.c
+++ b/darshan-runtime/lib/darshan-config.c
@@ -299,16 +299,18 @@ void darshan_parse_config_env(struct darshan_config *cfg)
                     continue;
                 }
                 ret = regcomp(&regex->regex, token, REG_EXTENDED);
-                if(ret)
+                if(!ret)
+                {
+                    LL_APPEND(cfg->app_exclusion_list, regex);
+                }
+                else
                 {
                     darshan_core_fprintf(stderr, "darshan library warning: "\
                         "unable to compile Darshan config DARSHAN_APP_EXCLUDE "\
                         "regex %s\n", token);
                     free(regex->regex_str);
                     free(regex);
-                    continue;
                 }
-                LL_APPEND(cfg->app_exclusion_list, regex);
             }
             token = strtok(NULL, ",");
         }
@@ -332,16 +334,18 @@ void darshan_parse_config_env(struct darshan_config *cfg)
                     continue;
                 }
                 ret = regcomp(&regex->regex, token, REG_EXTENDED);
-                if(ret)
+                if(!ret)
+                {
+                    LL_APPEND(cfg->app_inclusion_list, regex);
+                }
+                else
                 {
                     darshan_core_fprintf(stderr, "darshan library warning: "\
                         "unable to compile Darshan config DARSHAN_APP_INCLUDE "\
                         "regex %s\n", token);
                     free(regex->regex_str);
                     free(regex);
-                    continue;
                 }
-                LL_APPEND(cfg->app_inclusion_list, regex);
             }
             token = strtok(NULL, ",");
         }
@@ -578,16 +582,18 @@ void darshan_parse_config_file(struct darshan_config *cfg)
                             break;
                         }
                         ret = regcomp(&regex->regex, token, REG_EXTENDED);
-                        if(ret)
+                        if(!ret)
+                        {
+                            LL_APPEND(cfg->app_exclusion_list, regex);
+                        }
+                        else
                         {
                             darshan_core_fprintf(stderr, "darshan library warning: "\
                                 "unable to compile Darshan config %s regex %s\n",
                                 key, token);
                             free(regex->regex_str);
                             free(regex);
-                            continue;
                         }
-                        LL_APPEND(cfg->app_exclusion_list, regex);
                         token = strtok(NULL, ",");
                     }
                 }
@@ -609,16 +615,18 @@ void darshan_parse_config_file(struct darshan_config *cfg)
                             break;
                         }
                         ret = regcomp(&regex->regex, token, REG_EXTENDED);
-                        if(ret)
+                        if(!ret)
+                        {
+                            LL_APPEND(cfg->app_inclusion_list, regex);
+                        }
+                        else
                         {
                             darshan_core_fprintf(stderr, "darshan library warning: "\
                                 "unable to compile Darshan config %s regex %s\n",
                                 key, token);
                             free(regex->regex_str);
                             free(regex);
-                            continue;
                         }
-                        LL_APPEND(cfg->app_inclusion_list, regex);
                         token = strtok(NULL, ",");
                     }
                 }
@@ -723,16 +731,18 @@ void darshan_parse_config_file(struct darshan_config *cfg)
                             }
                             regex->mod_flags = tmp_mod_flags;
                             ret = regcomp(&regex->regex, token, REG_EXTENDED);
-                            if(ret)
+                            if(!ret)
+                            {
+                                LL_APPEND(cfg->rec_exclusion_list, regex);
+                            }
+                            else
                             {
                                 darshan_core_fprintf(stderr, "darshan library warning: "\
                                     "unable to compile Darshan config %s regex %s\n",
                                     key, token);
                                 free(regex->regex_str);
                                 free(regex);
-                                continue;
                             }
-                            LL_APPEND(cfg->rec_exclusion_list, regex);
                             token = strtok(NULL, ",");
                         }
                     }
@@ -760,16 +770,18 @@ void darshan_parse_config_file(struct darshan_config *cfg)
                             }
                             regex->mod_flags = tmp_mod_flags;
                             ret = regcomp(&regex->regex, token, REG_EXTENDED);
-                            if(ret)
+                            if(!ret)
+                            {
+                                LL_APPEND(cfg->rec_inclusion_list, regex);
+                            }
+                            else
                             {
                                 darshan_core_fprintf(stderr, "darshan library warning: "\
                                     "unable to compile Darshan config %s regex %s\n",
                                     key, token);
                                 free(regex->regex_str);
                                 free(regex);
-                                continue;
                             }
-                            LL_APPEND(cfg->rec_inclusion_list, regex);
                             token = strtok(NULL, ",");
                         }
                     }


### PR DESCRIPTION
Various Darshan config variables take a CSV of regexes as input (e.g. APP_EXCLUDE, NAME_EXCLUDE). Darshan's code for iterating and parsing these regexes can cause an infinite loop if one of the regexes is unable to be compiled. E.g.,

```
NAME_EXCLUDE    *    POSIX
```

The 2nd field is the regex CSV (in this case just a single regex), but `*` is not a valid regex (it is a special character indicating that the preceding character(s) are repeated one or more times, but there are no preceding characters above) and causes an error when compiling the regex. This input causes Darshan to continuously output the following warning:

```
darshan library warning: unable to compile Darshan config NAME_EXCLUDE regex *
```

This PR fixes the bug causing the Darshan library to continuously parse the same erroneous token rather than printing a warning once and advancing.