### PR TITLE
fix compile warning of shadowing a previous local [-Wshadow]

### DIFF
--- a/.github/workflows/mpich_openmpi.yml
+++ b/.github/workflows/mpich_openmpi.yml
@@ -95,6 +95,79 @@ jobs:
         run: |
           cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
 
+      - name: Build Darshan using MPICH --enable-apmpi-mod
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+          export DARSHAN_ROOT="${GITHUB_WORKSPACE}"
+          export DARSHAN_LOG_PATH="${GITHUB_WORKSPACE}/LOGS"
+          export DARSHAN_INSTALL="${GITHUB_WORKSPACE}/INSTALL"
+          export DARSHAN_BUILD="${GITHUB_WORKSPACE}/BUILD"
+          rm -rf ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD} ${DARSHAN_INSTALL}
+          mkdir -p ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD}
+          cd ${DARSHAN_BUILD}
+          $DARSHAN_ROOT/configure --prefix=${DARSHAN_INSTALL} \
+                                  --with-log-path=${DARSHAN_LOG_PATH} \
+                                  --with-jobid-env=NONE \
+                                  --enable-apmpi-mod \
+                                  CC=mpicc RUNTIME_CC=mpicc UTIL_CC=gcc
+          make -s LIBTOOLFLAGS=--silent V=1 -j8
+          make -s install
+      - name: make check (MPICH) --enable-apmpi-mod
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check
+      - name: Print test log files (MPICH) --enable-apmpi-mod
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+      - name: make check (MPICH) running 4 processes --enable-apmpi-mod
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check NP=4
+      - name: Print test log files (MPICH) running 4 processes --enable-apmpi-mod
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+
+      - name: Build Darshan using MPICH --enable-apmpi-mod --enable-apmpi-coll-sync
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+          export DARSHAN_ROOT="${GITHUB_WORKSPACE}"
+          export DARSHAN_LOG_PATH="${GITHUB_WORKSPACE}/LOGS"
+          export DARSHAN_INSTALL="${GITHUB_WORKSPACE}/INSTALL"
+          export DARSHAN_BUILD="${GITHUB_WORKSPACE}/BUILD"
+          rm -rf ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD} ${DARSHAN_INSTALL}
+          mkdir -p ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD}
+          cd ${DARSHAN_BUILD}
+          $DARSHAN_ROOT/configure --prefix=${DARSHAN_INSTALL} \
+                                  --with-log-path=${DARSHAN_LOG_PATH} \
+                                  --with-jobid-env=NONE \
+                                  --enable-apmpi-mod \
+                                  --enable-apmpi-coll-sync \
+                                  CC=mpicc RUNTIME_CC=mpicc UTIL_CC=gcc
+          make -s LIBTOOLFLAGS=--silent V=1 -j8
+          make -s install
+      - name: make check (MPICH) --enable-apmpi-mod --enable-apmpi-coll-sync
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check
+      - name: Print test log files (MPICH) --enable-apmpi-mod --enable-apmpi-coll-sync
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+      - name: make check (MPICH) running 4 processes --enable-apmpi-mod --enable-apmpi-coll-sync
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check NP=4
+      - name: Print test log files (MPICH) running 4 processes --enable-apmpi-mod --enable-apmpi-coll-sync
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+
       - name: Build Darshan using OpenMPI
         run: |
           export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
