### PR TITLE
darshan-runtime.pc.in - remove requirements of mpich and zlib

### DIFF
--- a/darshan-runtime/pkgconfig/darshan-runtime.pc.in
+++ b/darshan-runtime/pkgconfig/darshan-runtime.pc.in
@@ -5,7 +5,7 @@ Name: darshan
 Description: Darshan runtime library
 Version: @DARSHAN_VERSION@
 
-Requires: zlib mpich
+Requires:
 Requires.private:
 
 prefix=@prefix@


### PR DESCRIPTION
Darshan may be built with a different MPI library.
Also, it may be built without zlib.
This PR resolves issue #1094 