### PR TITLE
DOC: add missing configure options to user guides

### DIFF
--- a/darshan-runtime/doc/darshan-runtime.rst
+++ b/darshan-runtime/doc/darshan-runtime.rst
@@ -79,31 +79,51 @@ Compilation
 
 **Configure and build example (with MPI support)**
 
- .. code-block:: bash
+* When using the release tar ball:
 
-    tar -xvzf darshan-<version-number>.tar.gz
-    cd darshan-<version-number>/
-    ./prepare.sh
-    cd darshan-runtime/
-    ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID CC=mpicc
-    make
-    make install
+  .. code-block:: bash
 
+     tar -xvzf darshan-<version-number>.tar.gz
+     cd darshan-<version-number>/
+     ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID CC=mpicc
+     make -j 8 install
+
+* When cloning from Darshan's reposatory from Github.com:
+
+  .. code-block:: bash
+
+     git clone https://github.com/darshan-hpc/darshan.git
+     cd darshan
+     autoreconf -i
+     ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID CC=mpicc
+     make -j 8 install
 
 **Configure and build example (without MPI support)**
 
- .. code-block:: bash
+* When using the release tar ball:
 
-    tar -xvzf darshan-<version-number>.tar.gz
-    cd darshan-<version-number>/
-    ./prepare.sh
-    cd darshan-runtime/
-    ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID --without-mpi CC=gcc
-    make
-    make install
+  .. code-block:: bash
+
+     tar -xvzf darshan-<version-number>.tar.gz
+     cd darshan-<version-number>/
+     ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID --without-mpi CC=gcc
+     make -j 8 install
+
+* When cloning from Darshan's reposatory from Github.com:
+
+  .. code-block:: bash
+
+     git clone https://github.com/darshan-hpc/darshan.git
+     cd darshan
+     autoreconf -i
+     ./configure --with-log-path=/darshan-logs --with-jobid-env=PBS_JOBID --without-mpi CC=gcc
+     make -j 8
+     make install
 
 **Explanation of configure arguments:**
 
+* ``--disable-darshan-util``: Build without Darshan utility tools
+  (default: enable).
 * ``--with-mem-align=NUM``: This value is system-dependent and will be used by
   Darshan to determine if the buffer for a read or write operation is
   aligned in memory (default is 8).
@@ -858,7 +878,7 @@ path, respectively.
         --with-jobid-env=SLURM_JOBID \
         --with-username-env=SLURM_JOB_USER \
         CC=cc
-    make install
+    make -j 8 install
     module swap PrgEnv-gnu PrgEnv-pgi
 
 

--- a/darshan-test/automated/build-darshan.sh
+++ b/darshan-test/automated/build-darshan.sh
@@ -23,18 +23,18 @@ mkdir -p $DARSHAN_LOG_PATH
 
 # configure and build darshan-runtime (if not requested to skip)
 if [ ! -v DARSHAN_RUNTIME_SKIP ]; then
-    mkdir -p $build_dir/darshan-runtime && cd $build_dir/darshan-runtime
+    mkdir -p $build_dir && cd $build_dir
     if [ -z "${DARSHAN_RUNTIME_CONFIG_ARGS}" ]; then
         DARSHAN_RUNTIME_CONFIG_ARGS="--with-jobid-env=NONE --enable-apmpi-mod"
     fi
-    $darshan_root_dir/darshan-runtime/configure $DARSHAN_RUNTIME_CONFIG_ARGS --with-log-path=$DARSHAN_LOG_PATH --prefix=$DARSHAN_INSTALL_PREFIX
-    make install
+    $darshan_root_dir/configure --disable-darshan-util $DARSHAN_RUNTIME_CONFIG_ARGS --with-log-path=$DARSHAN_LOG_PATH --prefix=$DARSHAN_INSTALL_PREFIX
+    make -j8 install
 fi
 
 # configure and build darshan-util
-mkdir -p $build_dir/darshan-util && cd $build_dir/darshan-util
+mkdir -p $build_dir && cd $build_dir
 if [ -z "${DARSHAN_UTIL_CONFIG_ARGS}" ]; then
     DARSHAN_UTIL_CONFIG_ARGS="--enable-apmpi-mod --enable-apxc-mod"
 fi