@@ -126,6 +199,79 @@ jobs:
           cd ${GITHUB_WORKSPACE}/BUILD
           make check NP=4
       - name: Print test log files (OpenMPI) running 4 processes
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+
+      - name: Build Darshan using OpenMPI --enable-apmpi-mod
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
+          export DARSHAN_ROOT="${GITHUB_WORKSPACE}"
+          export DARSHAN_LOG_PATH="${GITHUB_WORKSPACE}/LOGS"
+          export DARSHAN_INSTALL="${GITHUB_WORKSPACE}/INSTALL"
+          export DARSHAN_BUILD="${GITHUB_WORKSPACE}/BUILD"
+          rm -rf ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD} ${DARSHAN_INSTALL}
+          mkdir -p ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD}
+          cd ${DARSHAN_BUILD}
+          $DARSHAN_ROOT/configure --prefix=${DARSHAN_INSTALL} \
+                                  --with-log-path=${DARSHAN_LOG_PATH} \
+                                  --with-jobid-env=NONE \
+                                  --enable-apmpi-mod \
+                                  CC=mpicc RUNTIME_CC=mpicc UTIL_CC=gcc
+          make -s LIBTOOLFLAGS=--silent V=1 -j8
+          make -s install
+      - name: make check (OpenMPI) --enable-apmpi-mod
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check
+      - name: Print test log files (OpenMPI) --enable-apmpi-mod
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+      - name: make check (OpenMPI) running 4 processes --enable-apmpi-mod
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check NP=4
+      - name: Print test log files (OpenMPI) running 4 processes --enable-apmpi-mod
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+
+      - name: Build Darshan using OpenMPI --enable-apmpi-mod --enable-apmpi-coll-sync
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
+          export DARSHAN_ROOT="${GITHUB_WORKSPACE}"
+          export DARSHAN_LOG_PATH="${GITHUB_WORKSPACE}/LOGS"
+          export DARSHAN_INSTALL="${GITHUB_WORKSPACE}/INSTALL"
+          export DARSHAN_BUILD="${GITHUB_WORKSPACE}/BUILD"
+          rm -rf ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD} ${DARSHAN_INSTALL}
+          mkdir -p ${DARSHAN_LOG_PATH} ${DARSHAN_BUILD}
+          cd ${DARSHAN_BUILD}
+          $DARSHAN_ROOT/configure --prefix=${DARSHAN_INSTALL} \
+                                  --with-log-path=${DARSHAN_LOG_PATH} \
+                                  --with-jobid-env=NONE \
+                                  --enable-apmpi-mod \
+                                  --enable-apmpi-coll-sync \
+                                  CC=mpicc RUNTIME_CC=mpicc UTIL_CC=gcc
+          make -s LIBTOOLFLAGS=--silent V=1 -j8
+          make -s install
+      - name: make check (OpenMPI) --enable-apmpi-mod --enable-apmpi-coll-sync
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check
+      - name: Print test log files (OpenMPI) --enable-apmpi-mod --enable-apmpi-coll-sync
+        if: ${{ always() }}
+        run: |
+          cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log
+      - name: make check (OpenMPI) running 4 processes --enable-apmpi-mod --enable-apmpi-coll-sync
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/OPENMPI/bin:${PATH}"
+          cd ${GITHUB_WORKSPACE}/BUILD
+          make check NP=4
+      - name: Print test log files (OpenMPI) running 4 processes --enable-apmpi-mod --enable-apmpi-coll-sync
         if: ${{ always() }}
         run: |
           cat ${GITHUB_WORKSPACE}/BUILD/darshan-runtime/test/tst_runs.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 
 ACLOCAL_AMFLAGS = -I maint/config
 
-SUBDIRS =
+SUBDIRS = modules .
 
 if BUILD_DARSHAN_RUNTIME
    SUBDIRS += darshan-runtime

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ fi
 dnl must configure subpackages even if they are not built
 AC_CONFIG_SUBDIRS([darshan-util])
 
-AC_CONFIG_FILES(Makefile)
+AC_CONFIG_FILES(Makefile modules/Makefile)
 
 AC_OUTPUT
 

--- a/darshan-runtime/lib/darshan-core-init-finalize.c
+++ b/darshan-runtime/lib/darshan-core-init-finalize.c
@@ -20,6 +20,8 @@
 #include "darshan.h"
 #include "darshan-dynamic.h"
 
+static int __darshan_disabled;
+
 #ifdef HAVE_MPI
 DARSHAN_FORWARD_DECL(PMPI_Finalize, int, ());
 DARSHAN_FORWARD_DECL(PMPI_Init, int, (int *argc, char ***argv));

--- a/darshan-runtime/lib/darshan-core.c
+++ b/darshan-runtime/lib/darshan-core.c
@@ -52,6 +52,8 @@
 #include <lustre/lustre_user.h>
 #endif
 
