### PR TITLE
ENH: new PyDarshan CLI tools for job/file stats for many logs

### DIFF
--- a/darshan-util/pydarshan/darshan/cli/file_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/file_stats.py
@@ -1,0 +1,176 @@
+import pandas as pd
+import argparse
+import darshan
+import darshan.cli
+from darshan.backend.cffi_backend import accumulate_records
+from typing import Any, Union, Callable
+import glob
+
+def df_IO_data(file_path, mod):
+    """
+    Save the data in the columns ('id', 'POSIX_BYTES_READ', 'POSIX_BYTES_WRITTEN') from a single log file to a DataFrame.
+
+    Parameters
+    ----------
+    file_path : a string, the path to a darshan log file.
+    mod : a string, the module name
+
+    Returns
+    -------
+    a single DataFrame.
+
+    """
+    report = darshan.DarshanReport(file_path, read_all=True)
+    posix_recs = report.records[mod].to_df()
+    df = posix_recs['counters'][['id', f'{mod}_BYTES_READ', f'{mod}_BYTES_WRITTEN']]
+    return df
+
+def combined_dfs(list_dfs):
+    """
+    Combine DataFrames of each log files to one DataFrame.
+
+    Parameters
+    ----------
+    list_dfs : a list of DataFrames.
+
+    Returns
+    -------
+    a single DataFrame with data from multiple DataFrames.
+
+    """
+    combined_dfs = pd.concat(list_dfs, ignore_index = True)
+    return combined_dfs
+
+def group_by_id(combine_dfs):
+    """
+        Group DataFrame using the column 'id'.
+
+        Parameters
+        ----------
+        combined_dfs : a DataFrame with data from multiple DataFrames.
+
+        Returns
+        -------
+        a DataFrame with the sum of each group.
+
+    """
+    df_groupby_id_max = combine_dfs.groupby('id').sum()
+    return df_groupby_id_max
+
+def sort_data_desc(combined_dfs, order_by_colname):
+    """
+    Sort data by the column name the user inputs in a descending order.
+
+    Parameters
+    ----------
+    combined_dfs : a DataFrame with data from multiple DataFrames.
+    order_by_colname : a string, the column name
+
+    Returns
+    -------
+    a DataFrame with a descending order of one column.
+
+    """
+    combined_dfs_sort = combined_dfs.sort_values(by=[order_by_colname], ascending=False)
+    return combined_dfs_sort
+
+def first_n_recs(df, n):
+    """
+    Filtering the data with the first n records.
+
+    Parameters
+    ----------
+    df : a dataframe
+    n : an int, number of rows.
+
+    Returns
+    -------
+    a DataFrame with n rows.
+
+    """
+
+    combined_dfs_first_n = df.head(n)
+    return combined_dfs_first_n
+
+def setup_parser(parser: argparse.ArgumentParser):
+    """
+    Configures the command line arguments.
+
+    Parameters
+    ----------
+    parser : command line argument parser.
+
+    """
+    parser.description = "Generates a DataFrame with statistical data of n jobs for a certain module"
+
+    parser.add_argument(
+        "log_path",
+        type=str,
+        help="Specify the path to darshan log files."
+    )
+    parser.add_argument(
+        "module",
+        type=str,
+        help="Specify the module name."
+    )
+    parser.add_argument(
+        "order_by_colname",
+        type=str,
+        help="Specify the column name."
+    )
+    parser.add_argument(
+        "number_of_rows",
+        type=int,
+        help="The first n rows of the DataFrame"
+    )
+
+def discover_logpaths(user_path_glob):
+    """
+    Generate a list with log file paths.
+
+    Parameters
+    ----------
+    user_path :  a string, a path glob pattern from the user input
+
+    Returns
+    -------
+    a list with paths of log files.
+
+    """
+    paths = glob.glob(user_path_glob)
+    return paths
+
+def main(args: Union[Any, None] = None):
+    """
+    Generates a DataFrame based on user's input.
+
+    Parameters
+    ----------
+    args: command line arguments.
+
+    """
+    if args is None:
+        parser = argparse.ArgumentParser(description="")
+        setup_parser(parser)
+        args = parser.parse_args()
+    mod = args.module
+    order_by_colname = args.order_by_colname
+    n = args.number_of_rows
+    colname_list = [f'{mod}_BYTES_READ', f'{mod}_BYTES_WRITTEN']
+    if order_by_colname in colname_list:
+        log_paths = discover_logpaths(args.log_path)
+        item_number = len(log_paths)
+        list_dfs = []
+        for i in range(item_number):
+            df_i = df_IO_data(log_paths[i], mod)
+            list_dfs.append(df_i)
+        com_dfs = combined_dfs(list_dfs)
+        combined_dfs_groupby = group_by_id(com_dfs)
+        combined_dfs_sort = sort_data_desc(combined_dfs_groupby, order_by_colname)
+        combined_dfs_selected = first_n_recs(combined_dfs_sort, n)
+        print("Statistical data of files:", combined_dfs_selected)
+    else:
+        print("Column name should be '{mod}_BYTES_READ' or '{mod}_BYTES_WRITTEN'")
+
+if __name__ == "__main__":
+    main()

--- a/darshan-util/pydarshan/darshan/cli/file_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/file_stats.py
@@ -149,7 +149,6 @@ def main(args: Union[Any, None] = None):
     order_by_colname = args.order_by_colname
     if order_by_colname == " ":
         order_by_colname = f'{mod}_BYTES_READ'
-        print("order_by_colname: ", order_by_colname)
     n = args.number_of_rows
     colname_list = [f'{mod}_BYTES_READ', f'{mod}_BYTES_WRITTEN']
     if order_by_colname in colname_list:

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -1,3 +1,4 @@
+import sys
 import pandas as pd
 import argparse
 import darshan
