### PR TITLE
Pin PyDarshan dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "pip"
+    directory: "darshan-util/pydarshan"
+    schedule:
+      interval: "weekly"

--- a/darshan-util/pydarshan/pyproject.toml
+++ b/darshan-util/pydarshan/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "wheel",
+    "wheel>=0.45.1",
     "setuptools>=65.0.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -12,14 +12,14 @@ requires-python = ">=3.7"
 description = "Python tools to interact with Darshan log records of HPC applications."
 readme = 'README.rst'
 dependencies = [
-    "cffi",
-    "numpy",
-    "pandas",
-    "matplotlib",
-    "seaborn",
-    "mako",
-    "humanize",
-    "rich"
+    "cffi>=1.17.1",
+    "numpy>=1.24.4",
+    "pandas>=2.0.3",
+    "matplotlib>=3.7.5",
+    "seaborn>=0.13.2",
+    "mako>=1.3.10",
+    "humanize>=4.10.0",
+    "rich>=14.3.2"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -41,15 +41,15 @@ repository = 'https://github.com/darshan-hpc/darshan'
 
 [project.optional-dependencies]
 test = [
-    "packaging",
-    "pytest",
-    "lxml",
-    "importlib_resources;python_version<'3.9'",
+    "packaging>=26.0",
+    "pytest>=8.3.5",
+    "lxml>=6.0.2",
+    "importlib_resources>=6.4.5;python_version<'3.9'",
 ]
 dev = [
-    "sphinx",
-    "sphinx_rtd_theme",
-    "pipx"
+    "sphinx>=8.1.3",
+    "sphinx_rtd_theme>=3.1.0",
+    "pipx>=1.8.0"
 ]
 
 [tool.setuptools.packages.find]
@@ -76,12 +76,12 @@ skip = [
     "*_s390x"
 ]
 test-requires = [
-    "packaging",
-    "pytest",
-    "lxml",
-    "matplotlib",
-    "importlib_resources;python_version<'3.9'",
-    "humanize"
+    "packaging>=26.0",
+    "pytest>=8.3.5",
+    "lxml>=6.0.2",
+    "matplotlib>=3.7.5",
+    "importlib_resources>=6.4.5;python_version<'3.9'",
+    "humanize>=4.10.0"
 ]
 before-test = "pip install -U git+https://github.com/darshan-hpc/darshan-logs.git@main"
 test-command = "pytest {package}"

--- a/darshan-util/pydarshan/requirements.txt
+++ b/darshan-util/pydarshan/requirements.txt
@@ -1,4 +1,4 @@
-cffi
-numpy
-pandas
-matplotlib
+cffi>=1.17.1
+numpy>=1.24.4
+pandas>=2.0.3
+matplotlib>=3.7.5

--- a/darshan-util/pydarshan/requirements_dev.txt
+++ b/darshan-util/pydarshan/requirements_dev.txt
@@ -1,19 +1,19 @@
-wheel
-watchdog
-twine
+wheel>=0.46.3
+watchdog>=6.0.0
+twine>=6.2.0
 
-cffi
-numpy
-pandas
-matplotlib
-seaborn
-mako
-jupyterlab
+cffi>=1.17.1
+numpy>=1.24.4
+pandas>=2.0.3
+matplotlib>=3.7.5
+seaborn>=0.13.2
+mako>=1.3.10
+jupyterlab>=4.5.4
 
-pytest
-pytest-runner
+pytest>=8.3.5
+pytest-runner>=6.0.1
 # lxml needed implicitly for pandas read_html calls in some tests
-lxml
+lxml>=6.0.2
 
-sphinx
-sphinx_rtd_theme
+sphinx>=8.1.3
+sphinx_rtd_theme>=3.1.0


### PR DESCRIPTION
This commit pins all of the PyDarshan dependencies to >= the current latest version compatible with Python 3.7 and adds a Dependabot configuration to keep them up-to-date.