### PR TITLE
various fixes the warnings found by the copilot 

### DIFF
--- a/autoperf/apmpi/lib/darshan-apmpi.c
+++ b/autoperf/apmpi/lib/darshan-apmpi.c
@@ -62,7 +62,7 @@ typedef long long ap_bytes_t;
           ap_bytes_t bytes = 0; \
           if((COUNT > 0) && (TYPE != MPI_DATATYPE_NULL)) { \
               PMPI_Type_size(TYPE, &tsize); \
-              bytes = (COUNT) * tsize; \
+              bytes = (ap_bytes_t)(COUNT) * tsize; \
           }
 
 #define BYTECOUNTND(TYPE, COUNT) \
@@ -70,7 +70,7 @@ typedef long long ap_bytes_t;
           bytes = 0; \
           if((COUNT > 0) && (TYPE != MPI_DATATYPE_NULL)) { \
               PMPI_Type_size(TYPE, &tsize2); \
-              bytes = (COUNT) * tsize2; \
+              bytes = (ap_bytes_t)(COUNT) * tsize2; \
           }
 
 

--- a/autoperf/apmpi/util/print-apmpi-size.c
+++ b/autoperf/apmpi/util/print-apmpi-size.c
@@ -8,8 +8,8 @@ int main (int argc, char **argv)
    printf ("APMPI_F_NUM_INDICES = %d\n", APMPI_F_MPIOP_TOTALTIME_NUM_INDICES);
    printf ("APMPI_F_SYNC_NUM_INDICES = %d\n", APMPI_F_MPIOP_SYNCTIME_NUM_INDICES);
    printf ("APMPI_F_GLOBAL_NUM_INDICES = %d\n", APMPI_F_MPI_GLOBAL_NUM_INDICES);
-   printf ("sizeof darshan_apmpi_header_record = %d\n", sizeof(struct darshan_apmpi_header_record));
-   printf ("sizeof darshan_apmpi_perf_record = %d\n", sizeof(struct darshan_apmpi_perf_record));
+   printf ("sizeof darshan_apmpi_header_record = %zd\n", sizeof(struct darshan_apmpi_header_record));
+   printf ("sizeof darshan_apmpi_perf_record = %zd\n", sizeof(struct darshan_apmpi_perf_record));
 
    return 0;
 }

--- a/autoperf/apss/util/print-apss-size.c
+++ b/autoperf/apss/util/print-apss-size.c
@@ -5,8 +5,8 @@
 int main (int argc, char **argv)
 {
    printf ("APSS_NUM_INDICES = %d\n", APSS_NUM_INDICES);
-   printf ("sizeof darshan_apss_header_record = %d\n", sizeof(struct darshan_apss_header_record));
-   printf ("sizeof darshan_apss_perf_record = %d\n", sizeof(struct darshan_apss_perf_record));
+   printf ("sizeof darshan_apss_header_record = %zd\n", sizeof(struct darshan_apss_header_record));
+   printf ("sizeof darshan_apss_perf_record = %zd\n", sizeof(struct darshan_apss_perf_record));
 
    return 0;
 }

--- a/darshan-test/tst_mpio_pthread.c
+++ b/darshan-test/tst_mpio_pthread.c
@@ -139,7 +139,7 @@ void* thread_func(void *arg)
     // err = setenv_thread_safe("DARSHAN_DXT_EXTRA_INFO", annotation, 0);
     err = setenv("DARSHAN_DXT_EXTRA_INFO", annotation, 0);
     if (err == -1)
-        printf("Error: rank %s thread %d failed to call setenv (%s)\n",
+        printf("Error: rank %d thread %d failed to call setenv (%s)\n",
         rank, id, strerror(errno));
 
     off = rank * NTHREADS * LEN + id * LEN;

--- a/darshan-util/darshan-lustre-logutils.c
+++ b/darshan-util/darshan-lustre-logutils.c
@@ -344,7 +344,7 @@ static void darshan_log_print_lustre_record(void *rec, char *file_name,
                 for(k = 0; k < sizeof(flag_str_table)/sizeof(flag_str_table[0]); k++)
                 {
                     if(flags & flag)
-                        strncat(flag_str, flag_str_table[k], 64 - strlen(flag_str));
+                        strncat(flag_str, flag_str_table[k], sizeof(flag_str) - strlen(flag_str) - 1);
                     flag = flag << 1;
                 }
                 /* drop last ',' separator */


### PR DESCRIPTION
* fix useage of strncat - suggested by github copilot
* Copilot: fix Wrong type of arguments to formatting function
* Copilot: fix Multiplication result converted to larger type