@@ -22,6 +23,8 @@ def df_IO_data(file_path, mod):
 
     """
     report = darshan.DarshanReport(file_path, read_all=False)
+    if mod not in report.modules:
+        return pd.DataFrame()
     report.mod_read_all_records(mod)
     recs = report.records[mod].to_df()
     acc_rec = accumulate_records(recs, mod, report.metadata['job']['nprocs'])
@@ -153,7 +156,10 @@ def main(args: Union[Any, None] = None):
     list_dfs = []
     for log_path in log_paths:
         df_i = df_IO_data(log_path, mod)
-        list_dfs.append(df_i)
+        if not df_i.empty:
+            list_dfs.append(df_i)
+    if len(list_dfs) == 0:
+        sys.exit()
     combined_dfs = combine_dfs(list_dfs)
     combined_dfs_sorted = sort_dfs_desc(combined_dfs, order_by)
     df = first_n_recs(combined_dfs_sorted, limit)

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -1,0 +1,170 @@
+import pandas as pd
+import argparse
+import darshan
+import darshan.cli
+from darshan.backend.cffi_backend import accumulate_records
+from typing import Any, Union, Callable
+import glob
+
+def df_IO_data(file_path, mod):
+    """
+    Save the data from a single log file to a DataFrame.
+
+    Parameters
+    ----------
+    file_path : a string, the path to a darshan log file.
+    mod : a string, the module name
+
+    Returns
+    -------
+    a single DataFrame.
+
+    """
+    report = darshan.DarshanReport(file_path, read_all=True)
+    posix_recs = report.records[mod].to_df()
+    acc_recs = accumulate_records(posix_recs, mod, report.metadata['job']['nprocs'])
+    dict_recs = {}
+    dict_recs['agg_perf_by_slowest'] = acc_recs.derived_metrics.agg_perf_by_slowest
+    dict_recs['agg_time_by_slowest'] = acc_recs.derived_metrics.agg_time_by_slowest
+    dict_recs['category_counters'] = acc_recs.derived_metrics.category_counters
+    dict_recs['shared_io_total_time_by_slowest'] = acc_recs.derived_metrics.shared_io_total_time_by_slowest
+    dict_recs['total_bytes'] = acc_recs.derived_metrics.total_bytes
+    dict_recs['unique_io_slowest_rank'] = acc_recs.derived_metrics.unique_io_slowest_rank
+    dict_recs['unique_io_total_time_by_slowest'] = acc_recs.derived_metrics.unique_io_total_time_by_slowest
+    dict_recs['unique_md_only_time_by_slowest'] = acc_recs.derived_metrics.unique_md_only_time_by_slowest
+    dict_recs['unique_rw_only_time_by_slowest'] = acc_recs.derived_metrics.unique_rw_only_time_by_slowest
+    df = pd.DataFrame.from_dict([dict_recs])
+    return df
+
+def combined_dfs(list_dfs):
+    """
+    Combine DataFrames of each log files to one DataFrame.
+
+    Parameters
+    ----------
+    list_dfs : a list of DataFrames.
+
+    Returns
+    -------
+    a single DataFrame with data from multiple DataFrames.
+
+    """
+    combined_dfs = pd.concat(list_dfs, ignore_index = True)
+    return combined_dfs
+
+def sort_data_desc(combined_dfs, order_by_colname):
+    """
+    Sort data by the column name the user inputs in a descending order.
+
+    Parameters
+    ----------
+    combined_dfs : a DataFrame with data from multiple DataFrames.
+    order_by_colname : a string, the column name
+
+    Returns
+    -------
+    a DataFrame with a descending order of one column.
+
+    """
+    combined_dfs_sort = combined_dfs.sort_values(by=[order_by_colname], ascending=False)
+    return combined_dfs_sort
+
+def first_n_recs(df, n):
+    """
+    Filtering the data with the first n records.
+
+    Parameters
+    ----------
+    df : a dataframe
+    n : an int, number of rows.
+
+    Returns
+    -------
+    a DataFrame with n rows.
+
+    """
+
+    combined_dfs_first_n = df.head(n)
+    return combined_dfs_first_n
+
+def setup_parser(parser: argparse.ArgumentParser):
+    """
+    Configures the command line arguments.
+
+    Parameters
+    ----------
+    parser : command line argument parser.
+
+    """
+    parser.description = "Generates a DataFrame with statistical data of n jobs for a certain module"
+
+    parser.add_argument(
+        "log_path",
+        type=str,
+        help="Specify the path to darshan log files."
+    )
+    parser.add_argument(
+        "module",
+        type=str,
+        help="Specify the module name."
+    )
+    parser.add_argument(
+        "order_by_colname",
+        type=str,
+        help="Specify the column name."
+    )
+    parser.add_argument(
+        "number_of_rows",
+        type=int,
+        help="The first n rows of the DataFrame"
+    )
+
+def discover_logpaths(user_path):
+    """
+    Generate a list with all of the log file paths.
+
+    Parameters
+    ----------
+    user_path :  a string, user input for the file path
+
+    Returns
+    -------
+    a list with paths of log files.
+
+    """
+    paths = glob.glob(user_path + "worker*.darshan")
+    return paths
+
+def main(args: Union[Any, None] = None):
+    """
+    Generates a DataFrame based on user's input.
+
+    Parameters
+    ----------
+    args: command line arguments.
+
+    """
+    if args is None:
+        parser = argparse.ArgumentParser(description="")
+        setup_parser(parser)
+        args = parser.parse_args()
+    mod = args.module
+    order_by_colname = args.order_by_colname
+    n = args.number_of_rows
+    colname_list = ['agg_perf_by_slowest', 'agg_time_by_slowest', 'total_bytes']
+    if order_by_colname in colname_list:
+        log_paths = discover_logpaths(args.log_path)
+        item_number = len(log_paths)
+        list_dfs = []
+        for i in range(item_number):
+            df_i = df_IO_data(log_paths[i], mod)
+            list_dfs.append(df_i)
+        com_dfs = combined_dfs(list_dfs)
+        combined_dfs_sort = sort_data_desc(com_dfs, order_by_colname)
+        combined_dfs_selected = first_n_recs(combined_dfs_sort, n)
+        print("Statistical data of jobs:", combined_dfs_selected)
+    else:
+        print("Column name should be 'agg_perf_by_slowest', 'agg_time_by_slowest', or 'total_bytes'")
+
+if __name__ == "__main__":
+    main()

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -30,6 +30,7 @@ def df_IO_data(file_path, mod):
     acc_rec = accumulate_records(recs, mod, report.metadata['job']['nprocs'])
     dict_acc_rec = {}
     dict_acc_rec['log_file'] = file_path.split('/')[-1]
+    dict_acc_rec['exe'] = report.metadata['exe']
     dict_acc_rec['job_id'] = report.metadata['job']['jobid']
     dict_acc_rec['nprocs'] = report.metadata['job']['nprocs']
     dict_acc_rec['start_time'] = report.metadata['job']['start_time_sec']
@@ -38,6 +39,7 @@ def df_IO_data(file_path, mod):
     dict_acc_rec['agg_perf_by_slowest'] = acc_rec.derived_metrics.agg_perf_by_slowest * 1024**2
     dict_acc_rec['agg_time_by_slowest'] = acc_rec.derived_metrics.agg_time_by_slowest
     dict_acc_rec['total_bytes'] = acc_rec.derived_metrics.total_bytes
+    dict_acc_rec['total_files'] = acc_rec.derived_metrics.category_counters[0].count
     df = pd.DataFrame.from_dict([dict_acc_rec])
     return df
 
@@ -164,7 +166,8 @@ def main(args: Union[Any, None] = None):
     combined_dfs_sorted = sort_dfs_desc(combined_dfs, order_by)
     df = first_n_recs(combined_dfs_sorted, limit)
     if args.csv:
-        print(df.to_csv(index=False))
+        df = df.drop("exe", axis=1)
+        print(df.to_csv(index=False), end="")
     else:
         df.loc[:, 'start_time'] = df['start_time'].apply(lambda x: datetime.datetime.fromtimestamp(x).strftime("%m/%d/%Y %H:%M:%S"))
         df.loc[:, 'end_time'] = df['end_time'].apply(lambda x: datetime.datetime.fromtimestamp(x).strftime("%m/%d/%Y %H:%M:%S"))

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -119,20 +119,20 @@ def setup_parser(parser: argparse.ArgumentParser):
         help="The first n rows of the DataFrame"
     )
 
-def discover_logpaths(user_path):
+def discover_logpaths(user_path_glob):
     """
