### PR TITLE
CI: update upload-artifact version in build-wheels workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -57,6 +57,6 @@ jobs:
         with:
           package-dir: ./darshan-util/pydarshan
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,3 +61,13 @@ jobs:
         with:
           name: pydarshan-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
+          retention-days: 0
+
+  merge_artifacts:
+    name: Merge built wheel artifacts
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: pydarshan-wheels-all

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -59,4 +59,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: pydarshan-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
The `upload-artifact` version we had been using is now deprecated. 

Note that there are changes in the new version that don't allow multiple workflow steps to combine their output into a single artifact archive. Changes have been made to direct output from each step into unique archives, along with a new phase of the workflow that merges all of these together into a single artifact.