### PR TITLE
MAINT: stop using deprecated autoconf functions

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -300,10 +300,9 @@ if test "x$enable_darshan_runtime" = xyes ; then
          AC_MSG_ERROR([--enable-apmpi-mod Autoperf MPI module requires MPI support])
       fi
       abssrcdir=$(readlink -f ${srcdir})
-      AC_CHECK_HEADER([${abssrcdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h],
-                      [],
-                      [AC_MSG_ERROR([The Autoperf MPI module is not present])],
-                      [-]) # this last part tells it to only check for presence
+      AC_CHECK_FILE([${abssrcdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h],
+                    [],
+                    [AC_MSG_ERROR([The Autoperf MPI module is not present])])
 
       # APMPI only support MPI v3 or higher
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -339,10 +338,9 @@ if test "x$enable_darshan_runtime" = xyes ; then
                       [with_papi=-lpapi],
                       [AC_MSG_ERROR([Cannot find papi header required for Autoperf XC module])],
                       [])
-      AC_CHECK_HEADER([${abssrcdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h],
-                      [],
-                      [AC_MSG_ERROR([The Autoperf XC git submodule is not present])],
-                      [-]) # this last part tells it to only check for presence
+      AC_CHECK_FILE([${abssrcdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h],
+                    [],
+                    [AC_MSG_ERROR([The Autoperf XC git submodule is not present])])
    fi
 
    # inform about HDF5 installs not found in default locations
@@ -665,34 +663,29 @@ if test "x$enable_darshan_runtime" = xyes ; then
       old_cflags="$CFLAGS"
       CFLAGS="$CFLAGS -Werror"
       AC_MSG_CHECKING(for MPI prototypes without const qualifier)
-      AC_TRY_COMPILE(
-          [
-          #include <mpi.h>
-          int MPI_File_open(MPI_Comm comm, char *filename, int amode,
-              MPI_Info info, MPI_File *fh)
-              {return 0;}
-          ],
-          [],
-          [AC_MSG_RESULT(yes)
-           AS_IF([test "x$BUILD_APMPI_MODULE" = "x1"],
-                 AC_MSG_ERROR(APMPI module requires MPI version 3+))],
-          [AC_MSG_RESULT(no)
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+         #include <mpi.h>
+         int MPI_File_open(MPI_Comm comm, char *filename, int amode,
+             MPI_Info info, MPI_File *fh)
+             {return 0;}
+         ],[])],
+         [AC_MSG_RESULT(yes)
+          AS_IF([test "x$BUILD_APMPI_MODULE" = "x1"],
+                AC_MSG_ERROR(APMPI module requires MPI version 3+))],
+         [AC_MSG_RESULT(no)
 
           # unable to compile without const qualifiers.  Let's try again with
           # const qualifiers.
           AC_MSG_CHECKING(for MPI prototypes with const qualifier)
-          AC_TRY_COMPILE(
-              [
-              #include <mpi.h>
-              int MPI_File_open(MPI_Comm comm, const char *filename, int amode,
-                  MPI_Info info, MPI_File *fh)
-                  {return 0;}
-              ],
-              [],
-              AC_MSG_RESULT(yes)
-              AC_DEFINE(HAVE_MPI_CONST, 1, Define if MPI prototypes use const qualifier),
-              ,
-              AC_MSG_ERROR(Darshan is unable to find a compatible MPI_File_open prototype)
+          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+             #include <mpi.h>
+             int MPI_File_open(MPI_Comm comm, const char *filename, int amode,
+                 MPI_Info info, MPI_File *fh)
+                 {return 0;}
+             ],[])],
+             [AC_MSG_RESULT(yes)
+              AC_DEFINE(HAVE_MPI_CONST, 1, Define if MPI prototypes use const qualifier)],
+             [AC_MSG_ERROR(Darshan is unable to find a compatible MPI_File_open prototype)]
           )]
       )
       CFLAGS="$old_cflags"

--- a/darshan-util/configure.ac
+++ b/darshan-util/configure.ac
@@ -95,10 +95,9 @@ if test "x$enable_darshan_util" = xyes ; then
       [], [enable_apxc_mod=no]
    )
    if test "x$enable_apxc_mod" = xyes; then
-      AC_CHECK_HEADER([${ac_abs_confdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h],
+      AC_CHECK_FILE([${ac_abs_confdir}/../modules/autoperf/apxc/darshan-apxc-log-format.h],
                       DARSHAN_USE_APXC=1,
-                      [AC_MSG_ERROR([The autoperf APXC module is not present])],
-                      [-]) # this last part tells it to only check for presence
+                      [AC_MSG_ERROR([The autoperf APXC module is not present])])
    fi
    AC_ARG_ENABLE([apmpi_mod],
       [AS_HELP_STRING([--enable-apmpi-mod],
@@ -106,10 +105,9 @@ if test "x$enable_darshan_util" = xyes ; then
       [], [enable_apmpi_mod=no]
    )
    if test "x$enable_apmpi_mod" = xyes; then
-      AC_CHECK_HEADER([${ac_abs_confdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h],
-                      DARSHAN_USE_APMPI=1,
-                      [AC_MSG_ERROR([The autoperf MPI module is not present])],
-                      [-]) # this last part tells it to only check for presence
+      AC_CHECK_FILE([${ac_abs_confdir}/../modules/autoperf/apmpi/darshan-apmpi-log-format.h],
+                    DARSHAN_USE_APMPI=1,
+                    [AC_MSG_ERROR([The autoperf MPI module is not present])])
    fi
 
    AC_CHECK_FUNCS([strndup])

--- a/maint/config/check_bzlib.m4
+++ b/maint/config/check_bzlib.m4
@@ -61,7 +61,7 @@ then
         LDFLAGS="$LDFLAGS -L${BZLIB_HOME}/lib"
         CPPFLAGS="$CPPFLAGS -I${BZLIB_HOME}/include"
         AC_LANG_SAVE
-        AC_LANG_C
+        AC_LANG([C])
         AC_CHECK_LIB(bz2, BZ2_bzCompressInit, [bzlib_cv_libbz2=yes], [bzlib_cv_libbz2=no])
         AC_CHECK_HEADER(bzlib.h, [bzlib_cv_bzlib_h=yes], [bzlib_cv_bzlib_h=no])
         AC_LANG_RESTORE


### PR DESCRIPTION
We've gotten reports of strange errors when configuring `darshan-util` with APMPI support with newer autoconf versions (e.g., 2.72). I could not make sense of the errors, but there were lots of warnings about usage of deprecated functions, so I went ahead and fixed all of those here. Not exactly sure how, but it does seem to have resolved the weird configure error we're getting. Tested using autoconf 2.69 and 2.72 and things all seems good, but let's see how CI goes.