### PR TITLE
TYP: Disable NumPy's deprecated mypy plugin

### DIFF
--- a/darshan-util/pydarshan/mypy.ini
+++ b/darshan-util/pydarshan/mypy.ini
@@ -2,7 +2,6 @@
 warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True
-plugins = numpy.typing.mypy_plugin
 exclude = darshan/examples/tutorial/
 
 # Third party dependencies that don't have types.


### PR DESCRIPTION
* Mirror the upstream change to disable this plugin. For details, see:
https://github.com/scipy/scipy/pull/23123

* I don't think we're running `mypy` in CI anyway, but might as well clean it up in case the team
turns it on at some point (a well-maintained type stub library now exists upstream: https://github.com/numpy/numtype).