### PR TITLE
Doc: update release check list for creating an example log file on Polaris

### DIFF
--- a/darshan-test/RELEASE-CHECKLIST.txt
+++ b/darshan-test/RELEASE-CHECKLIST.txt
@@ -31,13 +31,14 @@ Notes on how to release a new version of Darshan
     the darshan-logs repo in the darshan_logs/release_logs/ directory
     a. log into polaris.alcf.anl.gov
     b. clone darshan repo, say into $HOME/Darshan/Github/darshan
-    c. install Darshan, say into folder $HOME/Darshan/Github/DEV
-    d. cd $HOME/Darshan/Github/darshan/darshan-test/regression/
-    e. ./run-all.sh $HOME/Darshan/Github/DEV $HOME/Darshan/TEST alcf-polaris-cray-module
-    f. clone darshan-logs repo, say into $HOME/Darshan/Github/darshan-logs
-    g. cd $HOME/Darshan/Github/darshan-logs/darshan_logs/release_logs
-    h. cp $HOME/Darshan/TEST/mpi-io-test.darshan mpi-io-test-x86_64-3.5.0.darshan
-    i. Create a new PR
+    c. module swap PrgEnv-nvidia PrgEnv-gnu
+    d. install Darshan, say into folder $HOME/Darshan/Github/DEV
+    e. cd $HOME/Darshan/Github/darshan/darshan-test/regression/
+    f. ./run-all.sh $HOME/Darshan/Github/DEV $HOME/Darshan/TEST alcf-polaris-cray-module
+    g. clone darshan-logs repo, say into $HOME/Darshan/Github/darshan-logs
+    h. cd $HOME/Darshan/Github/darshan-logs/darshan_logs/release_logs
+    i. cp $HOME/Darshan/TEST/mpi-io-test.darshan mpi-io-test-x86_64-3.5.0.darshan
+    j. Create a new PR
 10) make a tag for the release according to instructions at
     http://git-scm.com/book/en/Git-Basics-Tagging
     - example (annotated tag, pushed to repo):


### PR DESCRIPTION
Default loaded module is PrgEnv-nvidia on Polaris. If not swapped to PrgEnv-gnu, all Fortran test programs failed when running darhan-test/regression/run-all.sh. Only C and C++ programs ran fine.

According to Phil, Darshan is usually built with gnu compilers on DOE parallel computers, because then the library can be safely linked into executables built with any compiler.