### PR TITLE
Fix doc for Spack installation

### DIFF
--- a/darshan-runtime/doc/darshan-runtime.rst
+++ b/darshan-runtime/doc/darshan-runtime.rst
@@ -282,7 +282,7 @@ install either or both as follows:
 
 You can use the ``spack info darshan-runtime`` query to view the full list of
 variants available for the darshan-runtime Spack package.  For example, adding
-a ``+slurm`` to the command line (``spack install darshan-runtime+slurm``) will
+a ``scheduler=slurm`` to the command line (``spack install "darshan-runtime scheduler=slurm"``) will
 cause Darshan to be compiled with support for gathering job ID information from
 the Slurm scheduler.
 

--- a/darshan-runtime/doc/darshan-runtime.txt
+++ b/darshan-runtime/doc/darshan-runtime.txt
@@ -229,8 +229,8 @@ ensure maximum runtime compatibility.
 ====
 
 You can use the `spack info darshan-runtime` query to view the full list of
-variants available for the darshan-runtime Spack package.  For example, adding a `+slurm` to
-the command line (`spack install darshan-runtime+slurm`) will cause Darshan
+variants available for the darshan-runtime Spack package.  For example, adding a `scheduler=slurm` to
+the command line (`spack install "darshan-runtime scheduler=slurm"`) will cause Darshan
 to be compiled with support for gathering job ID information from the Slurm
 scheduler.
 


### PR DESCRIPTION
To install the Spack Variant with slurm support it is necessary to pass `scheduler=slurm` to the `spack install` commandline instead of just `+slurm` as stated by the docs before. Just fixed that in the docs.