-    Generate a list with all of the log file paths.
+    Generate a list with log file paths.
 
     Parameters
     ----------
-    user_path :  a string, user input for the file path
+    user_path_glob :  a string, a path glob pattern from the user input
 
     Returns
     -------
     a list with paths of log files.
 
     """
-    paths = glob.glob(user_path + "worker*.darshan")
+    paths = glob.glob(user_path_glob)
     return paths
 
 def main(args: Union[Any, None] = None):

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -7,16 +7,16 @@ from typing import Any, Union, Callable
 
 def df_IO_data(file_path, mod):
     """
-    Save the data from a single log file to a DataFrame.
+    Save the statistical data from a single Darshan log file to a DataFrame.
 
     Parameters
     ----------
-    file_path : a string, the path to a darshan log file.
-    mod : a string, the module name
+    file_path : a string, the path to a Darshan log file.
+    mod : a string, the Darshan module name
 
     Returns
     -------
-    a single DataFrame.
+    a single DataFrame of job statistics.
 
     """
     report = darshan.DarshanReport(file_path, read_all=True)
@@ -29,9 +29,9 @@ def df_IO_data(file_path, mod):
     df = pd.DataFrame.from_dict([dict_recs])
     return df
 
-def combined_dfs(list_dfs):
+def combine_dfs(list_dfs):
     """
-    Combine DataFrames of each log files to one DataFrame.
+    Combine per-job DataFrames of each Darshan log into one DataFrame.
 
     Parameters
     ----------
@@ -39,32 +39,32 @@ def combined_dfs(list_dfs):
 
     Returns
     -------
-    a single DataFrame with data from multiple DataFrames.
+    a single DataFrame with data from multiple Darshan logs.
 
     """
-    combined_dfs = pd.concat(list_dfs, ignore_index = True)
+    combined_dfs = pd.concat(list_dfs, ignore_index=True)
     return combined_dfs
 
-def sort_data_desc(combined_dfs, order_by_colname):
+def sort_dfs_desc(combined_dfs, order_by):
     """
     Sort data by the column name the user inputs in a descending order.
 
     Parameters
     ----------
-    combined_dfs : a DataFrame with data from multiple DataFrames.
-    order_by_colname : a string, the column name
+    combined_dfs : a DataFrame with data from multiple Darshan logs.
+    order_by : a string, the column name of the statistical metric to sort by
 
     Returns
     -------
-    a DataFrame with a descending order of one column.
+    a DataFrame sorted in descending order by a given column.
 
     """
-    combined_dfs_sort = combined_dfs.sort_values(by=[order_by_colname], ascending=False)
-    return combined_dfs_sort
+    combined_dfs_sorted = combined_dfs.sort_values(by=[order_by], ascending=False)
+    return combined_dfs_sorted
 
 def first_n_recs(df, n):
     """
-    Filtering the data with the first n records.
+    Filter the data to return only the first n records.
 
     Parameters
     ----------
@@ -83,7 +83,7 @@ def first_n_recs(df, n):
 
 def setup_parser(parser: argparse.ArgumentParser):
     """
-    Configures the command line arguments.
+    Parses the command line arguments.
 
     Parameters
     ----------
@@ -121,7 +121,7 @@ def setup_parser(parser: argparse.ArgumentParser):
 
 def main(args: Union[Any, None] = None):
     """
-    Generates a DataFrame based on user's input.
+    Prints statistics on a set of input Darshan job logs.
 
     Parameters
     ----------
@@ -140,9 +140,9 @@ def main(args: Union[Any, None] = None):
     for log_path in log_paths:
         df_i = df_IO_data(log_path, mod)
         list_dfs.append(df_i)
-    com_dfs = combined_dfs(list_dfs)
-    combined_dfs_sort = sort_data_desc(com_dfs, order_by_colname)
-    combined_dfs_selected = first_n_recs(combined_dfs_sort, n)
+    combined_dfs = combine_dfs(list_dfs)
+    combined_dfs_sorted = sort_dfs_desc(combined_dfs, order_by)
+    combined_dfs_selected = first_n_recs(combined_dfs_sorted, limit)
     print("Statistical data of jobs:\n", combined_dfs_selected)
 
 if __name__ == "__main__":

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -11,7 +11,7 @@ from humanize import naturalsize
 from rich.console import Console
 from rich.table import Table
 
-def df_IO_data(file_path, mod):
+def df_IO_data(file_path, mod, filter_patterns, filter_mode):
     """
     Save the statistical data from a single Darshan log file to a DataFrame.
 
@@ -25,10 +25,14 @@ def df_IO_data(file_path, mod):
     a single DataFrame of job statistics.
 
     """
+    extra_options = {}
+    if filter_patterns:
+        extra_options["filter_patterns"] = filter_patterns
+        extra_options["filter_mode"] = filter_mode
     report = darshan.DarshanReport(file_path, read_all=False)
     if mod not in report.modules:
         return pd.DataFrame()
-    report.mod_read_all_records(mod)
+    report.mod_read_all_records(mod, **extra_options)
     recs = report.records[mod].to_df()
     acc_rec = accumulate_records(recs, mod, report.metadata['job']['nprocs'])
     dict_acc_rec = {}
@@ -155,20 +159,17 @@ def setup_parser(parser: argparse.ArgumentParser):
 
     parser.add_argument(
         "log_paths",
-        type=str,
         nargs='+',
         help="specify the paths to Darshan log files"
     )
     parser.add_argument(
         "--module", "-m",
-        type=str,
         nargs='?', default='POSIX',
         choices=['POSIX', 'MPI-IO', 'STDIO'],
         help="specify the Darshan module to generate job stats for (default: %(default)s)"
     )
     parser.add_argument(
         "--order_by", "-o",
-        type=str,
         nargs='?', default='total_bytes',
         choices=['perf_by_slowest', 'time_by_slowest', 'total_bytes', 'total_files'],
         help="specify the I/O metric to order jobs by (default: %(default)s)"
@@ -184,6 +185,17 @@ def setup_parser(parser: argparse.ArgumentParser):
         action='store_true',
         help="output job stats in CSV format"
     )
