### PR TITLE
DOC: add link to an example PyDarshan report in docs

### DIFF
--- a/darshan-util/pydarshan/RELEASE-CHECKLIST-PyDarshan.txt
+++ b/darshan-util/pydarshan/RELEASE-CHECKLIST-PyDarshan.txt
@@ -16,6 +16,8 @@ Notes on how to release a new version of PyDarshan
     - make docs
     - upload docs/build/html contents to CELS server @ /nfs/pub_html/gce/projects/darshan/docs/pydarshan
     - (might eventually connect this with readthedocs to have this automatically uploaded)
+    - determine whether new job summary tool features warrant generating a new summary report to include in docs
+        (stored @ /nfs/pub_html/gce/projects/darshan/docs/example_report.html)
 
  - Submit to PyPI using cibuildwheel/twine:
     - pipx run build --sdist

--- a/darshan-util/pydarshan/docs/usage.rst
+++ b/darshan-util/pydarshan/docs/usage.rst
@@ -8,7 +8,9 @@ Darshan job summary tool
 ------------------------
 
 As a starting point, users can use PyDarshan to generate detailed
-summary HTML reports of I/O activity for a given Darshan log.
+summary HTML reports of I/O activity for a given Darshan log. An
+example job summary report can be viewed `HERE <https://www.mcs.anl.gov/research/projects/darshan/docs/example_report.html>`_.
+
 Usage of this job summary tool is described below. ::
 
     usage: darshan summary [-h] [--output OUTPUT] [--enable_dxt_heatmap] log_path


### PR DESCRIPTION
This PR adds a link to an example PyDarshan job summary HTML report to our docs, and adds a note to the release checklist to consider updating the example report as new features are added.

You can view the example report here: https://www.mcs.anl.gov/research/projects/darshan/docs/example_report.html