### PR TITLE
Add pnetcdf lib to --dyn-ld-flags

### DIFF
--- a/darshan-runtime/darshan-config.in
+++ b/darshan-runtime/darshan-config.in
@@ -140,7 +140,7 @@ POST_LD_FLAGS="-L$DARSHAN_LIB_PATH -ldarshan @DARSHAN_LUSTRE_LD_FLAGS@ -lz -lrt 
 # - when dynamic linking there is no need for wrapping options, we simply
 #   need to get the darshan symbol definitions early enough in the link
 #   order.  We also set no-as-needed for linkers that may not identify
-DYN_LD_FLAGS="-L$DARSHAN_LIB_PATH $DARSHAN_LD_FLAGS -Wl,-rpath=$DARSHAN_LIB_PATH -Wl,-no-as-needed -ldarshan @DARSHAN_LUSTRE_LD_FLAGS@ @DARSHAN_HDF5_LD_FLAGS@"
+DYN_LD_FLAGS="-L$DARSHAN_LIB_PATH $DARSHAN_LD_FLAGS -Wl,-rpath=$DARSHAN_LIB_PATH -Wl,-no-as-needed -ldarshan @DARSHAN_LUSTRE_LD_FLAGS@ @DARSHAN_HDF5_LD_FLAGS@ @DARSHAN_PNETCDF_LD_FLAGS@"
 
 # NOTE:
 # - construct complete list of log path options, separated by commas.


### PR DESCRIPTION
Add the missing pnetcdf library path, which fixes the linking error below.
```
mpicc -Wall -g -O2 -I/usr/include   hello-mpiio.c   -o hello-mpiio
/usr/bin/ld: /lus/flare/projects/alcf_training/io-libraries/soft/darshan-3.5.0/lib/libdarshan.so: undefined reference to `ncmpi_inq_vardimid'
```