+    parser.add_argument(
+        "--exclude_names", "-e",
+        action='append',
+        help="regex patterns for file record names to exclude in stats"
+    )
+    parser.add_argument(
+        "--include_names", "-i",
+        action='append',
+        help="regex patterns for file record names to include in stats"
+     )
+
 
 def main(args: Union[Any, None] = None):
     """
@@ -202,9 +214,20 @@ def main(args: Union[Any, None] = None):
     order_by = args.order_by
     limit = args.limit
     log_paths = args.log_paths
+    filter_patterns=None
+    filter_mode=None
+    if args.exclude_names and args.include_names:
+        print('job_stats error: only one of --exclude-names and --include-names may be used.')
+        sys.exit(1)
+    elif args.exclude_names:
+        filter_patterns = args.exclude_names
+        filter_mode = "exclude"
+    elif args.include_names:
+        filter_patterns = args.include_names
+        filter_mode = "include"
     list_dfs = []
     for log_path in log_paths:
-        df_i = df_IO_data(log_path, mod)
+        df_i = df_IO_data(log_path, mod, filter_patterns, filter_mode)
         if not df_i.empty:
             list_dfs.append(df_i)
     if len(list_dfs) == 0:

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -25,6 +25,11 @@ def df_IO_data(file_path, mod):
     acc_rec = accumulate_records(recs, mod, report.metadata['job']['nprocs'])
     dict_acc_rec = {}
     dict_acc_rec['log_file'] = file_path.split('/')[-1]
+    dict_acc_rec['job_id'] = report.metadata['job']['jobid']
+    dict_acc_rec['nprocs'] = report.metadata['job']['nprocs']
+    dict_acc_rec['start_time'] = report.metadata['job']['start_time_sec']
+    dict_acc_rec['end_time'] = report.metadata['job']['end_time_sec']
+    dict_acc_rec['run_time'] = report.metadata['job']['run_time']
     dict_acc_rec['agg_perf_by_slowest'] = acc_rec.derived_metrics.agg_perf_by_slowest
     dict_acc_rec['agg_time_by_slowest'] = acc_rec.derived_metrics.agg_time_by_slowest
     dict_acc_rec['total_bytes'] = acc_rec.derived_metrics.total_bytes

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -47,6 +47,7 @@ def process_logfile(log_path, mod, filter_patterns, filter_mode):
         dict_acc_rec['log_file'] = log_path.split('/')[-1]
         dict_acc_rec['exe'] = report.metadata['exe']
         dict_acc_rec['job_id'] = report.metadata['job']['jobid']
+        dict_acc_rec['uid'] = report.metadata['job']['uid']
         dict_acc_rec['nprocs'] = report.metadata['job']['nprocs']
         dict_acc_rec['start_time'] = report.metadata['job']['start_time_sec']
         dict_acc_rec['end_time'] = report.metadata['job']['end_time_sec']
@@ -55,6 +56,7 @@ def process_logfile(log_path, mod, filter_patterns, filter_mode):
         dict_acc_rec['time_by_slowest'] = acc_rec.derived_metrics.agg_time_by_slowest
         dict_acc_rec['total_bytes'] = acc_rec.derived_metrics.total_bytes
         dict_acc_rec['total_files'] = acc_rec.derived_metrics.category_counters[0].count
+        dict_acc_rec['partial_flag'] = report.modules[mod]['partial_flag']
         df = pd.DataFrame.from_dict([dict_acc_rec])
         return df
     except Exception as e:
@@ -144,6 +146,7 @@ def rich_print(df, mod, order_by):
             column.style = column.header_style = column.footer_style = "bold cyan"
     for _, row in df.iterrows():
         job_str  = f"[bold]job id[/bold]: {row['job_id']}\n"
+        job_str  = f"[bold]uid[/bold]: {row['uid']}\n"
         job_str += f"[bold]nprocs[/bold]: {row['nprocs']}\n"
         job_str += f"[bold]start time[/bold]: {datetime.fromtimestamp(row['start_time']).strftime('%m/%d/%Y %H:%M:%S')}\n"
         job_str += f"[bold]end time[/bold]: {datetime.fromtimestamp(row['end_time']).strftime('%m/%d/%Y %H:%M:%S')}\n"

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -36,8 +36,8 @@ def df_IO_data(file_path, mod):
     dict_acc_rec['start_time'] = report.metadata['job']['start_time_sec']
     dict_acc_rec['end_time'] = report.metadata['job']['end_time_sec']
     dict_acc_rec['run_time'] = report.metadata['job']['run_time']
-    dict_acc_rec['agg_perf_by_slowest'] = acc_rec.derived_metrics.agg_perf_by_slowest * 1024**2
-    dict_acc_rec['agg_time_by_slowest'] = acc_rec.derived_metrics.agg_time_by_slowest
+    dict_acc_rec['perf_by_slowest'] = acc_rec.derived_metrics.agg_perf_by_slowest * 1024**2
+    dict_acc_rec['time_by_slowest'] = acc_rec.derived_metrics.agg_time_by_slowest
     dict_acc_rec['total_bytes'] = acc_rec.derived_metrics.total_bytes
     dict_acc_rec['total_files'] = acc_rec.derived_metrics.category_counters[0].count
     df = pd.DataFrame.from_dict([dict_acc_rec])
@@ -123,7 +123,7 @@ def setup_parser(parser: argparse.ArgumentParser):
         "--order_by", "-o",
         type=str,
         nargs='?', default='total_bytes',
-        choices=['agg_perf_by_slowest', 'agg_time_by_slowest', 'total_bytes'],
+        choices=['perf_by_slowest', 'time_by_slowest', 'total_bytes', 'total_files'],
         help="specify the I/O metric to order jobs by (default: %(default)s)"
     )
     parser.add_argument(

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -146,7 +146,7 @@ def rich_print(df, mod, order_by):
             column.style = column.header_style = column.footer_style = "bold cyan"
     for _, row in df.iterrows():
         job_str  = f"[bold]job id[/bold]: {row['job_id']}\n"
-        job_str  = f"[bold]uid[/bold]: {row['uid']}\n"
+        job_str += f"[bold]uid[/bold]: {row['uid']}\n"
         job_str += f"[bold]nprocs[/bold]: {row['nprocs']}\n"
         job_str += f"[bold]start time[/bold]: {datetime.fromtimestamp(row['start_time']).strftime('%m/%d/%Y %H:%M:%S')}\n"
         job_str += f"[bold]end time[/bold]: {datetime.fromtimestamp(row['end_time']).strftime('%m/%d/%Y %H:%M:%S')}\n"

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -1,13 +1,13 @@
 import sys
 import pandas as pd
 import argparse
+from pathlib import Path
 import darshan
 import darshan.cli
 from darshan.backend.cffi_backend import accumulate_records
 from typing import Any, Union, Callable
 from datetime import datetime
 from humanize import naturalsize
-
 import concurrent.futures
 from functools import partial
 
@@ -173,8 +173,13 @@ def setup_parser(parser: argparse.ArgumentParser):
 
     parser.add_argument(
         "log_paths",
-        nargs='+',
+        nargs='*',
         help="specify the paths to Darshan log files"
+    )
+    parser.add_argument(
+        "--log_paths_file",
+        type=str,
+        help="specify the path to a manifest file listing Darshan log files"
     )
     parser.add_argument(
         "--module", "-m",
@@ -210,6 +215,17 @@ def setup_parser(parser: argparse.ArgumentParser):
         help="regex patterns for file record names to include in stats"
      )
 
+def get_input_logs(args):
+    if args.log_paths_file:
+        manifest_path = Path(args.log_paths_file)
+        if not manifest_path.is_file():
+            raise ValueError(f"Input manifest file {manifest_path} not found.")
+        with open(manifest_path) as f:
+            return [line.strip() for line in f if line.strip()]
+    elif args.log_paths:
+        return args.log_paths
+    else:
+        raise ValueError("No input Darshan logs provided.")
 
 def main(args: Union[Any, None] = None):
     """
