### PR TITLE
Setting --with-pnetcdf automatically enables enable_pnetcdf_mod

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -603,13 +603,38 @@ if test "x$enable_darshan_runtime" = xyes ; then
          [], [AC_MSG_ERROR([mdhim requested but headers cannot be found])])
    fi
 
+   # inform about LDMS installs not found in default locations
+   AC_ARG_WITH([ldms],
+      [AS_HELP_STRING([--with-ldms@<:@=DIR@:>@],
+                      [Installation directory for LDMS.])]
+   )
+
    # LDMS support (disabled by default)
    AC_ARG_ENABLE([ldms-mod],
       [AS_HELP_STRING([--enable-ldms-mod],
-                      [Include LDMS for runtime I/O monitoring])],
-      [], [enable_ldms_mod=no]
+                      [Include LDMS for runtime I/O monitoring])]
    )
+
+   # When --with-ldms is set, we automatically enable enable_ldms_mod
+   if test "x$enable_ldms_mod" = x ; then
+      if test "x$with_ldms" != x ; then
+         enable_ldms_mod=yes
+      else
+         enable_ldms_mod=no
+      fi
+   fi
+
    if test "x$enable_ldms_mod" = xyes ; then
+      if test -d "$with_ldms"; then
+         LDMS_HOME="$with_ldms"
+         LDFLAGS="$LDFLAGS -L${LDMS_HOME}/lib -Wl,-rpath=${LDMS_HOME}/lib"
+         CPPFLAGS="$CPPFLAGS -I${LDMS_HOME}/include"
+         __DARSHAN_LDMS_LINK_FLAGS="-L${LDMS_HOME}/lib"
+         __DARSHAN_LDMS_INCLUDE_FLAGS="-I${LDMS_HOME}/include"
+      else
+         AC_MSG_ERROR([LDMS installation path, $with_ldms, is not found])
+      fi
+
       CHECK_LDMS
    fi
 

--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -506,16 +506,24 @@ if test "x$enable_darshan_runtime" = xyes ; then
    # inform about DAOS installs not found in default locations
    AC_ARG_WITH([daos],
       [AS_HELP_STRING([--with-daos@<:@=DIR@:>@],
-                      [Installation directory for DAOS.])],
-      [], [with_daos=no]
+                      [Installation directory for DAOS.])]
    )
 
    # DAOS module (disabled by default)
    AC_ARG_ENABLE([daos-mod],
       [AS_HELP_STRING([--enable-daos-mod],
-                      [Enables compilation and use of DAOS module])],
-      [], [enable_daos_mod=no]
+                      [Enables compilation and use of DAOS module])]
    )
+
+   # When --with-daos is set, we automatically enable enable_daos_mod
+   if test "x$enable_daos_mod" = x ; then
+      if test "x$with_daos" != x ; then
+         enable_daos_mod=yes
+      else
+         enable_daos_mod=no
+      fi
+   fi
+
    if test "x$enable_daos_mod" = xyes ; then
       AC_CHECK_HEADERS(m4_normalize([daos_types.h daos_prop.h daos_pool.h daos_cont.h
 				     daos_obj.h daos_array.h daos_fs.h]),

--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -346,16 +346,24 @@ if test "x$enable_darshan_runtime" = xyes ; then
    # inform about HDF5 installs not found in default locations
    AC_ARG_WITH([hdf5],
       [AS_HELP_STRING([--with-hdf5=DIR],
-                      [Installation directory for HDF5.])],
-      [], [with_hdf5=no]
+                      [Installation directory for HDF5.])]
    )
 
    # HDF5 module (disabled by default)
    AC_ARG_ENABLE([hdf5-mod],
       [AS_HELP_STRING([--enable-hdf5-mod],
-                      [Enables compilation and use of HDF5 module])],
-      [], [enable_hdf5_mod=no]
+                      [Enables compilation and use of HDF5 module])]
    )
+
+   # When --with-hdf5 is set, we automatically enable enable_hdf5_mod
+   if test "x$enable_hdf5_mod" = x ; then
+      if test "x$with_hdf5" != x ; then
+         enable_hdf5_mod=yes
+      else
+         enable_hdf5_mod=no
+      fi
+   fi
+
    if test "x$enable_hdf5_mod" = xyes ; then
       if test -d "$with_hdf5" ; then
          AC_PATH_PROG(H5DUMP_CHECK, h5dump, "no", "${with_hdf5}/bin")

--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -434,16 +434,24 @@ if test "x$enable_darshan_runtime" = xyes ; then
    # inform about PnetCDF installs not found in default locations
    AC_ARG_WITH([pnetcdf],
       [AS_HELP_STRING([--with-pnetcdf=DIR],
-                      [Installation directory for PnetCDF.])],
-      [], [with_pnetcdf=no]
+                      [Installation directory for PnetCDF.])]
    )
 
    # PnetCDF module (disabled by default)
    AC_ARG_ENABLE([pnetcdf-mod],
       [AS_HELP_STRING([--enable-pnetcdf-mod],
-                      [Enables compilation and use of PnetCDF module (requires MPI)])],
-      [], [enable_pnetcdf_mod=no]
+                      [Enables compilation and use of PnetCDF module (requires MPI)])]
    )