+static int __darshan_disabled;
+
 extern char* __progname;
 extern char* __progname_full;
 struct darshan_core_runtime *__darshan_core = NULL;

--- a/darshan-runtime/lib/darshan-daos.c
+++ b/darshan-runtime/lib/darshan-daos.c
@@ -34,6 +34,8 @@
 #include <daos_obj.h>
 #include <daos_array.h>
 
+static int __darshan_disabled;
+
 /* container access routines intercepted for maintaining pool/container UUIDs */
 DARSHAN_FORWARD_DECL(daos_cont_open, int, (daos_handle_t poh, const char *cont, unsigned int flags, daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev));
 DARSHAN_FORWARD_DECL(daos_cont_global2local, int, (daos_handle_t poh, d_iov_t glob, daos_handle_t *coh));

--- a/darshan-runtime/lib/darshan-dfs.c
+++ b/darshan-runtime/lib/darshan-dfs.c
@@ -35,6 +35,8 @@
 #include <daos_array.h>
 #include <daos_fs.h>
 
+static int __darshan_disabled;
+
 DARSHAN_FORWARD_DECL(dfs_mount, int, (daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **dfs));
 DARSHAN_FORWARD_DECL(dfs_global2local, int, (daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob, dfs_t **dfs));
 DARSHAN_FORWARD_DECL(dfs_umount, int, (dfs_t *dfs));

--- a/darshan-runtime/lib/darshan-hdf5.c
+++ b/darshan-runtime/lib/darshan-hdf5.c
@@ -30,6 +30,8 @@
 
 #include <hdf5.h>
 
+static int __darshan_disabled;
+
 /* H5F prototypes */
 DARSHAN_FORWARD_DECL(H5Fcreate, hid_t, (const char *filename, unsigned flags, hid_t create_plist, hid_t access_plist));
 DARSHAN_FORWARD_DECL(H5Fopen, hid_t, (const char *filename, unsigned flags, hid_t access_plist));

--- a/darshan-runtime/lib/darshan-mdhim.c
+++ b/darshan-runtime/lib/darshan-mdhim.c
@@ -26,6 +26,8 @@
 
 #define RECORD_STRING "total-mdhim-obj-stats"
 
+static int __darshan_disabled;
+
 /* The DARSHAN_FORWARD_DECL macro (defined in darshan.h) is used to provide forward
  * declarations for wrapped funcions, regardless of whether Darshan is used with
  * statically or dynamically linked executables.

--- a/darshan-runtime/lib/darshan-mpiio.c
+++ b/darshan-runtime/lib/darshan-mpiio.c
@@ -31,6 +31,8 @@
 #include "darshan-heatmap.h"
 #include "darshan-ldms.h"
 
+static int __darshan_disabled;
+
 DARSHAN_FORWARD_DECL(PMPI_File_close, int, (MPI_File *fh));
 DARSHAN_FORWARD_DECL(PMPI_File_iread, int, (MPI_File fh, void  *buf, int  count, MPI_Datatype  datatype, __D_MPI_REQUEST  *request));
 DARSHAN_FORWARD_DECL(PMPI_File_iread_all, int, (MPI_File fh, void *buf, int count, MPI_Datatype datatype, __D_MPI_REQUEST *request));

--- a/darshan-runtime/lib/darshan-null.c
+++ b/darshan-runtime/lib/darshan-null.c
@@ -21,6 +21,8 @@
 #include "darshan.h"
 #include "darshan-dynamic.h"
 
+static int __darshan_disabled;
+
 /* module-specific macro to retrieve current time stamp.  It first checks to
  * see if Darshan has been disabled at run time; in that case the module can
  * skip potentially costly timer calls.

--- a/darshan-runtime/lib/darshan-pnetcdf.c
+++ b/darshan-runtime/lib/darshan-pnetcdf.c
@@ -29,6 +29,8 @@
 
 #include <pnetcdf.h>
 
+static int __darshan_disabled;
+
 /* structure that can track i/o stats for a given PnetCDF file record at runtime */
 struct pnetcdf_file_record_ref
 {

--- a/darshan-runtime/lib/darshan-posix.c
+++ b/darshan-runtime/lib/darshan-posix.c
@@ -37,6 +37,8 @@
 #include "darshan-heatmap.h"
 #include "darshan-ldms.h"
 
+static int __darshan_disabled;
+
 #ifndef HAVE_OFF64_T
 typedef int64_t off64_t;
 #endif

--- a/darshan-runtime/lib/darshan-stdio.c
+++ b/darshan-runtime/lib/darshan-stdio.c
@@ -89,6 +89,8 @@
 #include "darshan-heatmap.h"
 #include "darshan-ldms.h"
 
+static int __darshan_disabled;
+
 #ifndef HAVE_OFF64_T
 typedef int64_t off64_t;
 #endif

--- a/darshan-runtime/lib/darshan.h
+++ b/darshan-runtime/lib/darshan.h
@@ -205,7 +205,7 @@ extern pthread_mutex_t __darshan_core_mutex;
             exit(1); \
        } \
     } \