@@ -227,12 +243,11 @@ def main(args: Union[Any, None] = None):
     mod = args.module
     order_by = args.order_by
     limit = args.limit
-    log_paths = args.log_paths
+    log_paths = get_input_logs(args)
     filter_patterns=None
     filter_mode=None
     if args.exclude_names and args.include_names:
-        print('job_stats error: only one of --exclude-names and --include-names may be used.')
-        sys.exit(1)
+        raise ValueError('Only one of --exclude_names and --include_names may be used.')
     elif args.exclude_names:
         filter_patterns = args.exclude_names
         filter_mode = "exclude"

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -118,6 +118,11 @@ def setup_parser(parser: argparse.ArgumentParser):
         nargs='?', default='-1',
         help="limit output to the top LIMIT number of jobs according to selected metric"
     )
+    parser.add_argument(
+        "--csv", "-c",
+        action='store_true',
+        help="output job stats in CSV format"
+    )
 
 def main(args: Union[Any, None] = None):
     """
@@ -143,7 +148,10 @@ def main(args: Union[Any, None] = None):
     combined_dfs = combine_dfs(list_dfs)
     combined_dfs_sorted = sort_dfs_desc(combined_dfs, order_by)
     combined_dfs_selected = first_n_recs(combined_dfs_sorted, limit)
-    print("Statistical data of jobs:\n", combined_dfs_selected)
+    if args.csv:
+        print(combined_dfs_selected.to_csv(index=False))
+    else:
+        print(combined_dfs_selected.to_string(index=False))
 
 if __name__ == "__main__":
     main()

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -69,7 +69,7 @@ def sort_dfs_desc(combined_dfs, order_by):
     Parameters
     ----------
     combined_dfs : a DataFrame with data from multiple Darshan logs.
-    order_by : a string, the column name of the statistical metric to sort by
+    order_by : a string, the column name of the statistical metric to sort by.
 
     Returns
     -------
@@ -118,7 +118,7 @@ def rich_print(df, mod, order_by):
     # instantiate a rich table and pretty print the dataframe
     console = Console()
     table = Table(title=f"Darshan {mod} Job Stats", show_lines=True, show_footer=True)
-    table.add_column("job", "[u i]TOTAL", justify="center", ratio=4)
+    table.add_column("job", f"[u i]TOTAL ({len(df)} jobs)", justify="center", ratio=4)
     default_kwargs = {"justify": "center", "no_wrap": True, "ratio": 1}
     table.add_column("perf_by_slowest", f"[u i]{naturalsize(all_perf_by_slowest, binary=True, format='%.2f')}/s", **default_kwargs)
     table.add_column("time_by_slowest", f"[u i]{all_time_by_slowest:.2f} s", **default_kwargs)
@@ -187,7 +187,7 @@ def setup_parser(parser: argparse.ArgumentParser):
 
 def main(args: Union[Any, None] = None):
     """
-    Prints statistics on a set of input Darshan job logs.
+    Prints job statistics on a set of input Darshan logs.
 
     Parameters
     ----------

