### PR TITLE
workstation-ld-preload/env.sh - remove hack of adding libfmpich.so

### DIFF
--- a/darshan-test/regression/workstation-ld-preload/env.sh
+++ b/darshan-test/regression/workstation-ld-preload/env.sh
@@ -5,7 +5,7 @@
 
 # Script to set up the environment for tests on this platform.  Must export
 # the following environment variables:
-# 
+#
 # DARSHAN_CC: command to compile C programs
 # DARSHAN_CXX: command to compile C++ programs
 # DARSHAN_F90: command to compile Fortran90 programs
@@ -18,7 +18,7 @@
 
 # Notes specific to this platform (workstation-ld-preload)
 ########################
-# This particular env script assumes that mpicc and its variants for other 
+# This particular env script assumes that mpicc and its variants for other
 # languages are already in the path, and that they will produce dynamic
 # executables by default.  Test programs are compiled using the existing
 # scripts, and LD_PRELOAD is set to enable instrumentation.
@@ -29,13 +29,8 @@ export DARSHAN_CC=mpicc
 export DARSHAN_CXX=mpicxx
 export DARSHAN_F77=mpif77
 export DARSHAN_F90=mpif90
-FULL_MPICC_PATH=`which mpicc`
 
-# This is a hack.  In order to instrument Fortran programs with LD_PRELOAD,
-# we must prepend libfmpich.so to the LD_PRELOAD variable, but with a fully
-# resolve path.  To find a path we locate mpicc and speculate that
-# libfmich.so can be found in ../lib.
-export LD_PRELOAD=`dirname $FULL_MPICC_PATH`/../lib/libfmpich.so:$DARSHAN_RUNTIME_PATH/lib/libdarshan.so:$LD_PRELOAD
+export LD_PRELOAD=$DARSHAN_RUNTIME_PATH/lib/libdarshan.so:$LD_PRELOAD
 
 export DARSHAN_RUNJOB="mpiexec -n $DARSHAN_DEFAULT_NPROCS"
 


### PR DESCRIPTION
After the installation of Darshan 3.5.0 under Spack environment, a test run of
`darshan-test/regression/run-all.sh` failed with errors saying Darshan log
files could not be found. The issue points to this line of codes in file
`workstation-ld-preload/env.sh`.
```
export LD_PRELOAD=`dirname $FULL_MPICC_PATH`/../lib/libfmpich.so:$DARSHAN_RUNTIME_PATH/lib/libdarshan.so:$LD_PRELOAD
```
Removing `libfmpich.so` fixes the problem. 

The older versions of mpich needed that hack, but it's no longer the case with today's MPICH, which has changed how the libraries are organized quite some time ago.