### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data in arithmetic expression

### DIFF
--- a/darshan-runtime/lib/darshan-mpiio.c
+++ b/darshan-runtime/lib/darshan-mpiio.c
@@ -1712,8 +1712,11 @@ void darshan_mpiio_shutdown_bench_setup(int test_case)
     for(j = 0; j < 1024; j++)
         fh_array[j] = (MPI_File)j;
     for(i = 0; i < DARSHAN_COMMON_VAL_MAX_RUNTIME_COUNT; i++) {
-        offset_array[i] = rand();
-        size_array[i] = rand();
+        /* keep generated values in a safe bounded range to avoid overflow in
+         * downstream arithmetic on offsets/sizes
+         */
+        offset_array[i] = (MPI_Offset)(rand() % (1024 * 1024));
+        size_array[i] = (int64_t)(rand() % (1024 * 1024));
     }
 
     switch(test_case)


### PR DESCRIPTION
Potential fix for [https://github.com/darshan-hpc/darshan/security/code-scanning/12](https://github.com/darshan-hpc/darshan/security/code-scanning/12)

To fix this without changing intended functionality, clamp generated random sizes (and optionally offsets) to a conservative upper bound before storing/using them. The best targeted fix is in the initialization loop in `darshan-runtime/lib/darshan-mpiio.c` where `size_array[i]` and `offset_array[i]` are assigned from `rand()`. Replace direct assignments with bounded casts to `int64_t`/`MPI_Offset` so downstream macros always receive validated values.

Concretely, edit the loop around lines 1714–1717:
- Keep randomness, but constrain to a safe max write size (e.g., 1 MiB) and safe offset range.
- Example approach:
  - `int rsize = rand();`
  - `size_array[i] = (int64_t)(rsize % (1024 * 1024));`
This preserves benchmark variability while ensuring arithmetic remains in small, safe ranges. No new dependencies are required; existing headers already cover needed types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
