### PR TITLE
cirrus CI bump up to MacOS sonoma

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 macos_instance:
-  image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  image: ghcr.io/cirruslabs/macos-runner:sonoma
 
 macos_M1_native_apple_silicon_py310_task:
   script: |


### PR DESCRIPTION
Cirrus CI warning message:
```
⚠️ Only [ghcr.io/cirruslabs/macos-runner:sonoma, ghcr.io/cirruslabs/macos-runner:sequoia, ghcr.io/cirruslabs/macos-runner:tahoe] is allowed. Automatically upgraded to ghcr.io/cirruslabs/macos-runner:tahoe.
```

Starting from Dec. 4, 2025, Github action no longer support Ventura.
Other options are to bump up to Sequoia or Tahoe