### PR TITLE
Github CI: set permission to read only

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,5 +1,8 @@
 name: Build Wheels
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/darshan_ldms_test_ci.yml
+++ b/.github/workflows/darshan_ldms_test_ci.yml
@@ -8,6 +8,9 @@
 
 name: Darshan-LDMS Integration Test - Latest
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/end_to_end_pytest.yml
+++ b/.github/workflows/end_to_end_pytest.yml
@@ -1,5 +1,8 @@
 name: End-to-end Testing (pytest)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/end_to_end_regression.yml
+++ b/.github/workflows/end_to_end_regression.yml
@@ -1,5 +1,8 @@
 name: End-to-end Testing (regression)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/end_to_end_regression_aurora.yml
+++ b/.github/workflows/end_to_end_regression_aurora.yml
@@ -1,5 +1,8 @@
 name: End-to-end Testing (regression) Aurora
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/end_to_end_regression_polaris.yml
+++ b/.github/workflows/end_to_end_regression_polaris.yml
@@ -1,5 +1,8 @@
 name: End-to-end Testing (regression) Polaris
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -2,6 +2,10 @@
 # Rely on .github/pr_path_labeler.yml
 # https://github.com/marketplace/actions/labeler
 name: "Pull Request Labeler"
+
+permissions:
+  contents: read
+
 on:
 - pull_request_target
 

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,5 +1,8 @@
 name: Python Testing
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/mpich_openmpi.yml
+++ b/.github/workflows/mpich_openmpi.yml
@@ -1,5 +1,8 @@
 name: Test MPICH and OpenMPI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
A warning message generated from Dependabot:

Workflow does not contain permissions
Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}