--- a/darshan-util/pydarshan/darshan/cli/job_stats.py
+++ b/darshan-util/pydarshan/darshan/cli/job_stats.py
@@ -19,14 +19,16 @@ def df_IO_data(file_path, mod):
     a single DataFrame of job statistics.
 
     """
-    report = darshan.DarshanReport(file_path, read_all=True)
-    posix_recs = report.records[mod].to_df()
-    acc_recs = accumulate_records(posix_recs, mod, report.metadata['job']['nprocs'])
-    dict_recs = {}
-    dict_recs['agg_perf_by_slowest'] = acc_recs.derived_metrics.agg_perf_by_slowest
-    dict_recs['agg_time_by_slowest'] = acc_recs.derived_metrics.agg_time_by_slowest
-    dict_recs['total_bytes'] = acc_recs.derived_metrics.total_bytes
-    df = pd.DataFrame.from_dict([dict_recs])
+    report = darshan.DarshanReport(file_path, read_all=False)
+    report.mod_read_all_records(mod)
+    recs = report.records[mod].to_df()
+    acc_rec = accumulate_records(recs, mod, report.metadata['job']['nprocs'])
+    dict_acc_rec = {}
+    dict_acc_rec['log_file'] = file_path.split('/')[-1]
+    dict_acc_rec['agg_perf_by_slowest'] = acc_rec.derived_metrics.agg_perf_by_slowest
+    dict_acc_rec['agg_time_by_slowest'] = acc_rec.derived_metrics.agg_time_by_slowest
+    dict_acc_rec['total_bytes'] = acc_rec.derived_metrics.total_bytes
+    df = pd.DataFrame.from_dict([dict_acc_rec])
     return df
 
 def combine_dfs(list_dfs):

--- a/darshan-util/pydarshan/darshan/tests/test_file_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_file_stats.py
@@ -1,0 +1,25 @@
+import argparse
+from unittest import mock
+from darshan.log_utils import get_log_path
+from darshan.cli import file_stats
+import pytest
+@pytest.mark.parametrize(
+    "argv", [
+        [get_log_path("e3sm_io_heatmap_only.darshan"),
+         "-mSTDIO",
+         "-oSTDIO_BYTES_READ",
+         "-n5"],
+    ]
+)
+def test_file_stats(argv, capsys):
+    with mock.patch("sys.argv", argv):
+        # initialize the parser
+        parser = argparse.ArgumentParser(description="")
+        # run through setup_parser()
+        file_stats.setup_parser(parser=parser)
+        # parse the input arguments
+        args = parser.parse_args(argv)
+    file_stats.main(args=args)
+    captured = capsys.readouterr()
+    assert "15920181672442173319" in captured.out
+

--- a/darshan-util/pydarshan/darshan/tests/test_file_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_file_stats.py
@@ -2,17 +2,17 @@ import argparse
 from unittest import mock
 from darshan.log_utils import get_log_path
 from darshan.cli import file_stats
+from darshan.log_utils import _provide_logs_repo_filepaths
 import pandas as pd
 import io
 import pytest
 
 @pytest.mark.parametrize(
     "argv", [
-        [get_log_path("shane_macsio_id29959_5-22-32552-7035573431850780836_1590156158.darshan"),
-         "--csv",
+        ["--csv",
          "--module=POSIX",
          "--order_by=bytes_written",
-         "--limit=5"],
+         get_log_path("shane_macsio_id29959_5-22-32552-7035573431850780836_1590156158.darshan")],
     ]
 )
 def test_file_stats(argv, capsys):
@@ -58,3 +58,77 @@ def test_file_stats(argv, capsys):
     # run again to ensure default Rich print mode runs successfully
     args.csv = False
     file_stats.main(args=args)
+    assert not captured.err
+
+def _provide_logs_repo_filepaths_filtered():
+    return [
+        path for path in _provide_logs_repo_filepaths()
+        if 'dlio_logs' in path
+    ]
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (
+            ["--csv",
+             "--module=POSIX",
+             "--order_by=bytes_read",
+             *_provide_logs_repo_filepaths_filtered()],
+            {'len': 194,
+             'bytes_read': 129953991223,
+             'bytes_written': 523946754,
+             'reads': 35762,
+             'writes': 168,
+             'total_jobs': 670}
+        ),
+        (
+            ["--csv",
+             "--module=POSIX",
+             "--order_by=bytes_read",
+             "--limit=5",
+             *_provide_logs_repo_filepaths_filtered()],
+            {'len': 5,
+             'bytes_read': 7214542900,
+             'bytes_written': 0,
+             'reads': 1830,
+             'writes': 0,
+             'total_jobs': 5}
+        ),
+        (
+            ["--csv",
+             "--module=POSIX",
+             "--order_by=bytes_read",
+             "--include_names=\\.npz$",
+             *_provide_logs_repo_filepaths_filtered()],
+            {'len': 168,
+             'bytes_read': 129953701195,
+             'bytes_written': 0,
+             'reads': 34770,
+             'writes': 0,
+             'total_jobs': 172}
+        )
+    ]
+)
+def test_file_stats_multi(argv, expected, capsys):
+    with mock.patch("sys.argv", argv):
+        # initialize the parser
+        parser = argparse.ArgumentParser(description="")
+        # run through setup_parser()
+        file_stats.setup_parser(parser=parser)
+        # parse the input arguments
+        args = parser.parse_args(argv)
+    # run once with CSV output and spot check some of the output
+    file_stats.main(args=args)
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out
+    df = pd.read_csv(io.StringIO(captured.out))
+    assert len(df) == expected['len']
+    assert df['bytes_read'].sum() == expected['bytes_read']
+    assert df['bytes_written'].sum() == expected['bytes_written']
+    assert df['reads'].sum() == expected['reads']
+    assert df['writes'].sum() == expected['writes']
+    assert df['total_jobs'].sum() == expected['total_jobs']
+    # run again to ensure default Rich print mode runs successfully
+    args.csv = False
+    file_stats.main(args=args)
+    assert not captured.err

--- a/darshan-util/pydarshan/darshan/tests/test_file_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_file_stats.py
@@ -65,6 +65,8 @@ def _provide_logs_repo_filepaths_filtered():
         path for path in _provide_logs_repo_filepaths()
         if 'dlio_logs' in path
     ]
+@pytest.mark.skipif(not pytest.has_log_repo,
+                    reason="missing darshan_logs")
 @pytest.mark.parametrize(
     ("argv", "expected"),
     [

--- a/darshan-util/pydarshan/darshan/tests/test_file_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_file_stats.py
@@ -2,13 +2,17 @@ import argparse
 from unittest import mock
 from darshan.log_utils import get_log_path
 from darshan.cli import file_stats
+import pandas as pd
+import io
 import pytest
+
 @pytest.mark.parametrize(
     "argv", [
-        [get_log_path("e3sm_io_heatmap_only.darshan"),
-         "-mSTDIO",
-         "-oSTDIO_BYTES_READ",
-         "-n5"],
+        [get_log_path("shane_macsio_id29959_5-22-32552-7035573431850780836_1590156158.darshan"),
+         "--csv",
+         "--module=POSIX",
+         "--order_by=bytes_written",
+         "--limit=5"],
     ]
 )
 def test_file_stats(argv, capsys):
@@ -19,7 +23,38 @@ def test_file_stats(argv, capsys):
         file_stats.setup_parser(parser=parser)
         # parse the input arguments
         args = parser.parse_args(argv)
+    # run once with CSV output and spot check some of the output
     file_stats.main(args=args)
     captured = capsys.readouterr()
-    assert "15920181672442173319" in captured.out
-
+    assert not captured.err
+    assert captured.out
+    df = pd.read_csv(io.StringIO(captured.out))
+    assert len(df) == 3
+    # check the first file (most bytes written)
+    expected_first = {
+        'file': '/tmp/test/macsio_hdf5_000.h5',
+        'bytes_read': 39816960,
+        'bytes_written': 54579416,
+        'reads': 6,
+        'writes': 7699,
+        'total_jobs': 1
+    }
+    row = df.iloc[0]
+    for key, value in expected_first.items():
+        assert row[key] == value
+    # check the last file (least bytes written)
+    expected_last = {
+        'file': '/tmp/test/macsio-timings.log',
+        'bytes_read': 0,
+        'bytes_written': 12460,
+        'reads': 0,
+        'writes': 51,
+        'total_jobs': 1
+    }
+    row = df.iloc[-1]
+    for key, value in expected_last.items():
+        assert row[key] == value
+    assert expected_first['bytes_written'] > expected_last['bytes_written']
+    # run again to ensure default Rich print mode runs successfully
+    args.csv = False
+    file_stats.main(args=args)

--- a/darshan-util/pydarshan/darshan/tests/test_job_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_job_stats.py
@@ -1,0 +1,24 @@
+import argparse
+from unittest import mock
+from darshan.log_utils import get_log_path
+from darshan.cli import job_stats
+import pytest
+@pytest.mark.parametrize(
+    "argv", [
+        [get_log_path("e3sm_io_heatmap_only.darshan"),
+         "-mSTDIO",
+         "-ototal_bytes",
+         "-n5"],
+    ]
+)
+def test_job_stats(argv, capsys):
+    with mock.patch("sys.argv", argv):
+        # initialize the parser
+        parser = argparse.ArgumentParser(description="")
+        # run through setup_parser()
+        job_stats.setup_parser(parser=parser)
+        # parse the input arguments
+        args = parser.parse_args(argv)
+    job_stats.main(args=args)
+    captured = capsys.readouterr()
+    assert "3.258853" in captured.out

--- a/darshan-util/pydarshan/darshan/tests/test_job_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_job_stats.py
@@ -2,6 +2,7 @@ import argparse
 from unittest import mock
 from darshan.log_utils import get_log_path
 from darshan.cli import job_stats
+from darshan.log_utils import _provide_logs_repo_filepaths
 from numpy.testing import assert_allclose
 import pandas as pd
 import io
@@ -9,11 +10,10 @@ import pytest
 
 @pytest.mark.parametrize(
     "argv", [
-        [get_log_path("sample-badost.darshan"),
-         "--csv",
+        ["--csv",
          "--module=STDIO",
          "--order_by=total_bytes",
-         "--limit=5"],
+         get_log_path("sample-badost.darshan")],
     ]
 )
 def test_job_stats(argv, capsys):
@@ -51,3 +51,70 @@ def test_job_stats(argv, capsys):
     # run again to ensure default Rich print mode runs successfully
     args.csv = False
     job_stats.main(args=args)
+    assert not captured.err
+
+def _provide_logs_repo_filepaths_filtered():
+    return [
+        path for path in _provide_logs_repo_filepaths()
+        if 'dlio_logs' in path
+    ]
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (
+            ["--csv",
+             "--module=POSIX",
+             "--order_by=perf_by_slowest",
+             *_provide_logs_repo_filepaths_filtered()],
+            {'perf_by_slowest': 1818543162.0558,
+             'time_by_slowest': 89.185973,
+             'total_bytes': 130477937977,
+             'total_files': 670}
+        ),
+        (
+            ["--csv",
+             "--module=POSIX",
+             "--order_by=perf_by_slowest",
+             "--limit=5",
+             *_provide_logs_repo_filepaths_filtered()],
+            {'perf_by_slowest': 1818543162.0558,
+             'time_by_slowest': 30.823626,
+             'total_bytes': 54299532365,
+             'total_files': 190}
+        )
+    ]
+)
+def test_job_stats_multi(argv, expected, capsys):
+    # this case tests job_stats with multiple input logs
+    # and ensures that aggregate statistics are as expected
+    with mock.patch("sys.argv", argv):
+        # initialize the parser
+        parser = argparse.ArgumentParser(description="")
+        # run through setup_parser()
+        job_stats.setup_parser(parser=parser)
+        # parse the input arguments
+        args = parser.parse_args(argv)
+    # run once with CSV output and spot check some of the output
+    job_stats.main(args=args)
+    captured = capsys.readouterr()
+    assert not captured.err
+    assert captured.out
+    df = pd.read_csv(io.StringIO(captured.out))
+    # verify max perf is first row and min perf is last row
+    max_perf = df['perf_by_slowest'].max()
+    min_perf = df['perf_by_slowest'].min()
+    assert df.iloc[0]['perf_by_slowest'] == max_perf
+    assert df.iloc[-1]['perf_by_slowest'] == min_perf
+    # verify values against expected
+    assert_allclose(max_perf, expected['perf_by_slowest'], rtol=1e-5, atol=1e-8)
+    assert max_perf == expected['perf_by_slowest']
+    total_time = df['time_by_slowest'].sum()
+    assert_allclose(total_time, expected['time_by_slowest'], rtol=1e-5, atol=1e-8)
+    total_bytes = df['total_bytes'].sum()
+    assert total_bytes == expected['total_bytes']
+    total_files = df['total_files'].sum()
+    assert total_files == expected['total_files']
+    # run again to ensure default Rich print mode runs successfully
+    args.csv = False
+    job_stats.main(args=args)
+    assert not captured.err

--- a/darshan-util/pydarshan/darshan/tests/test_job_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_job_stats.py
@@ -58,6 +58,8 @@ def _provide_logs_repo_filepaths_filtered():
         path for path in _provide_logs_repo_filepaths()
         if 'dlio_logs' in path
     ]
+@pytest.mark.skipif(not pytest.has_log_repo,
+                    reason="missing darshan_logs")
 @pytest.mark.parametrize(
     ("argv", "expected"),
     [

--- a/darshan-util/pydarshan/darshan/tests/test_job_stats.py
+++ b/darshan-util/pydarshan/darshan/tests/test_job_stats.py
@@ -2,13 +2,18 @@ import argparse
 from unittest import mock
 from darshan.log_utils import get_log_path
 from darshan.cli import job_stats
+from numpy.testing import assert_allclose
+import pandas as pd
+import io
 import pytest
+
 @pytest.mark.parametrize(
     "argv", [
-        [get_log_path("e3sm_io_heatmap_only.darshan"),
-         "-mSTDIO",
-         "-ototal_bytes",
-         "-n5"],
+        [get_log_path("sample-badost.darshan"),
+         "--csv",
+         "--module=STDIO",
+         "--order_by=total_bytes",
+         "--limit=5"],
     ]
 )
 def test_job_stats(argv, capsys):
@@ -19,6 +24,30 @@ def test_job_stats(argv, capsys):
         job_stats.setup_parser(parser=parser)
         # parse the input arguments
         args = parser.parse_args(argv)
+    # run once with CSV output and spot check some of the output
     job_stats.main(args=args)
     captured = capsys.readouterr()
-    assert "3.258853" in captured.out
+    assert not captured.err
+    assert captured.out
+    df = pd.read_csv(io.StringIO(captured.out))
+    assert len(df) == 1
+    expected = {
+        'log_file': 'sample-badost.darshan',
+        'job_id': 6265799,
+        'nprocs': 2048,
+        'run_time': 780.0,
+        'perf_by_slowest': 8.249708e+06,
+        'time_by_slowest': 0.200828,
+        'total_bytes': 1656773,
+        'total_files': 3,
+        'partial_flag': False
+    }
+    row = df.iloc[0]
+    for key, value in expected.items():
+        if key == 'perf_by_slowest' or key == 'time_by_slowest':
+            assert_allclose(row[key], value, rtol=1e-5, atol=1e-8)
+        else:
+            assert row[key] == value
+    # run again to ensure default Rich print mode runs successfully
+    args.csv = False
+    job_stats.main(args=args)

--- a/darshan-util/pydarshan/darshan/tests/test_report.py
+++ b/darshan-util/pydarshan/darshan/tests/test_report.py
@@ -78,10 +78,10 @@ def test_load_records():
 def test_load_records_filtered():
     """Sample for an expected number of records after filtering."""
     logfile = get_log_path("shane_macsio_id29959_5-22-32552-7035573431850780836_1590156158.darshan")
-    with darshan.DarshanReport(logfile, filter_patterns=["\.h5$"], filter_mode="exclude") as report:
+    with darshan.DarshanReport(logfile, filter_patterns=[r"\.h5$"], filter_mode="exclude") as report:
         assert 2 == len(report.data['records']['POSIX'])
         assert 0 == len(report.data['records']['MPI-IO'])
-    with darshan.DarshanReport(logfile, filter_patterns=["\.h5$"], filter_mode="include") as report:
+    with darshan.DarshanReport(logfile, filter_patterns=[r"\.h5$"], filter_mode="include") as report:
         assert 1 == len(report.data['records']['POSIX'])
         assert 1 == len(report.data['records']['MPI-IO'])
 

--- a/darshan-util/pydarshan/darshan/tests/test_summary.py
+++ b/darshan-util/pydarshan/darshan/tests/test_summary.py
@@ -176,11 +176,16 @@ def test_main_without_args(tmpdir, argv, expected_img_count, expected_table_coun
             with pytest.raises(RuntimeError):
                 summary.main()
 
-
+# just punt on this test for the dlio_logs given there's 26 of them
+def _provide_logs_repo_filepaths_filtered():
+    return [
+        path for path in _provide_logs_repo_filepaths()
+        if 'dlio_logs' not in path
+    ]
 @pytest.mark.skipif(not pytest.has_log_repo,
                     reason="missing darshan_logs")
 @pytest.mark.parametrize("log_filepath",
-        _provide_logs_repo_filepaths()
+        _provide_logs_repo_filepaths_filtered()
         )
 def test_main_all_logs_repo_files(tmpdir, log_filepath):
     # similar to `test_main_without_args` but focused

--- a/darshan-util/pydarshan/docs/usage.rst
+++ b/darshan-util/pydarshan/docs/usage.rst
@@ -13,7 +13,9 @@ example job summary report can be viewed `HERE <https://www.mcs.anl.gov/research
 
 Usage of this job summary tool is described below. ::
 
-    usage: darshan summary [-h] [--output OUTPUT] [--enable_dxt_heatmap] log_path
+    usage: darshan summary [-h] [--output OUTPUT] [--enable_dxt_heatmap]
+                           [--exclude_names EXCLUDE_NAMES] [--include_names INCLUDE_NAMES]
+                           log_path
 
     Generates a Darshan Summary Report
 
@@ -24,6 +26,10 @@ Usage of this job summary tool is described below. ::
       -h, --help            show this help message and exit
       --output OUTPUT       Specify output filename.
       --enable_dxt_heatmap  Enable DXT-based versions of I/O activity heatmaps.
+      --exclude_names EXCLUDE_NAMES
+                            regex patterns for file record names to exclude in summary report
+      --include_names INCLUDE_NAMES
+                            regex patterns for file record names to include in summary report
 
 For example, the following command would generate an HTML job summary report
 for a Darshan log file named `example.darshan`.
@@ -35,6 +41,82 @@ for a Darshan log file named `example.darshan`.
 If ``--output`` option is not specified, the output HTML report will be based
 on the input log file name (i.e., the above command would generate an HTML
 report named `example_report.html`).
+
+Other Darshan CLI tools
+-----------------------
+
+There are also command line tools available for quickly printing terminal output
+describing general I/O statistics of one or more input Darhan logs.
+The ``job_stats`` tool is used to summarize key job-level I/O parameters for each
+of a given set of Darshan logs, ordering the jobs according to some I/O metric.
+Alternatively, the ``file_stats`` is used to summarize key file-level I/O
+parameters for each file accessed across a set of Darshan logs, with the files
+ordered according to some I/O metric.
+
+Usage of the ``job_stats`` tool is described below. ::
+
+    usage: darshan job_stats [-h] [--log_paths_file LOG_PATHS_FILE] [--module [{POSIX,MPI-IO,STDIO}]]
+                             [--order_by [{perf_by_slowest,time_by_slowest,total_bytes,total_files}]] [--limit [LIMIT]]
+                             [--csv] [--exclude_names EXCLUDE_NAMES] [--include_names INCLUDE_NAMES]
+                             [log_paths [log_paths ...]]
+
+    Print statistics describing key metadata and I/O performance metrics for a given list of jobs.
+
+    positional arguments:
+      log_paths             specify the paths to Darshan log files
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --log_paths_file LOG_PATHS_FILE
+                            specify the path to a manifest file listing Darshan log files
+      --module [{POSIX,MPI-IO,STDIO}], -m [{POSIX,MPI-IO,STDIO}]
+                            specify the Darshan module to generate job stats for (default: POSIX)
+      --order_by [{perf_by_slowest,time_by_slowest,total_bytes,total_files}], -o [{perf_by_slowest,time_by_slowest,total_bytes,total_files}]
+                            specify the I/O metric to order jobs by (default: total_bytes)
+      --limit [LIMIT], -l [LIMIT]
+                            limit output to the top LIMIT number of jobs according to selected metric
+      --csv, -c             output job stats in CSV format
+      --exclude_names EXCLUDE_NAMES, -e EXCLUDE_NAMES
+                        regex patterns for file record names to exclude in stats
+      --include_names INCLUDE_NAMES, -i INCLUDE_NAMES
+                        regex patterns for file record names to include in stats
+
+Options allow for users to calculate stats for specific modules, to use a number of different
+I/O statistics to order jobs, to limit output to the top N jobs, to print in CSV format
+(rather than default Rich printing), and to filter file names within jobs.
+Note that users can either provide the list of Darshan logs directly on the command line
+or use a manifest file in cases where many logs are to be analyzed at once.
+
+Usage of the ``file_stats`` tool is described below. ::
+
+    usage: darshan file_stats [-h] [--log_paths_file LOG_PATHS_FILE] [--module [{POSIX,MPI-IO,STDIO}]]
+                              [--order_by [{bytes_read,bytes_written,reads,writes,total_jobs}]] [--limit [LIMIT]] [--csv]
+                              [--exclude_names EXCLUDE_NAMES] [--include_names INCLUDE_NAMES]
+                              [log_paths [log_paths ...]]
+
+    Print statistics describing key metadata and I/O performance metrics for files accessed by a given list of jobs.
+
+    positional arguments:
+      log_paths             specify the paths to Darshan log files
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --log_paths_file LOG_PATHS_FILE
+                            specify the path to a manifest file listing Darshan log files
+      --module [{POSIX,MPI-IO,STDIO}], -m [{POSIX,MPI-IO,STDIO}]
+                            specify the Darshan module to generate file stats for (default: POSIX)
+      --order_by [{bytes_read,bytes_written,reads,writes,total_jobs}], -o [{bytes_read,bytes_written,reads,writes,total_jobs}]
+                            specify the I/O metric to order files by (default: bytes_read)
+      --limit [LIMIT], -l [LIMIT]
+                            limit output to the top LIMIT number of jobs according to selected metric
+      --csv, -c             output file stats in CSV format
+      --exclude_names EXCLUDE_NAMES, -e EXCLUDE_NAMES
+                        regex patterns for file record names to exclude in stats
+      --include_names INCLUDE_NAMES, -i INCLUDE_NAMES
+                            regex patterns for file record names to include in stats
+
+The options for the ``file_stats`` are largely identical to that of ``file_stats`` other
+than slightly different I/O metrics that can be used to sort output.
 
 Darshan Report interface
 ------------------------

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "matplotlib",
     "seaborn",
     "mako",
-    "humanize"
+    "humanize",
+    "rich"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -43,9 +44,7 @@ test = [
     "packaging",
     "pytest",
     "lxml",
-    "matplotlib",
     "importlib_resources;python_version<'3.9'",
-    "humanize"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Based on original PR from @Yanlilyu in #954.

Key enhancements are as follows:
- lots of new statistics/metadata printed
- support for pretty printing via Rich package (default) or output in CSV format for subsequent analysis
- support for PyDarshan name filtering from #1017 
- parallelization using ProcessPoolExecutor
- optional manifest file to support massive amounts of log file input (to avoid command line limits)
- in-depth testing to exercise various options as part of our CI
- updated docs to describe usage of these 2 new tools

See docs/usage.rst for details on command line tool options.