+
+   # When --with-pnetcdf is set, we automatically enable enable_pnetcdf_mod
+   if test "x$enable_pnetcdf_mod" = x ; then
+      if test "x$with_pnetcdf" != x ; then
+         enable_pnetcdf_mod=yes
+      else
+         enable_pnetcdf_mod=no
+      fi
+   fi
+
    if test "x$enable_pnetcdf_mod" = xyes ; then
       if test "x$ENABLE_MPI" = xno ; then
          AC_MSG_ERROR([--enable-pnetcdf-mod is used but MPI feature is disabled])

--- a/darshan-runtime/doc/darshan-runtime.rst
+++ b/darshan-runtime/doc/darshan-runtime.rst
@@ -183,9 +183,10 @@ Compilation
   installation directory for PnetCDF
 
   .. note::
-     * Users must call ``--enable-pnetcdf-mod`` to enable PnetCDF modules,
-       ``--with-pnetcdf`` is only used to additionally provide a PnetCDF
-       install prefix.
+     * When ``--with-pnetcdf=DIR`` is set, building PnetCDF module is automatically
+       enabled.
+     * When ``--enable-pnetcdf-mod`` is set but not ``--with-pnetcdf=DIR``, Darshan
+       will search for the PnetCDF installation location available on the system.
      * PnetCDF instrumentation only works on PnetCDF library versions >= 1.8.
 * ``--disable-lustre-mod``: disables compilation and use of Darshan's Lustre
   module (default=enabled)

--- a/darshan-runtime/doc/darshan-runtime.rst
+++ b/darshan-runtime/doc/darshan-runtime.rst
@@ -209,8 +209,10 @@ Compilation
   installation directory for LDMS
 
   .. note::
-     * Users must use the configuration flags ``--enable-ldms-mod`` and
-       ``--with-ldms=DIR`` to enable runtime data collection via LDMS.
+     * When ``--with-ldms=DIR`` is set, building LDMS module is automatically
+       enabled.
+     * When ``--enable-ldms-mod`` is set but not ``--with-ldms=DIR``, Darshan
+       will search for the LDMS installation location available on the system.
      * To collect runtime I/O information from Darshan, you will need to
        configure, initialize, and connect to an LDMS streams daemon. For
        detailed instructions please visit

--- a/darshan-runtime/doc/darshan-runtime.rst
+++ b/darshan-runtime/doc/darshan-runtime.rst
@@ -167,9 +167,10 @@ Compilation
   installation directory for HDF5
 
   .. note::
-     * Users must call ``--enable-hdf5-mod`` to enable HDF5 modules,
-       ``--with-hdf5`` is only used to additionally provide an HDF5 install
-       prefix.
+     * When ``--with-hdf5=DIR`` is set, building HDF5 module is automatically
+       enabled.
+     * When ``--enable-hdf5-mod`` is set but not ``--with-hdf5=DIR``, Darshan
+       will search for the HDF5 installation location available on the system.
      * HDF5 instrumentation only works on HDF5 library versions >= 1.8, and
        further requires that the HDF5 library used to build Darshan and the
        HDF5 library being linked in either both be version >=1.10 or both be

--- a/darshan-runtime/doc/darshan-runtime.rst
+++ b/darshan-runtime/doc/darshan-runtime.rst
@@ -197,9 +197,10 @@ Compilation
   installation directory for DAOS
 
   .. note::
-     Users must call ``--enable-daos-mod`` to enable DAOS modules,
-     ``--with-daos`` is only used to additionally provide a DAOS install
-     prefix.
+     * When ``--with-daos=DIR`` is set, building DAOS module is automatically
+       enabled.
+     * When ``--enable-daos-mod`` is set but not ``--with-daos=DIR``, Darshan
+       will search for the DAOS installation location available on the system.
 * ``--enable-mdhim-mod``: enables compilation and use of Darshan's MDHIM module
   (default=disabled)
 * ``--enable-ldms-mod``:  enables compilation and use of Darshan’s LDMS runtime

--- a/maint/config/check_ldms.m4
+++ b/maint/config/check_ldms.m4
@@ -1,18 +1,5 @@
 AC_DEFUN([CHECK_LDMS],
 [
-AC_ARG_WITH([ldms],
-[  --with-ldms=DIR         Root directory path of LDMS installation (defaults to
-                          to /usr/local or /usr if not found in /usr/local)],
-[if test -d "$withval"; then
-        LDMS_HOME="$withval"
-        LDFLAGS="$LDFLAGS -L${LDMS_HOME}/lib -Wl,-rpath=${LDMS_HOME}/lib"
-        CPPFLAGS="$CPPFLAGS -I${LDMS_HOME}/include"
-        __DARSHAN_LDMS_LINK_FLAGS="-L${LDMS_HOME}/lib"
-        __DARSHAN_LDMS_INCLUDE_FLAGS="-I${LDMS_HOME}/include"
-    else
-        AC_MSG_ERROR([LDMS installation path is required])
-fi])
-
 AC_CHECK_HEADERS([ldms/ldms.h ldms/ldmsd_stream.h ovis_json/ovis_json.h ovis_util/util.h],
         [ldms_found_stream_headers=yes],
         [AC_MSG_ERROR([One or more LDMS headers not found. Please check installation path or LDMS version > 4.3.4])])


### PR DESCRIPTION
When Darshan is configured using `--with-pnetcdf=DIR` without
`--enable-pnetcdf-mod`, the pnetcdf module will not be built.
However, in this case, it is clear that the user's intent is to enable pnetcdf.

This PR changes the behavior to automatically sets `--enable-pnetcdf-mod`
when `--with-pnetcdf=DIR` is used at the configure time.

Same for modules HDF5, DAOS, and LDMS.