-    int __darshan_disabled = darshan_core_disabled_instrumentation();
+    __darshan_disabled = darshan_core_disabled_instrumentation();
 #else
 
 #define DARSHAN_FORWARD_DECL(__name,__ret,__args) \
@@ -224,7 +224,7 @@ extern pthread_mutex_t __darshan_core_mutex;
     __ret __wrap_ ## __func __args __attribute__ ((alias ("__wrap_" #__fcall)));
 
 #define MAP_OR_FAIL(__func) \
-    int __darshan_disabled = darshan_core_disabled_instrumentation()
+    __darshan_disabled = darshan_core_disabled_instrumentation()
 
 #endif
 

--- a/darshan-runtime/test/Makefile.am
+++ b/darshan-runtime/test/Makefile.am
@@ -8,8 +8,12 @@ AM_CPPFLAGS  = -I$(top_builddir)
 check_PROGRAMS =
 
 if BUILD_MPIIO_MODULE
-   check_PROGRAMS += tst_mpi_io
+   check_PROGRAMS += tst_mpi_init \
+                     tst_mpi_io
+
+   tst_mpi_init_SOURCES = tst_mpi_init.c
    tst_mpi_io_SOURCES = tst_mpi_io.c
+
    TESTS = tst_runs.sh
 else
    TESTS =

--- a/darshan-runtime/test/tst_mpi_init.c
+++ b/darshan-runtime/test/tst_mpi_init.c
@@ -1,0 +1,15 @@
+#ifdef HAVE_CONFIG_H
+#include <darshan-runtime-config.h> /* output of 'configure' */
+#endif
+
+#include <mpi.h>
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+
+    MPI_Finalize();
+    return 0;
+}
+
+

--- a/darshan-runtime/test/tst_runs.sh
+++ b/darshan-runtime/test/tst_runs.sh
@@ -289,7 +289,17 @@ echo "LD_PRELOAD=$LD_PRELOAD"
 
 for exe in ${check_PROGRAMS} ; do
 
-   if test "x$exe" = xtst_mpi_io ; then
+   echo ""
+   echo "==== Testing program: $exe"
+   echo ""
+
+   if test "x$exe" = xtst_mpi_init ; then
+
+      CMD="${TESTMPIRUN} -n ${NP} ./$exe"
+      echo "CMD=$CMD"
+      $CMD
+
+   elif test "x$exe" = xtst_mpi_io ; then
 
       DARSHAN_LOG_FILE="${TST_DARSHAN_LOG_PATH}/${USERNAME_ENV}_${exe}*"
       echo "DARSHAN_LOG_FILE=$DARSHAN_LOG_FILE"

--- a/darshan-util/tests/unit-tests/munit/munit.c
+++ b/darshan-util/tests/unit-tests/munit/munit.c
@@ -1296,7 +1296,6 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
 #if !defined(MUNIT_NO_FORK)
   int pipefd[2];
   pid_t fork_pid;
