### PR TITLE
Fix: CSV data not being stored in darshan_ldms_test_ci.yml workflow

### DIFF
--- a/.github/workflows/darshan_ldms_test_ci.yml
+++ b/.github/workflows/darshan_ldms_test_ci.yml
@@ -88,6 +88,7 @@ jobs:
         fi
         echo "---generating ldmsd configuration file---"
         cat > stream-samp-latest.conf << EOF
+        stream_enable
         load name=hello_sampler
         config name=hello_sampler producer=host1 instance=host1/hello_sampler stream=darshanConnector component_id=1
         start name=hello_sampler interval=1000000 offset=0


### PR DESCRIPTION
This patch resolves an issue where no data was being written to the CSV file with the `darshan_ldms_test_ci.yml` workflow.

The problem was caused by a recent LDMS update that requires `stream_enable` to be set in the configuration file for the LDMS daemon to collect and store I/O application data.

To address this, `stream_enable` has been added at the top of `stream-samp-latest.conf.`