### PR TITLE
fix STDIO counter names in documentation

### DIFF
--- a/darshan-util/doc/darshan-util.txt
+++ b/darshan-util/doc/darshan-util.txt
@@ -356,11 +356,11 @@ value of 1 MiB for optimal file alignment.
 | STDIO_FASTEST_RANK_BYTES | The number of bytes transferred by the rank with the smallest time spent in stdio operations (cumulative read, write, and meta times)
 | STDIO_SLOWEST_RANK | The MPI rank with the largest time spent in stdio operations (cumulative read, write, and meta times)
 | STDIO_SLOWEST_RANK_BYTES | The number of bytes transferred by the rank with the largest time spent in stdio operations (cumulative read, write, and meta times)
-| STDIO_META_TIME | Cumulative time spent in stdio open/close/seek operations
-| STDIO_WRITE_TIME | Cumulative time spent in stdio write operations
-| STDIO_READ_TIME | Cumulative time spent in stdio read operations
-| STDIO_*_START_TIMESTAMP | Timestamp that the first stdio file open/read/write/close operation began
-| STDIO_*_END_TIMESTAMP | Timestamp that the last stdio file open/read/write/close operation ended
+| STDIO_F_META_TIME | Cumulative time spent in stdio open/close/seek operations
+| STDIO_F_WRITE_TIME | Cumulative time spent in stdio write operations
+| STDIO_F_READ_TIME | Cumulative time spent in stdio read operations
+| STDIO_F_*_START_TIMESTAMP | Timestamp that the first stdio file open/read/write/close operation began
+| STDIO_F_*_END_TIMESTAMP | Timestamp that the last stdio file open/read/write/close operation ended
 | STDIO_F_FASTEST_RANK_TIME | The time of the rank which had the smallest time spent in stdio I/O (cumulative read, write, and meta times)
 | STDIO_F_SLOWEST_RANK_TIME | The time of the rank which had the largest time spent in stdio I/O (cumulative read, write, and meta times)
 | STDIO_F_VARIANCE_RANK_TIME | The population variance for stdio I/O time of all the ranks


### PR DESCRIPTION
The documentation seems to refer to some STDIO counters with a slightly different name than the ones shown in the parsers. 