### PR TITLE
Check autoperf submodule git SHA to determine whether to use patched darshan-apmpi.c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,11 +5,7 @@
 
 ACLOCAL_AMFLAGS = -I maint/config
 
-if BUILD_APMPI_MODULE
-   SUBDIRS = modules .
-else
-   SUBDIRS = .
-endif
+SUBDIRS = modules
 
 if BUILD_DARSHAN_RUNTIME
    SUBDIRS += darshan-runtime

--- a/configure.ac
+++ b/configure.ac
@@ -30,14 +30,6 @@ AC_ARG_ENABLE([darshan-runtime],
 )
 AM_CONDITIONAL(BUILD_DARSHAN_RUNTIME, [test "x$enable_darshan_runtime" != xno])
 
-# AUTOPERF MPI module
-AC_ARG_ENABLE([apmpi-mod],
-   [AS_HELP_STRING([--enable-apmpi-mod],
-                   [Enables compilation and use of AUTOPERF MPI module (requ  ires MPI)])],
-   [], [enable_apmpi_mod=no]
-)
-AM_CONDITIONAL(BUILD_APMPI_MODULE, [test "x$enable_apmpi_mod" = xyes])
-
 AC_ARG_ENABLE([darshan-util],
    [AS_HELP_STRING([--disable-darshan-util],
                    [Build without Darshan utility tools])],

--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -312,6 +312,23 @@ if test "x$enable_darshan_runtime" = xyes ; then
          #endif]])], [],
          [AC_MSG_ERROR([APMPI module requires MPI version 3+.])]
       )
+
+      AC_MSG_CHECKING([whether patching darshan-apmpi.c is necessary])
+      submod_status="m4_esyscmd_s([git submodule status])"
+      apmpi_mod_sha=`echo ${submod_status} | cut -d' ' -f1`
+
+      if test "x$apmpi_mod_sha" = x8623a0652735785fe87d89514112e43e4f52a78d ; then
+         apply_apmpi_patch=yes
+      else
+         # check if git HAED of autoperf is a descendent of 8623a06
+         ac_flag=m4_esyscmd_s([cd ../modules/autoperf && git merge-base --is-ancestor 8623a0652735785fe87d89514112e43e4f52a78d HEAD && echo "$?"])
+         if test "x$ac_flag" = x0 ; then
+            apply_apmpi_patch=no
+         else
+            apply_apmpi_patch=yes
+         fi
+      fi
+      AC_MSG_RESULT([$apply_apmpi_patch])
    fi
 
    AC_ARG_ENABLE([apmpi-coll-sync],
@@ -1032,6 +1049,7 @@ AM_CONDITIONAL(BUILD_BGQ_MODULE,    [test "x$enable_bgq_mod"     = xyes])
 AM_CONDITIONAL(BUILD_LUSTRE_MODULE, [test "x$enable_lustre_mod"  = xyes])
 AM_CONDITIONAL(BUILD_MDHIM_MODULE,  [test "x$enable_mdhim_mod"   = xyes])
 AM_CONDITIONAL(BUILD_APMPI_MODULE,  [test "x$enable_apmpi_mod"   = xyes])
+AM_CONDITIONAL(PATCH_APMPI_MODULE,  [test "x$apply_apmpi_patch"  = xyes])
 AM_CONDITIONAL(BUILD_APXC_MODULE,   [test "x$enable_apxc_mod"    = xyes])
 AM_CONDITIONAL(BUILD_HEATMAP_MODULE,[test "x$enable_heatmap_mod" = xyes])
 AM_CONDITIONAL(BUILD_DAOS_MODULE,   [test "x$enable_daos_mod"    = xyes])

--- a/darshan-runtime/lib/Makefile.am
+++ b/darshan-runtime/lib/Makefile.am
@@ -104,8 +104,15 @@ if BUILD_APMPI_MODULE
    AM_CPPFLAGS += -DDARSHAN_USE_APMPI \
                   -I$(apmpi_root) -I$(apmpi_root)/lib
 endif
+
+if PATCH_APMPI_MODULE
+   darshan_apmpi_c=$(top_srcdir)/../modules/patched_darshan-apmpi.c
+else
+   darshan_apmpi_c=$(apmpi_root)/lib/darshan-apmpi.c
+endif
+
 darshan-apmpi.c:
-	$(LN_S) $(top_srcdir)/../modules/patched_darshan-apmpi.c $@
+	$(LN_S) $(darshan_apmpi_c) $@
 
 libdarshan_la_SOURCES  = $(C_SRCS)
 libdarshan_la_LIBADD   = -lpthread -lrt -lz -ldl $(DARSHAN_LUSTRE_LD_FLAGS)


### PR DESCRIPTION
Patched darshan-apmpi.c will only be used when submodule autoperf's HEAD SHA is equal or earlier than 8623a0652735785fe87d89514112e43e4f52a78d

related PR #1082 and #1083