### PR TITLE
Darshan-LDMS Workflow Patch

### DIFF
--- a/.github/workflows/darshan_ldms_test_ci.yml
+++ b/.github/workflows/darshan_ldms_test_ci.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install openmpi-bin libopenmpi-dev
+        sudo apt-get install libjansson-dev
     - name: Clone LDMS
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This fixes the  libjansson error that was occurring when installing the LDMS from top of tree:
```checking for libjansson... no
configure: error: libjansson or jansson.h not found
```