-  int orig_stderr;
   ssize_t bytes_written = 0;
   ssize_t write_res;
   ssize_t bytes_read = 0;
@@ -1352,7 +1351,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
     if (fork_pid == 0) {
       close(pipefd[0]);
 
-      orig_stderr = munit_replace_stderr(stderr_buf);
+      int orig_stderr = munit_replace_stderr(stderr_buf);
       munit_test_runner_exec(runner, test, params, &report);
 
       /* Note that we don't restore stderr.  This is so we can buffer

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -1,0 +1,23 @@
+#
+# See COPYRIGHT notice in top-level directory.
+#
+# @configure_input@
+
+apmpi_c_src = $(srcdir)/autoperf/apmpi/lib/darshan-apmpi.c
+apmpi_c_saved = $(srcdir)/autoperf/apmpi/lib/saved_darshan-apmpi.c
+apmpi_c_patch = $(srcdir)/apmpi.patch
+
+# Rule to apply the patch
+$(apmpi_c_saved): $(apmpi_c_src) $(apmpi_c_patch)
+	cp -f $(apmpi_c_src) $(apmpi_c_saved)
+	patch -f -p0 $(apmpi_c_src) < $(apmpi_c_patch)
+	touch $@
+
+BUILT_SOURCES = $(apmpi_c_saved)
+
+EXTRA_DIST = apmpi.patch
+
+clean: $(apmpi_c_saved)
+	cp -f $(apmpi_c_saved) $(apmpi_c_src)
+	rm -f $(apmpi_c_saved) $(apmpi_c_src).*
+

--- a/modules/apmpi.patch
+++ b/modules/apmpi.patch
@@ -1,6 +1,15 @@
 --- darshan-apmpi.c.orig	2025-10-03 14:11:57.395296967 -0500
-+++ darshan-apmpi.c	2025-10-03 14:22:12.684565527 -0500
-@@ -29,14 +29,16 @@
++++ darshan-apmpi.c	2025-10-04 12:03:16.352785800 -0500
+@@ -19,6 +19,8 @@
+ #include "darshan-dynamic.h"
+ #include "darshan-apmpi-log-format.h"
+
++static int __darshan_disabled;
++
+ typedef long long ap_bytes_t;
+ #define MAX(x,y) ((x>y)?x:y)
+ #define MIN(x,y) ((x==0.0)?y:((x<y)?x:y))
+@@ -29,14 +31,16 @@
  #define TIME_SYNC(FUNC) \
            double tm1, tm2, tm3, tdiff, tsync;\
            int ret; \

--- a/modules/apmpi.patch
+++ b/modules/apmpi.patch
@@ -1,0 +1,27 @@
+--- darshan-apmpi.c.orig	2025-10-03 14:11:57.395296967 -0500
++++ darshan-apmpi.c	2025-10-03 14:22:12.684565527 -0500
+@@ -29,14 +29,16 @@
+ #define TIME_SYNC(FUNC) \
+           double tm1, tm2, tm3, tdiff, tsync;\
+           int ret; \
+-          MAP_OR_FAIL(PMPI_Barrier);\
+-          tm1 = APMPI_WTIME(); \
+-          ret = __real_PMPI_Barrier(comm); \
+-          tm2 = APMPI_WTIME(); \
+-          ret = FUNC; \
+-          tm3 = APMPI_WTIME(); \
+-          tdiff = tm3-tm2; \
+-          tsync = tm2-tm1
++          { \
++              MAP_OR_FAIL(PMPI_Barrier);\
++              tm1 = APMPI_WTIME(); \
++              ret = __real_PMPI_Barrier(comm); \
++              tm2 = APMPI_WTIME(); \
++              ret = FUNC; \
++              tm3 = APMPI_WTIME(); \
++              tdiff = tm3-tm2; \
++              tsync = tm2-tm1; \
++          }
+ #else
+ 
+ #define TIME_SYNC(FUNC) \


### PR DESCRIPTION
This is to fix #1077 

Note this PR stacks on top of #1082, because file `darshan-apmpi.c`
from autoperf submodule also needs to be fixed.