### PR TITLE
Github action: remove setuptools version constrain

### DIFF
--- a/.github/workflows/end_to_end_pytest.yml
+++ b/.github/workflows/end_to_end_pytest.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y hdf5-tools libhdf5-openmpi-dev openmpi-bin
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mpi4py "cython<3.0.0" numpy wheel pkgconfig "setuptools<62.0.0"
+          python -m pip install --upgrade pytest mpi4py "cython<3.0.0" numpy wheel pkgconfig setuptools
           # we need to build h5py with the system HDF5 lib backend
           export HDF5_MPI="ON"
           # Install h5py https://github.com/h5py/h5py/issues/2222


### PR DESCRIPTION
Looks like using the default version of setuptools solves the issue of #1040.
Now the github action job of end_to_end_pytest.yml passed.