### PR TITLE
BUG: correct DAOS and DFS layout in dataframe repacking that is consumed by the logutils accumulator API

### DIFF
--- a/darshan-util/pydarshan/darshan/backend/cffi_backend.py
+++ b/darshan-util/pydarshan/darshan/backend/cffi_backend.py
@@ -736,10 +736,30 @@ def _df_to_rec(rec_dict, mod_name, rec_index_of_interest=None):
         num_recs = 1
     # id and rank columns are duplicated
     # in counters and fcounters
-    rec_arr = np.recarray(shape=(num_recs), dtype=[("id", "<u8", (1,)),
-                                                   ("rank", "<i8", (1,)),
-                                                   ("counters", "<i8", (counters_n_cols - 2,)),
-                                                   ("fcounters", "<f8", (fcounters_n_cols - 2,))])
+
+    if mod_name not in ('DFS', 'DAOS'):
+        rec_arr = np.recarray(shape=(num_recs), dtype=[("id", "<u8", (1,)),
+                                                       ("rank", "<i8", (1,)),
+                                                       ("counters", "<i8", (counters_n_cols - 2,)),
+                                                       ("fcounters", "<f8", (fcounters_n_cols - 2,))])
+    elif mod_name == 'DFS':
+        rec_arr = np.recarray(shape=(num_recs), dtype=[("id", "<u8", (1,)),
+                                                     ("rank", "<i8", (1,)),
+                                                     ("counters", "<i8", (counters_n_cols - 2,)),
+                                                     ("fcounters", "<f8", (fcounters_n_cols - 2,)),
+                                                     ("pool_uuid", "V16"),
+                                                     ("cont_uuid", "V16")])
+    elif mod_name == 'DAOS':
+        rec_arr = np.recarray(shape=(num_recs), dtype=[("id", "<u8", (1,)),
+                                                     ("rank", "<i8", (1,)),
+                                                     ("counters", "<i8", (counters_n_cols - 2,)),
+                                                     ("fcounters", "<f8", (fcounters_n_cols - 2,)),
+                                                     ("pool_uuid", "V16"),
+                                                     ("cont_uuid", "V16"),
+                                                     ("oid_hi", "<u8"),
+                                                     ("oid_lo", "<u8")])
+
+
     rec_arr.fcounters = fcounters_df.iloc[rec_index_of_interest, 2:].to_numpy()
     rec_arr.counters = counters_df.iloc[rec_index_of_interest, 2:].to_numpy()
     if num_recs > 1:


### PR DESCRIPTION
When generating summary report from the Darshan logs containing DAOS module data, derived metrics like total_read_volume_bytes and total_write_volume_bytes were displaying incorrect values. 

The issue was the pydarshan.backend.cffi_backend._df_to_rec utility function. It was using an incomplete NumPy dtype with missing several fields from the darshan_daos_object C struct (pool_uuid, cont_uuid, oid_hi, and oid_lo) when converting DAOS records to a C buffer of records that is consumed by the Darshan-util C code. Similar problem exists for the DFS module data.

This PR fixes the issue by updating the np.recarray dtype in _df_to_rec to include all fields for DAOS and DFS records.