-$darshan_root_dir/darshan-util/configure $DARSHAN_UTIL_CONFIG_ARGS --prefix=$DARSHAN_INSTALL_PREFIX
-make install
+$darshan_root_dir/configure --disable-darshan-runtime $DARSHAN_UTIL_CONFIG_ARGS --prefix=$DARSHAN_INSTALL_PREFIX
+make -j8 install

--- a/darshan-util/doc/darshan-util.rst
+++ b/darshan-util/doc/darshan-util.rst
@@ -40,15 +40,23 @@ Compilation and installation
 
 **Configure and build example**
 
-.. code-block:: bash
+* When using the release tar ball:
 
-   tar -xvzf darshan-<version-number>.tar.gz
-   cd darshan-<version-number>/
-   ./prepare.sh
-   cd darshan-util/
-   ./configure
-   make
-   make install
+  .. code-block:: bash
+
+     tar -xvzf darshan-<version-number>.tar.gz
+     ./configure
+     make -j 8 install
+
+* When cloning from Darshan's reposatory from Github.com:
+
+  .. code-block:: bash
+
+     git clone https://github.com/darshan-hpc/darshan.git
+     cd darshan
+     autoreconf -i
+     ./configure
+     make -j 8 install
 
 The darshan-util package is intended to be used on a login node or workstation.
 For most use cases this means that you should either leave ``CC`` to its
@@ -63,23 +71,37 @@ alternative paths for zlib and libbz2 development libraries.  darshan-util also
 supports VPATH or "out-of-tree" builds if you prefer that method of
 compilation.
 
-The ``--enable-shared`` argument to configure can be used to enable compilation
-of a shared version of the darshan-util library.
+**Explanation of configure arguments:**
 
-The ``--enable-apmpi-mod`` and ``--enable-apxc-mod`` configure arguments must
-be specified to build darshan-util with support for AutoPerf APMPI and APXC
-modules, respectively.
+* ``--disable-darshan-runtime``: Build without Darshan runtime libraries
+  (default: enable).
+* ``--disable-shared``: Build without a shared version of the darshan-util
+  library (default: enable).
+* ``--enable-apmpi-mod``: Build darshan-util with support for AutoPerf APMPI
+  modules (default: disable).
+* ``--enable-apxc-mod``: Build darshan-util with support for AutoPerf APXC
+  modules (default: disable).
 
-.. note::
-   AutoPerf log analysis code is provided as Git submodules to Darshan's main
-   repository, so if building Darshan source that has been cloned from Git, it
-   is necessary to first retrieve the AutoPerf submodules by running the
-   following command:
+  .. note::
+     AutoPerf log analysis code is provided as Git submodules to Darshan's main
+     repository, so if building Darshan source that has been cloned from Git,
+     it is necessary to first retrieve the AutoPerf submodules by running the
+     following command:
 
-   .. code-block:: bash
+     .. code-block:: bash
 
-      git submodule update --init
-
+        git submodule update --init
+* ``--enable-pydarshan``: Build pydarshan module and tools (default: disable).
+* ``--with-zlib=DIR``: root directory path of zlib installation (default:
+  /usr/local or /usr if not found in /usr/local).
+* ``--without-zlib``: Disable zlib usage completely.
+* ``--with-bzlib=DIR``: root directory path of bzlib installation (default:
+  /usr/local or /usr if not found in /usr/local).
+* ``--without-bzlib``: Disable bzlib usage completely
+* ``--with-python-sys-prefix``: Use Python's ``sys.prefix`` and
+  ``sys.exec_prefix`` values.
+* ``--with-python_prefix``: override the default ``PYTHON_PREFIX``.
+* ``--with-python_exec_prefix``: override the default ``PYTHON_EXEC_PREFIX``.
 
 **********************************
 Analyzing log files


### PR DESCRIPTION
* `--disable-darshan-util`
* `--disable-darshan-runtime`
* `--enable-pydarshan`
* `--with-zlib=DIR`
* `--without-zlib`
* `--with-bzlib=DIR`
* `--without-bzlib`
* `--with-python-sys-prefix`
* `--with-python_prefix`
* `--with-python_exec_prefix`

Also, modify `darshan-test/automated/build-darshan.sh` to build from the root folder.
