### PR TITLE
Fix security vulnerabilities in Python dependencies

### DIFF
--- a/darshan-util/pydarshan/darshan/examples/requirements-examples.txt
+++ b/darshan-util/pydarshan/darshan/examples/requirements-examples.txt
@@ -1,12 +1,12 @@
-jupyter
-notebook
+jupyter>=1.0.0
+notebook>=7.2.2
 
 
 # altair (has svg well exposed)
-altair
+altair>=5.0.0
 
 
 # for bokeh + svg export
 # but bokeh is almost as verbose to use as matplotlib
-bokeh
-selenium
+bokeh>=3.0.0
+selenium>=4.14.0

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -8,18 +8,18 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "darshan"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Python tools to interact with Darshan log records of HPC applications."
 readme = 'README.rst'
 dependencies = [
-    "cffi",
-    "numpy",
-    "pandas",
-    "matplotlib",
-    "seaborn",
-    "mako",
-    "humanize",
-    "rich"
+    "cffi>=1.15.0",
+    "numpy>=1.22.0",
+    "pandas>=2.0.0",
+    "matplotlib>=3.5.0",
+    "seaborn>=0.12.0",
+    "mako>=1.2.4",
+    "humanize>=4.0.0",
+    "rich>=13.0.0"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -27,7 +27,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -41,15 +40,15 @@ repository = 'https://github.com/darshan-hpc/darshan'
 
 [project.optional-dependencies]
 test = [
-    "packaging",
-    "pytest",
-    "lxml",
-    "importlib_resources;python_version<'3.9'",
+    "packaging>=21.0",
+    "pytest>=7.0.0",
+    "lxml>=4.9.1",
+    "importlib_resources>=5.0.0;python_version<'3.9'",
 ]
 dev = [
-    "sphinx",
-    "sphinx_rtd_theme",
-    "pipx"
+    "sphinx>=7.0.0",
+    "sphinx_rtd_theme>=2.0.0",
+    "pipx>=1.0.0"
 ]
 
 [tool.setuptools.packages.find]
@@ -76,12 +75,12 @@ skip = [
     "*_s390x"
 ]
 test-requires = [
-    "packaging",
-    "pytest",
-    "lxml",
-    "matplotlib",
-    "importlib_resources;python_version<'3.9'",
-    "humanize"
+    "packaging>=21.0",
+    "pytest>=7.0.0",
+    "lxml>=4.9.1",
+    "matplotlib>=3.5.0",
+    "importlib_resources>=5.0.0;python_version<'3.9'",
+    "humanize>=4.0.0"
 ]
 before-test = "pip install -U git+https://github.com/darshan-hpc/darshan-logs.git@main"
 test-command = "pytest {package}"

--- a/darshan-util/pydarshan/requirements.txt
+++ b/darshan-util/pydarshan/requirements.txt
@@ -1,4 +1,4 @@
-cffi
-numpy
-pandas
-matplotlib
+cffi>=1.15.0
+numpy>=1.22.0
+pandas>=2.0.0
+matplotlib>=3.5.0

--- a/darshan-util/pydarshan/requirements_dev.txt
+++ b/darshan-util/pydarshan/requirements_dev.txt
@@ -1,19 +1,19 @@
-wheel
-watchdog
-twine
+wheel>=0.38.1
+watchdog>=3.0.0
+twine>=4.0.0
 
-cffi
-numpy
-pandas
-matplotlib
-seaborn
-mako
-jupyterlab
+cffi>=1.15.0
+numpy>=1.22.0
+pandas>=2.0.0
+matplotlib>=3.5.0
+seaborn>=0.12.0
+mako>=1.2.4
+jupyterlab>=4.4.8
 
-pytest
-pytest-runner
+pytest>=7.0.0
+pytest-runner>=6.0.0
 # lxml needed implicitly for pandas read_html calls in some tests
-lxml
+lxml>=4.9.1
 
-sphinx
-sphinx_rtd_theme
+sphinx>=7.0.0
+sphinx_rtd_theme>=2.0.0

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -5,8 +5,8 @@ from setuptools import setup, Extension
 import sys
 import os
 
-if sys.version_info[:2] < (3, 7):
-    raise RuntimeError("Python version >= 3.7 required.")
+if sys.version_info[:2] < (3, 8):
+    raise RuntimeError("Python version >= 3.8 required.")
 
 
 

--- a/readthedocs/requirements.txt
+++ b/readthedocs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx==8.1.3
 sphinx-rtd-theme==3.0.2
-cffi
-numpy
-pandas
-matplotlib
+cffi>=1.15.0
+numpy>=1.22.0
+pandas>=2.0.0
+matplotlib>=3.5.0


### PR DESCRIPTION
Address all 34 reported vulnerabilities by pinning to patched versions:

- wheel: 0.38.1+ (PYSEC-2022-43017/GHSA-qwmp-2cf2-g9g6)
- jupyterlab: 4.4.8+ (GHSA-44cc-43rp-5947, GHSA-9q39-rmj3-p4r2, GHSA-vvfj-2jqx-52jm)
- notebook: 7.2.2+ (GHSA-hwvq-6gjx-j797, GHSA-rv62-4pmj-xw6h, plus jupyterlab CVEs)
- selenium: 4.14.0+ (PYSEC-2023-206)
- lxml: 4.9.1+ (GHSA-55x5-fj6c-h6m8, GHSA-pgww-xf46-h92r, PYSEC-2018-*, PYSEC-2020-*, PYSEC-2021-*)
- numpy: 1.22.0+ (GHSA-fpfv-jqm9-f5jm, PYSEC-2017-1, PYSEC-2019-*, PYSEC-2021-*, PYSEC-2022-*)

This has been found using the OpenSSF scorecard app with the following
command:

```
podman run -e GITHUB_AUTH_TOKEN=SECRE gcr.io/openssf/scorecard:stable --repo=github.com/darshan-hpc/darshan --checks=vulnerabilities --show-details
```

Here was its output:

```
Warn: Project is vulnerable to: PYSEC-2018-18 / GHSA-3p4q-x8f3-p7vq
Warn: Project is vulnerable to: PYSEC-2021-130 / GHSA-4952-p58q-6crx
Warn: Project is vulnerable to: PYSEC-2018-17 / GHSA-49qr-xh3w-h436
Warn: Project is vulnerable to: PYSEC-2018-57 / GHSA-6cwv-x26c-w2q4
Warn: Project is vulnerable to: PYSEC-2020-215 / GHSA-c7vm-f5p4-8fqh
Warn: Project is vulnerable to: PYSEC-2019-159 / GHSA-hhx8-cr55-qcxx
Warn: Project is vulnerable to: GHSA-hwvq-6gjx-j797
Warn: Project is vulnerable to: PYSEC-2019-157 / GHSA-jqwc-jm56-wcwj
Warn: Project is vulnerable to: PYSEC-2022-180 / GHSA-m87f-39q9-6f55
Warn: Project is vulnerable to: PYSEC-2019-158 / GHSA-rcx2-m7jp-p9wj
Warn: Project is vulnerable to: GHSA-rv62-4pmj-xw6h
Warn: Project is vulnerable to: PYSEC-2022-212 / GHSA-v7vq-3x77-87vg
Warn: Project is vulnerable to: PYSEC-2022-43167
Warn: Project is vulnerable to: PYSEC-2023-206
Warn: Project is vulnerable to: PYSEC-2018-34 / GHSA-2fc2-6r4j-p65h
Warn: Project is vulnerable to: PYSEC-2021-856 / GHSA-5545-2q6w-2gh6
Warn: Project is vulnerable to: PYSEC-2019-108 / GHSA-9fq2-x9r6-wfmf
Warn: Project is vulnerable to: PYSEC-2018-33 / GHSA-cw6w-4rcx-xphc
Warn: Project is vulnerable to: PYSEC-2021-857 / GHSA-f7c7-j99h-c22f
Warn: Project is vulnerable to: GHSA-fpfv-jqm9-f5jm
Warn: Project is vulnerable to: PYSEC-2017-1 / GHSA-frgw-fgh6-9g52
Warn: Project is vulnerable to: PYSEC-2020-73
Warn: Project is vulnerable to: GHSA-44cc-43rp-5947
Warn: Project is vulnerable to: GHSA-9q39-rmj3-p4r2
Warn: Project is vulnerable to: GHSA-vvfj-2jqx-52jm
Warn: Project is vulnerable to: GHSA-55x5-fj6c-h6m8
Warn: Project is vulnerable to: PYSEC-2014-9 / GHSA-57qw-cc2g-pv5p
Warn: Project is vulnerable to: PYSEC-2021-19 / GHSA-jq4v-f5q6-mjqq
Warn: Project is vulnerable to: GHSA-pgww-xf46-h92r
Warn: Project is vulnerable to: PYSEC-2022-230 / GHSA-wrxv-2j5q-m38w
Warn: Project is vulnerable to: PYSEC-2018-12 / GHSA-xp26-p53h-6h2p
Warn: Project is vulnerable to: PYSEC-2010-1 / GHSA-7q8x-38mc-p84f
Warn: Project is vulnerable to: PYSEC-2022-260 / GHSA-v973-fxgf-6xhp
Warn: Project is vulnerable to: PYSEC-2022-43017 / GHSA-qwmp-2cf2-g9g6
```

Running against my fork main branch (it can only read the main branch of a repo)

```
0 existing vulnerabilities
```
